### PR TITLE
Bundle 24: add canonical MIR contract and provider adapter

### DIFF
--- a/core/analysis/adapter.py
+++ b/core/analysis/adapter.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from core.analysis.contracts import CanonicalMirAnalysis
+from core.analysis.providers import select_best_provider
+
+
+def _as_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def canonicalize_provider_result(result: Dict[str, Any], path: str) -> CanonicalMirAnalysis:
+    provider = result.get("provider", "unknown")
+    status = result.get("status", "unknown")
+
+    beat = result.get("beat", {}) or {}
+    key_block = result.get("key", {}) or {}
+    metrics = result.get("metrics", {}) or {}
+    tags = result.get("tags", {}) or {}
+
+    bpm = result.get("bpm")
+    if bpm is None:
+        bpm = beat.get("bpm")
+
+    bpm_confidence = result.get("bpm_confidence")
+    if bpm_confidence is None:
+        bpm_confidence = beat.get("confidence")
+
+    key = result.get("key")
+    if isinstance(key, dict):
+        key = key.get("camelot") or key.get("key")
+    elif key is None:
+        key = key_block.get("camelot") or key_block.get("key")
+
+    key_confidence = result.get("key_confidence")
+    if key_confidence is None:
+        key_confidence = key_block.get("confidence")
+
+    energy = result.get("energy")
+    if energy is None:
+        energy = metrics.get("energy_score")
+
+    loudness_db = result.get("loudness_db")
+    if loudness_db is None:
+        loudness_db = metrics.get("loudness_db")
+
+    duration_seconds = result.get("duration_seconds")
+    if duration_seconds is None:
+        duration_seconds = result.get("duration_sec")
+    if duration_seconds is None:
+        duration_seconds = metrics.get("duration_seconds")
+
+    genre_hint = result.get("genre_hint")
+    if genre_hint is None:
+        genre_hint = tags.get("primary_genre_hint") or result.get("genre")
+
+    return CanonicalMirAnalysis(
+        path=path,
+        provider=str(provider),
+        bpm=_as_float(bpm),
+        bpm_confidence=_as_float(bpm_confidence),
+        key=key if isinstance(key, str) else None,
+        key_confidence=_as_float(key_confidence),
+        energy=_as_float(energy),
+        loudness_db=_as_float(loudness_db),
+        duration_seconds=_as_float(duration_seconds),
+        genre_hint=genre_hint if isinstance(genre_hint, str) else None,
+        analysis_status=str(status),
+    )
+
+
+class CanonicalAnalysisService:
+    def __init__(self, preferred_provider: Optional[str] = None) -> None:
+        self.provider = select_best_provider(preferred_provider)
+
+    def analyze_path(self, path: str) -> CanonicalMirAnalysis:
+        raw = self.provider.analyze(path)
+        return canonicalize_provider_result(raw, path=path)

--- a/core/analysis/contracts.py
+++ b/core/analysis/contracts.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass(frozen=True)
+class CanonicalMirAnalysis:
+    path: str
+    provider: str
+    bpm: Optional[float]
+    bpm_confidence: Optional[float]
+    key: Optional[str]
+    key_confidence: Optional[float]
+    energy: Optional[float]
+    loudness_db: Optional[float]
+    duration_seconds: Optional[float]
+    genre_hint: Optional[str]
+    analysis_status: str
+    analysis_version: str = "canonical-mir-v1"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)

--- a/docs/bundles/BUNDLE_24_CANONICAL_MIR_CONTRACT.md
+++ b/docs/bundles/BUNDLE_24_CANONICAL_MIR_CONTRACT.md
@@ -1,0 +1,31 @@
+# Bundle 24 — Canonical MIR Contract + Provider Adapter
+
+## Intent
+Standardize analyzer outputs into one canonical MIR contract.
+
+## Included
+- `core/analysis/contracts.py`
+- `core/analysis/adapter.py`
+- `tests/unit/test_analysis_contracts.py`
+
+## Canonical fields
+- path
+- provider
+- bpm
+- bpm_confidence
+- key
+- key_confidence
+- energy
+- loudness_db
+- duration_seconds
+- genre_hint
+- analysis_status
+- analysis_version
+
+## Why
+Different analyzers expose BPM/key/energy/duration in different shapes.
+This bundle creates a stable backend contract so the rest of APPLAYLIST can depend on one predictable schema.
+
+## Notes
+This is intentionally adapter-first and low-risk.
+The next step is to wire this contract into the existing analyzer pipeline and API responses.

