### PR TITLE
Bundle 25: essentia provider integration

### DIFF
--- a/core/analysis/provider_essentia.py
+++ b/core/analysis/provider_essentia.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+
+def essentia_enabled() -> bool:
+    return os.getenv("APPLAYLIST_ENABLE_ESSENTIA", "0") == "1"
+
+
+def essentia_available() -> bool:
+    if not essentia_enabled():
+        return False
+    try:
+        import essentia  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def analyze_with_essentia(path: str) -> Dict[str, Any]:
+    if not essentia_enabled():
+        raise RuntimeError("Essentia provider disabled. Set APPLAYLIST_ENABLE_ESSENTIA=1")
+    if not essentia_available():
+        raise RuntimeError("Essentia provider not available in current environment")
+
+    # Bundle 25: safe integration layer.
+    # Rich DSP extraction can be expanded later without changing downstream contract.
+    return {
+        "provider": "essentia",
+        "source_path": path,
+        "provider_version": None,
+        "rhythm_bpm": None,
+        "key_key": None,
+        "key_strength": None,
+        "loudness_energy": None,
+        "warnings": [
+            "Essentia provider integration active, but rich extraction is intentionally deferred in this bundle."
+        ],
+    }

--- a/core/analysis/provider_registry.py
+++ b/core/analysis/provider_registry.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+from core.analysis.provider_essentia import analyze_with_essentia, essentia_available, essentia_enabled
+
+
+def provider_capabilities() -> Dict[str, dict]:
+    return {
+        "essentia": {
+            "enabled": essentia_enabled(),
+            "available": essentia_available(),
+            "canonical_mapping_ready": True,
+        }
+    }
+
+
+def provider_registry() -> Dict[str, Callable[[str], dict]]:
+    registry: Dict[str, Callable[[str], dict]] = {}
+    if essentia_enabled() and essentia_available():
+        registry["essentia"] = analyze_with_essentia
+    return registry

--- a/docs/bundles/BUNDLE_25_ESSENTIA_PROVIDER_INTEGRATION.md
+++ b/docs/bundles/BUNDLE_25_ESSENTIA_PROVIDER_INTEGRATION.md
@@ -1,0 +1,17 @@
+# Bundle 25 — Essentia Provider Integration
+
+## Summary
+Adds a gated Essentia provider integration on top of the provider layer and canonical MIR architecture.
+
+## Why
+The system now has provider abstraction and canonical mapping, so the next step is to plug in a real advanced provider without hard-coupling the stack.
+
+## Included
+- `core/analysis/provider_essentia.py`
+- `core/analysis/provider_registry.py`
+- targeted unit tests
+- verify script
+
+## Notes
+Essentia remains optional and environment-gated in this bundle.
+Rich extraction can be expanded later without changing downstream contracts.

--- a/scripts/verify_bundle_25.sh
+++ b/scripts/verify_bundle_25.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="/Users/eimy/APPLAYLIST!"
+cd "$REPO"
+
+echo "[python] $(command -v python3 || true)"
+if [ -d ".venv" ]; then
+  . .venv/bin/activate
+elif [ -d "venv" ]; then
+  . venv/bin/activate
+fi
+
+echo "[1] compile"
+python3 -m compileall core/analysis
+
+echo "[2] tests"
+python3 -m pytest -q tests/unit/test_provider_essentia.py tests/unit/test_provider_registry.py
+
+echo "=== VERIFY DONE ==="

--- a/tests/unit/test_provider_essentia.py
+++ b/tests/unit/test_provider_essentia.py
@@ -1,0 +1,13 @@
+from core.analysis.provider_essentia import essentia_enabled, essentia_available
+
+
+def test_essentia_flag_defaults_disabled(monkeypatch):
+    monkeypatch.delenv("APPLAYLIST_ENABLE_ESSENTIA", raising=False)
+    assert essentia_enabled() is False
+    assert essentia_available() is False
+
+
+def test_essentia_flag_enabled_without_package(monkeypatch):
+    monkeypatch.setenv("APPLAYLIST_ENABLE_ESSENTIA", "1")
+    available = essentia_available()
+    assert available in {True, False}

--- a/tests/unit/test_provider_registry.py
+++ b/tests/unit/test_provider_registry.py
@@ -1,0 +1,14 @@
+from core.analysis.provider_registry import provider_capabilities, provider_registry
+
+
+def test_provider_capabilities_contains_essentia():
+    caps = provider_capabilities()
+    assert "essentia" in caps
+    assert "enabled" in caps["essentia"]
+    assert "available" in caps["essentia"]
+    assert "canonical_mapping_ready" in caps["essentia"]
+
+
+def test_provider_registry_returns_dict():
+    reg = provider_registry()
+    assert isinstance(reg, dict)


### PR DESCRIPTION
## Summary

* add gated Essentia provider integration
* register Essentia in provider registry
* prepare canonical-mapping-ready provider capabilities
* add targeted tests and verify script

## Verification

* compileall passed
* targeted pytest passed
* verify bundle script passed
* Essentia integration remains safely optional

## Notes

* no hard dependency on Essentia for baseline installs
* keeps downstream contract stable while enabling richer provider expansion
* prepares next bundle for real Essentia feature extraction

## Bundle Context

* Bundle: 25
* Base branch: feature/bundle-0-bootstrap
* Related issue:
