### PR TITLE
Bundle 25: fail-closed provider result contract

### DIFF
--- a/core/analysis/provider_contract.py
+++ b/core/analysis/provider_contract.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import math
+from dataclasses import asdict, dataclass
+from typing import Any, Mapping
+
+
+class ProviderContractError(Exception):
+    """Base class for controlled provider failures."""
+
+    code = "provider_error"
+
+    def __init__(self, message: str, *, provider: str | None = None) -> None:
+        super().__init__(message)
+        self.provider = provider
+
+
+class UnknownProviderError(ProviderContractError, ValueError):
+    code = "provider_unknown"
+
+
+class ProviderUnavailableError(ProviderContractError, RuntimeError):
+    code = "provider_unavailable"
+
+
+class ProviderRuntimeFailure(ProviderContractError, RuntimeError):
+    code = "provider_runtime_error"
+
+
+class ProviderOutputInvalid(ProviderContractError, ValueError):
+    code = "provider_output_invalid"
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalAnalysisResult:
+    path: str
+    provider: str
+    bpm: float | None
+    bpm_confidence: float | None
+    key: str | None
+    key_confidence: float | None
+    energy: float | None
+    loudness_db: float | None
+    duration_seconds: float | None
+    genre_hint: str | None
+    analysis_status: str = "ok"
+    analysis_version: str = "canonical-mir-v1"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _as_mapping(value: Any, field: str, provider: str | None) -> Mapping[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, Mapping):
+        return value
+    raise ProviderOutputInvalid(
+        f"Provider field '{field}' must be an object",
+        provider=provider,
+    )
+
+
+def _as_optional_float(value: Any, field: str, provider: str) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ProviderOutputInvalid(
+            f"Provider field '{field}' must be numeric",
+            provider=provider,
+        )
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ProviderOutputInvalid(
+            f"Provider field '{field}' must be numeric",
+            provider=provider,
+        ) from exc
+    if not math.isfinite(parsed):
+        raise ProviderOutputInvalid(
+            f"Provider field '{field}' must be finite",
+            provider=provider,
+        )
+    return parsed
+
+
+def _bounded(
+    value: float | None,
+    field: str,
+    provider: str,
+    *,
+    minimum: float,
+    maximum: float,
+) -> float | None:
+    if value is not None and not minimum <= value <= maximum:
+        raise ProviderOutputInvalid(
+            f"Provider field '{field}' must be between {minimum} and {maximum}",
+            provider=provider,
+        )
+    return value
+
+
+def _optional_text(value: Any, field: str, provider: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ProviderOutputInvalid(
+            f"Provider field '{field}' must be text",
+            provider=provider,
+        )
+    normalized = value.strip()
+    if not normalized:
+        return None
+    if len(normalized) > 128:
+        raise ProviderOutputInvalid(
+            f"Provider field '{field}' is too long",
+            provider=provider,
+        )
+    return normalized
+
+
+def normalize_provider_result(
+    raw_result: Mapping[str, Any],
+    *,
+    path: str,
+    expected_provider: str | None = None,
+) -> CanonicalAnalysisResult:
+    """Normalize a raw provider payload and reject unsafe or incomplete results."""
+    if not isinstance(raw_result, Mapping):
+        raise ProviderOutputInvalid("Provider result must be an object")
+    if not isinstance(path, str) or not path.strip():
+        raise ProviderOutputInvalid("Analysis path must be a non-empty string")
+
+    raw_provider = raw_result.get("provider", expected_provider)
+    if not isinstance(raw_provider, str) or not raw_provider.strip():
+        raise ProviderOutputInvalid("Provider result must identify its provider")
+    provider = raw_provider.strip().lower()
+
+    if expected_provider and provider != expected_provider.strip().lower():
+        raise ProviderOutputInvalid(
+            "Provider result identity does not match the selected provider",
+            provider=provider,
+        )
+
+    raw_status = raw_result.get("status")
+    if not isinstance(raw_status, str):
+        raise ProviderOutputInvalid(
+            "Provider result must include a string status",
+            provider=provider,
+        )
+    status = raw_status.strip().lower()
+    if status not in {"ok", "success", "completed"}:
+        raise ProviderOutputInvalid(
+            f"Provider returned non-success status '{status or 'empty'}'",
+            provider=provider,
+        )
+
+    beat = _as_mapping(raw_result.get("beat"), "beat", provider)
+    metrics = _as_mapping(raw_result.get("metrics"), "metrics", provider)
+    tags = _as_mapping(raw_result.get("tags"), "tags", provider)
+
+    raw_key = raw_result.get("key")
+    key_block = _as_mapping(raw_key, "key", provider) if not isinstance(raw_key, str) else {}
+
+    bpm_raw = raw_result.get("bpm", beat.get("bpm"))
+    bpm_confidence_raw = raw_result.get(
+        "bpm_confidence",
+        beat.get("confidence"),
+    )
+
+    if isinstance(raw_key, Mapping):
+        key_raw = raw_key.get("camelot") or raw_key.get("key")
+    else:
+        key_raw = raw_key
+    key_confidence_raw = raw_result.get(
+        "key_confidence",
+        key_block.get("confidence"),
+    )
+
+    energy_raw = raw_result.get("energy", metrics.get("energy_score"))
+    loudness_raw = raw_result.get("loudness_db", metrics.get("loudness_db"))
+    duration_raw = raw_result.get("duration_seconds")
+    if duration_raw is None:
+        duration_raw = raw_result.get("duration_sec", metrics.get("duration_seconds"))
+    genre_raw = raw_result.get(
+        "genre_hint",
+        tags.get("primary_genre_hint", raw_result.get("genre")),
+    )
+
+    bpm = _bounded(
+        _as_optional_float(bpm_raw, "bpm", provider),
+        "bpm",
+        provider,
+        minimum=20.0,
+        maximum=400.0,
+    )
+    bpm_confidence = _bounded(
+        _as_optional_float(bpm_confidence_raw, "bpm_confidence", provider),
+        "bpm_confidence",
+        provider,
+        minimum=0.0,
+        maximum=1.0,
+    )
+    key_confidence = _bounded(
+        _as_optional_float(key_confidence_raw, "key_confidence", provider),
+        "key_confidence",
+        provider,
+        minimum=0.0,
+        maximum=1.0,
+    )
+    energy = _bounded(
+        _as_optional_float(energy_raw, "energy", provider),
+        "energy",
+        provider,
+        minimum=0.0,
+        maximum=1.0,
+    )
+    duration_seconds = _as_optional_float(
+        duration_raw,
+        "duration_seconds",
+        provider,
+    )
+    if duration_seconds is not None and duration_seconds < 0:
+        raise ProviderOutputInvalid(
+            "Provider field 'duration_seconds' must not be negative",
+            provider=provider,
+        )
+
+    return CanonicalAnalysisResult(
+        path=path.strip(),
+        provider=provider,
+        bpm=bpm,
+        bpm_confidence=bpm_confidence,
+        key=_optional_text(key_raw, "key", provider),
+        key_confidence=key_confidence,
+        energy=energy,
+        loudness_db=_as_optional_float(loudness_raw, "loudness_db", provider),
+        duration_seconds=duration_seconds,
+        genre_hint=_optional_text(genre_raw, "genre_hint", provider),
+    )

--- a/core/analysis/provider_contract.py
+++ b/core/analysis/provider_contract.py
@@ -23,6 +23,10 @@ class ProviderUnavailableError(ProviderContractError, RuntimeError):
     code = "provider_unavailable"
 
 
+class ProviderDependencyMissingError(ProviderUnavailableError):
+    code = "provider_dependency_missing"
+
+
 class ProviderRuntimeFailure(ProviderContractError, RuntimeError):
     code = "provider_runtime_error"
 
@@ -48,6 +52,13 @@ class CanonicalAnalysisResult:
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
+
+
+def _first_not_none(*values: Any) -> Any:
+    for value in values:
+        if value is not None:
+            return value
+    return None
 
 
 def _as_mapping(value: Any, field: str, provider: str | None) -> Mapping[str, Any]:
@@ -131,7 +142,7 @@ def normalize_provider_result(
     if not isinstance(path, str) or not path.strip():
         raise ProviderOutputInvalid("Analysis path must be a non-empty string")
 
-    raw_provider = raw_result.get("provider", expected_provider)
+    raw_provider = _first_not_none(raw_result.get("provider"), expected_provider)
     if not isinstance(raw_provider, str) or not raw_provider.strip():
         raise ProviderOutputInvalid("Provider result must identify its provider")
     provider = raw_provider.strip().lower()
@@ -162,29 +173,38 @@ def normalize_provider_result(
     raw_key = raw_result.get("key")
     key_block = _as_mapping(raw_key, "key", provider) if not isinstance(raw_key, str) else {}
 
-    bpm_raw = raw_result.get("bpm", beat.get("bpm"))
-    bpm_confidence_raw = raw_result.get(
-        "bpm_confidence",
+    bpm_raw = _first_not_none(raw_result.get("bpm"), beat.get("bpm"))
+    bpm_confidence_raw = _first_not_none(
+        raw_result.get("bpm_confidence"),
         beat.get("confidence"),
     )
 
     if isinstance(raw_key, Mapping):
-        key_raw = raw_key.get("camelot") or raw_key.get("key")
+        key_raw = _first_not_none(raw_key.get("camelot"), raw_key.get("key"))
     else:
         key_raw = raw_key
-    key_confidence_raw = raw_result.get(
-        "key_confidence",
+    key_confidence_raw = _first_not_none(
+        raw_result.get("key_confidence"),
         key_block.get("confidence"),
     )
 
-    energy_raw = raw_result.get("energy", metrics.get("energy_score"))
-    loudness_raw = raw_result.get("loudness_db", metrics.get("loudness_db"))
-    duration_raw = raw_result.get("duration_seconds")
-    if duration_raw is None:
-        duration_raw = raw_result.get("duration_sec", metrics.get("duration_seconds"))
-    genre_raw = raw_result.get(
-        "genre_hint",
-        tags.get("primary_genre_hint", raw_result.get("genre")),
+    energy_raw = _first_not_none(
+        raw_result.get("energy"),
+        metrics.get("energy_score"),
+    )
+    loudness_raw = _first_not_none(
+        raw_result.get("loudness_db"),
+        metrics.get("loudness_db"),
+    )
+    duration_raw = _first_not_none(
+        raw_result.get("duration_seconds"),
+        raw_result.get("duration_sec"),
+        metrics.get("duration_seconds"),
+    )
+    genre_raw = _first_not_none(
+        raw_result.get("genre_hint"),
+        tags.get("primary_genre_hint"),
+        raw_result.get("genre"),
     )
 
     bpm = _bounded(

--- a/core/analysis/provider_service.py
+++ b/core/analysis/provider_service.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any, Protocol
+
+from core.analysis.provider_contract import (
+    CanonicalAnalysisResult,
+    ProviderContractError,
+    ProviderOutputInvalid,
+    ProviderRuntimeFailure,
+    ProviderUnavailableError,
+    UnknownProviderError,
+    normalize_provider_result,
+)
+from core.analysis.providers import BaseAnalyzerProvider, select_best_provider
+
+
+class AnalyzerProvider(Protocol):
+    name: str
+
+    def analyze(self, path: str) -> Mapping[str, Any]: ...
+
+
+ProviderSelector = Callable[[str | None], BaseAnalyzerProvider]
+
+
+class RoutedAnalysisService:
+    """Run one provider and return only a validated canonical result."""
+
+    def __init__(self, selector: ProviderSelector = select_best_provider) -> None:
+        self._selector = selector
+
+    def analyze_path(
+        self,
+        path: str,
+        *,
+        preferred_provider: str | None = None,
+    ) -> CanonicalAnalysisResult:
+        if not isinstance(path, str) or not path.strip():
+            raise ProviderOutputInvalid("Analysis path must be a non-empty string")
+
+        provider = self._select_provider(preferred_provider)
+        try:
+            raw_result = provider.analyze(path)
+        except ProviderContractError:
+            raise
+        except Exception as exc:
+            raise ProviderRuntimeFailure(
+                "Provider execution failed",
+                provider=provider.name,
+            ) from exc
+
+        return normalize_provider_result(
+            raw_result,
+            path=path,
+            expected_provider=provider.name,
+        )
+
+    def _select_provider(self, preferred_provider: str | None) -> AnalyzerProvider:
+        try:
+            return self._selector(preferred_provider)
+        except (UnknownProviderError, ProviderUnavailableError):
+            raise
+        except ValueError as exc:
+            raise UnknownProviderError(
+                str(exc),
+                provider=preferred_provider,
+            ) from exc
+        except RuntimeError as exc:
+            raise ProviderUnavailableError(
+                str(exc),
+                provider=preferred_provider,
+            ) from exc
+        except Exception as exc:
+            raise ProviderUnavailableError(
+                "Provider selection failed",
+                provider=preferred_provider,
+            ) from exc

--- a/core/analysis/providers.py
+++ b/core/analysis/providers.py
@@ -5,6 +5,11 @@ import os
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
+from core.analysis.provider_contract import (
+    ProviderUnavailableError,
+    UnknownProviderError,
+)
+
 
 @dataclass(frozen=True)
 class AnalyzerProviderInfo:
@@ -18,7 +23,11 @@ class BaseAnalyzerProvider:
 
     @classmethod
     def is_available(cls) -> AnalyzerProviderInfo:
-        return AnalyzerProviderInfo(name=cls.name, available=False, reason="not implemented")
+        return AnalyzerProviderInfo(
+            name=cls.name,
+            available=False,
+            reason="not implemented",
+        )
 
     def analyze(self, path: str) -> Dict[str, Any]:
         raise NotImplementedError
@@ -31,7 +40,11 @@ class LibrosaAnalyzerProvider(BaseAnalyzerProvider):
     def is_available(cls) -> AnalyzerProviderInfo:
         spec = importlib.util.find_spec("librosa")
         if spec is None:
-            return AnalyzerProviderInfo(name=cls.name, available=False, reason="librosa not installed")
+            return AnalyzerProviderInfo(
+                name=cls.name,
+                available=False,
+                reason="librosa not installed",
+            )
         return AnalyzerProviderInfo(name=cls.name, available=True, reason="ok")
 
     def analyze(self, path: str) -> Dict[str, Any]:
@@ -56,7 +69,11 @@ class EssentiaAnalyzerProvider(BaseAnalyzerProvider):
 
         py_spec = importlib.util.find_spec("essentia")
         if py_spec is not None:
-            return AnalyzerProviderInfo(name=cls.name, available=True, reason="python essentia available")
+            return AnalyzerProviderInfo(
+                name=cls.name,
+                available=True,
+                reason="python essentia available",
+            )
 
         return AnalyzerProviderInfo(
             name=cls.name,
@@ -74,9 +91,9 @@ class EssentiaAnalyzerProvider(BaseAnalyzerProvider):
 
 def list_analyzer_providers() -> Dict[str, AnalyzerProviderInfo]:
     infos = {}
-    for cls in (LibrosaAnalyzerProvider, EssentiaAnalyzerProvider):
-        info = cls.is_available()
-        infos[cls.name] = info
+    for provider_class in (LibrosaAnalyzerProvider, EssentiaAnalyzerProvider):
+        info = provider_class.is_available()
+        infos[provider_class.name] = info
     return infos
 
 
@@ -87,17 +104,23 @@ def select_best_provider(preferred: Optional[str] = None) -> BaseAnalyzerProvide
     }
 
     if preferred:
-        preferred = preferred.strip().lower()
-        if preferred not in providers:
-            raise ValueError(f"Unknown provider: {preferred}")
-        info = providers[preferred].is_available()
+        normalized = preferred.strip().lower()
+        if normalized not in providers:
+            raise UnknownProviderError(
+                f"Unknown provider: {normalized}",
+                provider=normalized,
+            )
+        info = providers[normalized].is_available()
         if not info.available:
-            raise RuntimeError(f"Preferred provider unavailable: {preferred} ({info.reason})")
-        return providers[preferred]()
+            raise ProviderUnavailableError(
+                f"Preferred provider unavailable: {normalized} ({info.reason})",
+                provider=normalized,
+            )
+        return providers[normalized]()
 
     for name in ("librosa", "essentia"):
         info = providers[name].is_available()
         if info.available:
             return providers[name]()
 
-    raise RuntimeError("No analyzer provider available")
+    raise ProviderUnavailableError("No analyzer provider available")

--- a/core/analysis/providers.py
+++ b/core/analysis/providers.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 from core.analysis.provider_contract import (
+    ProviderDependencyMissingError,
     ProviderUnavailableError,
     UnknownProviderError,
 )
@@ -97,6 +98,13 @@ def list_analyzer_providers() -> Dict[str, AnalyzerProviderInfo]:
     return infos
 
 
+def _raise_unavailable(info: AnalyzerProviderInfo) -> None:
+    message = f"Preferred provider unavailable: {info.name} ({info.reason})"
+    if info.reason.endswith("not installed"):
+        raise ProviderDependencyMissingError(message, provider=info.name)
+    raise ProviderUnavailableError(message, provider=info.name)
+
+
 def select_best_provider(preferred: Optional[str] = None) -> BaseAnalyzerProvider:
     providers = {
         "librosa": LibrosaAnalyzerProvider,
@@ -112,10 +120,7 @@ def select_best_provider(preferred: Optional[str] = None) -> BaseAnalyzerProvide
             )
         info = providers[normalized].is_available()
         if not info.available:
-            raise ProviderUnavailableError(
-                f"Preferred provider unavailable: {normalized} ({info.reason})",
-                provider=normalized,
-            )
+            _raise_unavailable(info)
         return providers[normalized]()
 
     for name in ("librosa", "essentia"):

--- a/docs/bundles/BUNDLE_25_PROVIDER_RESULT_CONTRACT.md
+++ b/docs/bundles/BUNDLE_25_PROVIDER_RESULT_CONTRACT.md
@@ -1,0 +1,113 @@
+# Bundle 25 — Fail-Closed Provider Result Contract
+
+## Goal
+
+Introduce one canonical, validated result boundary between optional audio providers and all downstream APPLAYLIST components.
+
+Bundle 25 does not enable provider mode in the API, jobs or persistence. The legacy analyzer remains the default path.
+
+## Source Audit
+
+### PR #20
+
+The canonical MIR concept is useful, but the branch is not safe to merge:
+
+- its adapter depends on a providers module absent from that commit,
+- a flat string key without confidence can call `.get()` on a string,
+- its PR Guard did not pass.
+
+Bundle 25 reimplements the useful contract independently and includes regressions for both P1 defects.
+
+### PR #22
+
+The branch title claims real Essentia extraction, but both provider implementations still return `status="stub"`.
+
+The branch also contains broad historical changes, duplicate `* 2.py` files, tracked production-style environment configuration and unresolved security/data-flow defects. It must not be merged or cherry-picked as a whole.
+
+## Contract
+
+Validated canonical fields:
+
+- path,
+- provider,
+- bpm,
+- bpm confidence,
+- key,
+- key confidence,
+- energy,
+- loudness,
+- duration,
+- genre hint,
+- analysis status,
+- analysis schema version.
+
+Accepted success statuses are normalized to `ok`:
+
+- `ok`,
+- `success`,
+- `completed`.
+
+Any other status, including `stub`, is rejected as `provider_output_invalid`.
+
+## Error Taxonomy
+
+- `provider_unknown`
+- `provider_unavailable`
+- `provider_runtime_error`
+- `provider_output_invalid`
+
+Errors retain provider identity when available and are raised before any persistence boundary.
+
+## Validation Rules
+
+- raw output must be a mapping,
+- provider identity must be present and must match the selected provider,
+- nested beat/key/metrics/tags blocks must be mappings,
+- numeric fields must be finite,
+- BPM must be between 20 and 400,
+- confidence and energy values must be between 0 and 1,
+- duration must not be negative,
+- text fields must have bounded length,
+- optional fields may remain null,
+- flat key strings without confidence are valid.
+
+## Execution Boundary
+
+```text
+provider selector
+  -> provider execution
+  -> canonical normalization
+  -> contract validation
+  -> CanonicalAnalysisResult
+```
+
+Persistence is intentionally outside Bundle 25. A later routed-analysis slice may persist only `CanonicalAnalysisResult` values after explicit conversion to the storage schema.
+
+## Security and Failure Behavior
+
+- optional audio libraries are not imported by the contract or service modules,
+- provider crashes are converted to controlled runtime errors,
+- provider selection failures remain explicit,
+- stub providers fail closed,
+- no silent fallback changes the selected provider,
+- no database or public API contract is changed.
+
+## Verification
+
+Required gates:
+
+- existing test suite remains green,
+- nested and flat payload normalization,
+- regression for flat key without confidence,
+- malformed nested block rejection,
+- non-finite and out-of-range number rejection,
+- stub rejection,
+- provider identity mismatch rejection,
+- runtime failure translation,
+- provider selection error preservation,
+- boot-safe import test,
+- Python 3.11 and 3.12 CI matrix.
+
+## Rollback
+
+Before merge, close the Bundle 25 pull request or delete its feature branch. After merge, revert its squash commit. No database rollback is required.

--- a/tests/unit/test_provider_contract.py
+++ b/tests/unit/test_provider_contract.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from core.analysis.provider_contract import (
+    ProviderOutputInvalid,
+    ProviderRuntimeFailure,
+    ProviderUnavailableError,
+    UnknownProviderError,
+    normalize_provider_result,
+)
+from core.analysis.provider_service import RoutedAnalysisService
+
+
+def test_normalizes_nested_provider_payload() -> None:
+    result = normalize_provider_result(
+        {
+            "provider": "librosa",
+            "status": "ok",
+            "beat": {"bpm": 128.4, "confidence": 0.91},
+            "key": {"camelot": "10A", "confidence": 0.88},
+            "metrics": {
+                "energy_score": 0.67,
+                "loudness_db": -8.4,
+                "duration_seconds": 367.2,
+            },
+            "tags": {"primary_genre_hint": "tech house"},
+        },
+        path="/tmp/demo.mp3",
+        expected_provider="librosa",
+    )
+
+    assert result.provider == "librosa"
+    assert result.bpm == 128.4
+    assert result.bpm_confidence == 0.91
+    assert result.key == "10A"
+    assert result.key_confidence == 0.88
+    assert result.energy == 0.67
+    assert result.loudness_db == -8.4
+    assert result.duration_seconds == 367.2
+    assert result.genre_hint == "tech house"
+    assert result.analysis_status == "ok"
+
+
+def test_flat_key_without_confidence_is_valid() -> None:
+    result = normalize_provider_result(
+        {
+            "provider": "essentia",
+            "status": "success",
+            "bpm": "130.0",
+            "key": "11A",
+            "energy": "0.52",
+        },
+        path="/tmp/demo.wav",
+    )
+
+    assert result.key == "11A"
+    assert result.key_confidence is None
+    assert result.bpm == 130.0
+    assert result.energy == 0.52
+
+
+def test_rejects_malformed_nested_block() -> None:
+    with pytest.raises(ProviderOutputInvalid) as exc_info:
+        normalize_provider_result(
+            {
+                "provider": "librosa",
+                "status": "ok",
+                "metrics": ["not", "an", "object"],
+            },
+            path="/tmp/demo.wav",
+        )
+
+    assert exc_info.value.code == "provider_output_invalid"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("bpm", float("nan")),
+        ("energy", float("inf")),
+        ("duration_seconds", float("-inf")),
+    ],
+)
+def test_rejects_non_finite_numbers(field: str, value: float) -> None:
+    with pytest.raises(ProviderOutputInvalid):
+        normalize_provider_result(
+            {
+                "provider": "librosa",
+                "status": "ok",
+                field: value,
+            },
+            path="/tmp/demo.wav",
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("bpm", 500),
+        ("bpm_confidence", 1.1),
+        ("key_confidence", -0.1),
+        ("energy", 1.5),
+        ("duration_seconds", -1),
+    ],
+)
+def test_rejects_values_outside_contract(field: str, value: float) -> None:
+    with pytest.raises(ProviderOutputInvalid):
+        normalize_provider_result(
+            {
+                "provider": "librosa",
+                "status": "ok",
+                field: value,
+            },
+            path="/tmp/demo.wav",
+        )
+
+
+def test_rejects_stub_as_success() -> None:
+    with pytest.raises(ProviderOutputInvalid) as exc_info:
+        normalize_provider_result(
+            {
+                "provider": "librosa",
+                "status": "stub",
+            },
+            path="/tmp/demo.wav",
+        )
+
+    assert "non-success status" in str(exc_info.value)
+
+
+def test_rejects_provider_identity_mismatch() -> None:
+    with pytest.raises(ProviderOutputInvalid):
+        normalize_provider_result(
+            {
+                "provider": "essentia",
+                "status": "ok",
+            },
+            path="/tmp/demo.wav",
+            expected_provider="librosa",
+        )
+
+
+@dataclass
+class FakeProvider:
+    payload: dict[str, Any]
+    name: str = "fake"
+
+    def analyze(self, path: str) -> dict[str, Any]:
+        return dict(self.payload)
+
+
+def test_routed_service_returns_only_validated_result() -> None:
+    provider = FakeProvider(
+        {
+            "provider": "fake",
+            "status": "completed",
+            "bpm": 126,
+            "energy": 0.4,
+        }
+    )
+    service = RoutedAnalysisService(selector=lambda _preferred: provider)
+
+    result = service.analyze_path("/tmp/demo.wav")
+
+    assert result.provider == "fake"
+    assert result.bpm == 126.0
+    assert result.energy == 0.4
+
+
+def test_routed_service_rejects_current_stub_provider() -> None:
+    provider = FakeProvider({"provider": "fake", "status": "stub"})
+    service = RoutedAnalysisService(selector=lambda _preferred: provider)
+
+    with pytest.raises(ProviderOutputInvalid):
+        service.analyze_path("/tmp/demo.wav")
+
+
+def test_routed_service_wraps_provider_crash() -> None:
+    class CrashingProvider:
+        name = "crashing"
+
+        def analyze(self, path: str) -> dict[str, Any]:
+            raise OSError("backend crashed")
+
+    service = RoutedAnalysisService(selector=lambda _preferred: CrashingProvider())
+
+    with pytest.raises(ProviderRuntimeFailure) as exc_info:
+        service.analyze_path("/tmp/demo.wav")
+
+    assert exc_info.value.code == "provider_runtime_error"
+    assert exc_info.value.provider == "crashing"
+
+
+def test_routed_service_preserves_selection_errors() -> None:
+    def unknown_selector(_preferred: str | None):
+        raise UnknownProviderError("unknown", provider="missing")
+
+    service = RoutedAnalysisService(selector=unknown_selector)
+    with pytest.raises(UnknownProviderError):
+        service.analyze_path("/tmp/demo.wav", preferred_provider="missing")
+
+    def unavailable_selector(_preferred: str | None):
+        raise ProviderUnavailableError("unavailable", provider="essentia")
+
+    service = RoutedAnalysisService(selector=unavailable_selector)
+    with pytest.raises(ProviderUnavailableError):
+        service.analyze_path("/tmp/demo.wav", preferred_provider="essentia")
+
+
+def test_contract_import_does_not_load_optional_audio_backends() -> None:
+    code = """
+import sys
+import core.analysis.provider_contract
+import core.analysis.provider_service
+assert 'librosa' not in sys.modules
+assert 'essentia' not in sys.modules
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr

--- a/tests/unit/test_provider_contract.py
+++ b/tests/unit/test_provider_contract.py
@@ -7,7 +7,9 @@ from typing import Any
 
 import pytest
 
+import core.analysis.providers as providers_module
 from core.analysis.provider_contract import (
+    ProviderDependencyMissingError,
     ProviderOutputInvalid,
     ProviderRuntimeFailure,
     ProviderUnavailableError,
@@ -45,6 +47,26 @@ def test_normalizes_nested_provider_payload() -> None:
     assert result.duration_seconds == 367.2
     assert result.genre_hint == "tech house"
     assert result.analysis_status == "ok"
+
+
+def test_nested_values_replace_explicit_top_level_nulls() -> None:
+    result = normalize_provider_result(
+        {
+            "provider": "librosa",
+            "status": "ok",
+            "bpm": None,
+            "energy": None,
+            "genre_hint": None,
+            "beat": {"bpm": 124.0},
+            "metrics": {"energy_score": 0.45},
+            "tags": {"primary_genre_hint": "hypnotic techno"},
+        },
+        path="/tmp/demo.mp3",
+    )
+
+    assert result.bpm == 124.0
+    assert result.energy == 0.45
+    assert result.genre_hint == "hypnotic techno"
 
 
 def test_flat_key_without_confidence_is_valid() -> None:
@@ -146,6 +168,21 @@ def test_rejects_provider_identity_mismatch() -> None:
         )
 
 
+def test_preferred_missing_dependency_has_distinct_error(monkeypatch) -> None:
+    monkeypatch.setenv("APPLAYLIST_ENABLE_ESSENTIA", "1")
+    monkeypatch.setattr(
+        providers_module.importlib.util,
+        "find_spec",
+        lambda _name: None,
+    )
+
+    with pytest.raises(ProviderDependencyMissingError) as exc_info:
+        providers_module.select_best_provider("essentia")
+
+    assert exc_info.value.code == "provider_dependency_missing"
+    assert exc_info.value.provider == "essentia"
+
+
 @dataclass
 class FakeProvider:
     payload: dict[str, Any]
@@ -226,6 +263,7 @@ assert 'essentia' not in sys.modules
         check=False,
         capture_output=True,
         text=True,
+        timeout=10,
     )
 
     assert completed.returncode == 0, completed.stderr


### PR DESCRIPTION
## Summary

- add canonical provider result model and strict normalizer
- add explicit provider error taxonomy
- reject stub, malformed, non-finite and out-of-range provider output
- add injected routed analysis service with no persistence side effects
- preserve lazy optional backend imports and the existing legacy default path
- replace the unsafe concepts in PR #20 and PR #22 without merging their history

## Verification

- branch created directly from verified Bundle 24 merge commit `ff021c82164f3a27674993034115f5b3773d43db`
- branch is ahead only; no base history was rewritten
- static diff scope is limited to provider contract, service, provider selection errors, tests and documentation
- CI must verify install, compile, critical Ruff and full pytest on Python 3.11 and 3.12
- no local test execution is claimed

## Notes

- current Librosa and Essentia providers still return `status="stub"`; the new service intentionally rejects them
- no real Essentia extraction is claimed or enabled
- no API route, response schema, database schema or persistence behavior is changed
- PR #20 and PR #22 remain open until this replacement is fully verified

## Bundle Context

- Bundle: 25 — Fail-Closed Provider Result Contract
- Base branch: `feature/bundle-0-bootstrap`
- Base commit: `ff021c82164f3a27674993034115f5b3773d43db`
- Related issue: #24
- Supersedes after green verification: #20, #22
- Rollback: close this PR or revert its future squash commit; no data rollback required