--- a/tests/unit/test_analysis_contracts.py
+++ b/tests/unit/test_analysis_contracts.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from core.analysis.adapter import canonicalize_provider_result
+from core.analysis.contracts import CanonicalMirAnalysis
+
+
+def test_canonicalize_provider_result_from_nested_payload():
+    payload = {
+        "provider": "librosa",
+        "status": "ok",
+        "beat": {"bpm": 128.4, "confidence": 0.91},
+        "key": {"camelot": "10A", "confidence": 0.88},
+        "metrics": {"energy_score": 0.67, "loudness_db": -8.4},
+        "tags": {"primary_genre_hint": "tech house"},
+        "duration_seconds": 367.2,
+    }
+
+    result = canonicalize_provider_result(payload, path="/tmp/demo.mp3")
+
+    assert isinstance(result, CanonicalMirAnalysis)
+    assert result.path == "/tmp/demo.mp3"
+    assert result.provider == "librosa"
+    assert result.bpm == 128.4
+    assert result.bpm_confidence == 0.91
+    assert result.key == "10A"
+    assert result.key_confidence == 0.88
+    assert result.energy == 0.67
+    assert result.loudness_db == -8.4
+    assert result.duration_seconds == 367.2
+    assert result.genre_hint == "tech house"
+    assert result.analysis_status == "ok"
+
+
+def test_canonicalize_provider_result_from_flat_payload():
+    payload = {
+        "provider": "essentia",
+        "status": "ok",
+        "bpm": "130.0",
+        "bpm_confidence": "0.75",
+        "key": "11A",
+        "key_confidence": "0.81",
+        "energy": "0.52",
+        "loudness_db": "-9.1",
+        "duration_sec": "301.5",
+        "genre_hint": "minimal techno",
+    }
+
+    result = canonicalize_provider_result(payload, path="/tmp/demo2.mp3")
+
+    assert result.provider == "essentia"
+    assert result.bpm == 130.0
+    assert result.bpm_confidence == 0.75
+    assert result.key == "11A"
+    assert result.key_confidence == 0.81
+    assert result.energy == 0.52
+    assert result.loudness_db == -9.1
+    assert result.duration_seconds == 301.5
+    assert result.genre_hint == "minimal techno"
+    assert result.analysis_status == "ok"
+
+
+def test_canonical_contract_to_dict():
+    payload = {
+        "provider": "librosa",
+        "status": "stub",
+    }
+
+    result = canonicalize_provider_result(payload, path="/tmp/empty.mp3")
+    data = result.to_dict()
+
+    assert data["path"] == "/tmp/empty.mp3"
+    assert data["provider"] == "librosa"
+    assert data["analysis_status"] == "stub"
+    assert data["analysis_version"] == "canonical-mir-v1"


### PR DESCRIPTION
## Summary
This PR introduces Bundle 24 for APPLAYLIST:
- canonical MIR analysis contract
- provider result adapter
- standardized BPM/key/energy/duration/loudness schema
- unit tests and bundle docs

## Why
Bundle 23 introduced provider abstraction, but downstream code still needs one stable schema.
This PR standardizes analyzer outputs so future pipeline, API, benchmark, and export layers can consume one predictable contract.

## Included
- `core/analysis/contracts.py`
- `core/analysis/adapter.py`
- `tests/unit/test_analysis_contracts.py`
- `docs/bundles/BUNDLE_24_CANONICAL_MIR_CONTRACT.md`

## Canonical fields
- path
- provider
- bpm
- bpm_confidence
- key
- key_confidence
- energy
- loudness_db
- duration_seconds
- genre_hint
- analysis_status
- analysis_version

## Design decisions
- adapter-first, low-risk implementation
- supports nested and flat provider payloads
- preserves optional/null fields cleanly
- prepares the system for pipeline integration and benchmark comparability

## Verify
- import + contract smoke passed
- targeted pytest passed
- compileall passed

## Next suggested bundle
Bundle 25:
- wire canonical contract into existing track analyzer pipeline
- add canonical result emission into API layer
- add fixture-based regression report