### PR TITLE
Bundle 26: export path integrity and unique pipeline runs

### DIFF
--- a/data/models/playlist_candidate.py
+++ b/data/models/playlist_candidate.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True, slots=True)
+class PlaylistCandidate:
+    """Read model combining track identity/path with analysis features."""
+
+    track_id: str
+    path: str
+    title: Optional[str] = None
+    artist: Optional[str] = None
+    bpm: Optional[float] = None
+    camelot: Optional[str] = None
+    energy: Optional[float] = None

--- a/data/repositories/analysis_repository.py
+++ b/data/repositories/analysis_repository.py
@@ -4,6 +4,8 @@ from typing import Optional
 
 from data.connection import get_sqlite_connection
 from data.models.analysis_record import AnalysisRecord
+from data.models.playlist_candidate import PlaylistCandidate
+from data.repositories.track_repository import TrackRepository
 
 
 class AnalysisRepository:
@@ -91,3 +93,28 @@ class AnalysisRepository:
             if row is None:
                 return None
             return AnalysisRecord(**dict(row))
+
+    def list_playlist_candidates(self) -> list[PlaylistCandidate]:
+        """Return only analyses that have a non-empty resolvable track path."""
+        self.ensure_schema()
+        TrackRepository().ensure_schema()
+
+        with get_sqlite_connection() as conn:
+            rows = conn.execute(
+                '''
+                SELECT
+                    analyses.track_id,
+                    tracks.path,
+                    tracks.title,
+                    tracks.artist,
+                    analyses.bpm,
+                    analyses.camelot,
+                    analyses.energy
+                FROM analyses
+                INNER JOIN tracks ON tracks.track_id = analyses.track_id
+                WHERE NULLIF(TRIM(tracks.path), '') IS NOT NULL
+                ORDER BY analyses.track_id
+                '''
+            ).fetchall()
+
+        return [PlaylistCandidate(**dict(row)) for row in rows]

--- a/docs/bundles/BUNDLE_26_EXPORT_PATH_INTEGRITY.md
+++ b/docs/bundles/BUNDLE_26_EXPORT_PATH_INTEGRITY.md
@@ -1,0 +1,39 @@
+# Bundle 26 — Export Path Integrity and Unique Pipeline Runs
+
+## Goal
+
+Ensure that every track selected by the composer carries a resolvable source path and that every pipeline invocation writes isolated export artifacts.
+
+## Confirmed defect
+
+The previous composer loaded rows directly from `analyses`. The source audio path is stored in `tracks`, so the exporter received `AnalysisRecord` instances without a `path` attribute. CI evidence showed composed tracks with `resolved_count=0` and all entries skipped as `missing_path`.
+
+The pipeline also used the constant identifier `pipeline_run`, allowing repeated or concurrent invocations to overwrite the same M3U, manifest, warning and audit files.
+
+## Implementation
+
+- add immutable `PlaylistCandidate` read model
+- add repository query joining `analyses` and `tracks` by `track_id`
+- include only rows with a non-empty track path
+- remove direct SQLite access from `Composer`
+- inject composer/exporter dependencies for deterministic tests
+- allow explicit export/artifact directories in `Exporter`
+- generate `pipeline-<uuid>` for every pipeline invocation
+- preserve the existing public response shape and database schema
+
+## Fail-closed behavior
+
+An analysis without a matching track row is not a playlist candidate and cannot reach the exporter. No fallback invents or copies a path into the analysis table.
+
+## Verification contract
+
+- existing test suite remains green
+- joined tracks produce resolved M3U entries
+- orphan analyses are excluded
+- `resolved_count` equals composed `count` for valid candidates
+- consecutive pipeline runs produce distinct playlist IDs and artifact paths
+- Python 3.11 and 3.12 CI must pass before merge
+
+## Rollback
+
+Revert the future Bundle 26 squash commit. No schema or data migration rollback is required.

--- a/services/composer/composer.py
+++ b/services/composer/composer.py
@@ -1,15 +1,18 @@
+from __future__ import annotations
+
+from core.energy_curve import target_energy
+from data.models.playlist_candidate import PlaylistCandidate
 from data.repositories.analysis_repository import AnalysisRepository
 from services.composer.scoring import score_transition
-from core.energy_curve import target_energy
 
 
 class Composer:
-    def __init__(self):
-        self.repo = AnalysisRepository()
+    def __init__(self, repository: AnalysisRepository | None = None) -> None:
+        self.repo = repository or AnalysisRepository()
 
-    def compose(self, limit: int = 10):
+    def compose(self, limit: int = 10) -> list[PlaylistCandidate]:
         tracks = self._load_tracks()
-        if not tracks:
+        if not tracks or limit <= 0:
             return []
 
         playlist = [tracks[0]]
@@ -17,22 +20,22 @@ class Composer:
         while len(playlist) < limit:
             current = playlist[-1]
             best = None
-            best_score = -1
+            best_score = -1.0
 
             for candidate in tracks:
                 if candidate in playlist:
                     continue
 
-                s = score_transition(current, candidate)
+                score = score_transition(current, candidate)
 
-                pos = len(playlist) / limit
-                target = target_energy(pos)
+                position = len(playlist) / limit
+                target = target_energy(position)
 
-                if candidate.energy:
-                    s += 1 - abs(candidate.energy - target)
+                if candidate.energy is not None:
+                    score += 1 - abs(candidate.energy - target)
 
-                if s > best_score:
-                    best_score = s
+                if score > best_score:
+                    best_score = score
                     best = candidate
 
             if best is None:
@@ -42,12 +45,5 @@ class Composer:
 
         return playlist
 
-    def _load_tracks(self):
-        import sqlite3
-        from data.connection import get_sqlite_connection
-
-        with get_sqlite_connection() as conn:
-            rows = conn.execute("SELECT * FROM analyses").fetchall()
-
-        from data.models.analysis_record import AnalysisRecord
-        return [AnalysisRecord(**dict(r)) for r in rows]
+    def _load_tracks(self) -> list[PlaylistCandidate]:
+        return self.repo.list_playlist_candidates()

--- a/services/export/exporter.py
+++ b/services/export/exporter.py
@@ -8,10 +8,26 @@ from core.config.settings import get_settings
 
 
 class Exporter:
-    def __init__(self) -> None:
-        settings = get_settings()
-        self.exports_dir = Path(settings.exports_dir)
-        self.artifacts_dir = Path(settings.artifacts_dir)
+    def __init__(
+        self,
+        *,
+        exports_dir: str | Path | None = None,
+        artifacts_dir: str | Path | None = None,
+    ) -> None:
+        settings = get_settings() if exports_dir is None or artifacts_dir is None else None
+
+        resolved_exports_dir = exports_dir
+        if resolved_exports_dir is None:
+            assert settings is not None
+            resolved_exports_dir = settings.exports_dir
+
+        resolved_artifacts_dir = artifacts_dir
+        if resolved_artifacts_dir is None:
+            assert settings is not None
+            resolved_artifacts_dir = settings.artifacts_dir
+
+        self.exports_dir = Path(resolved_exports_dir)
+        self.artifacts_dir = Path(resolved_artifacts_dir)
         self.exports_dir.mkdir(parents=True, exist_ok=True)
         self.artifacts_dir.mkdir(parents=True, exist_ok=True)
 
@@ -29,9 +45,9 @@ class Exporter:
 
         with m3u_path.open("w", encoding="utf-8") as f:
             f.write("#EXTM3U\n")
-            for t in tracks:
-                path = getattr(t, "path", None)
-                title = getattr(t, "track_id", "unknown")
+            for track in tracks:
+                path = getattr(track, "path", None)
+                title = getattr(track, "track_id", "unknown")
 
                 if path:
                     f.write(f"#EXTINF:-1,{title}\n")

--- a/services/orchestrator/pipeline.py
+++ b/services/orchestrator/pipeline.py
@@ -1,13 +1,27 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+from uuid import uuid4
+
 from services.composer.composer import Composer
 from services.export.exporter import Exporter
 
 
+def _new_pipeline_run_id() -> str:
+    return f"pipeline-{uuid4().hex}"
+
+
 class OrchestratorPipeline:
-    def __init__(self) -> None:
-        self.composer = Composer()
-        self.exporter = Exporter()
+    def __init__(
+        self,
+        *,
+        composer: Composer | None = None,
+        exporter: Exporter | None = None,
+        run_id_factory: Callable[[], str] | None = None,
+    ) -> None:
+        self.composer = composer or Composer()
+        self.exporter = exporter or Exporter()
+        self._run_id_factory = run_id_factory or _new_pipeline_run_id
 
     def run(
         self,
@@ -17,12 +31,16 @@ class OrchestratorPipeline:
         bpm_max: float | None = None,
         mode: str | None = None,
     ) -> dict:
-        # current clean MVP behavior:
-        # compose from precomputed DB analyses, then export
+        # Current clean MVP behavior:
+        # compose from precomputed DB analyses joined to track paths, then export.
         playlist = self.composer.compose(limit=limit)
+        playlist_id = self._run_id_factory()
+
+        if not isinstance(playlist_id, str) or not playlist_id.strip():
+            raise RuntimeError("Pipeline run ID factory returned an invalid identifier")
 
         export = self.exporter.export_m3u(
-            playlist_id="pipeline_run",
+            playlist_id=playlist_id.strip(),
             tracks=playlist,
         )
 
@@ -34,7 +52,7 @@ class OrchestratorPipeline:
                 "bpm_max": bpm_max,
                 "mode": mode,
             },
-            "tracks": [t.track_id for t in playlist],
+            "tracks": [track.track_id for track in playlist],
             "count": len(playlist),
             "export": export,
         }

--- a/tests/test_composer.py
+++ b/tests/test_composer.py
@@ -1,29 +1,49 @@
-from services.composer.composer import Composer
-from data.repositories.analysis_repository import AnalysisRepository
+from pathlib import Path
+
+from core.config.settings import get_settings
 from data.models.analysis_record import AnalysisRecord
+from data.models.track_record import TrackRecord
+from data.repositories.analysis_repository import AnalysisRepository
+from data.repositories.track_repository import TrackRepository
+from services.composer.composer import Composer
 
 
-def seed():
-    repo = AnalysisRepository()
+def seed() -> None:
+    analysis_repo = AnalysisRepository()
+    track_repo = TrackRepository()
 
-    for i in range(10):
-        repo.upsert(
+    for index in range(10):
+        track_id = f"composer-{index}"
+        track_repo.upsert(
+            TrackRecord(
+                track_id=track_id,
+                path=f"/music/{track_id}.mp3",
+                title=f"Track {index}",
+            )
+        )
+        analysis_repo.upsert(
             AnalysisRecord(
-                track_id=f"t{i}",
+                track_id=track_id,
                 analysis_version="1",
                 features_version="1",
                 extractor_backend="x",
                 extractor_name="x",
-                bpm=120 + i,
+                bpm=120 + index,
                 camelot="8A",
-                energy=i / 10,
+                energy=index / 10,
             )
         )
 
 
-def test_compose():
-    seed()
-    composer = Composer()
-    playlist = composer.compose(limit=5)
+def test_compose(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path / 'composer.db'}")
+    get_settings.cache_clear()
 
-    assert len(playlist) == 5
+    try:
+        seed()
+        playlist = Composer().compose(limit=5)
+
+        assert len(playlist) == 5
+        assert all(track.path.startswith("/music/composer-") for track in playlist)
+    finally:
+        get_settings.cache_clear()

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -4,11 +4,11 @@ from types import SimpleNamespace
 from services.export.exporter import Exporter
 
 
-def test_exporter_writes_files(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setenv("EXPORTS_DIR", str(tmp_path / "exports"))
-    monkeypatch.setenv("ARTIFACTS_DIR", str(tmp_path / "artifacts"))
-
-    exporter = Exporter()
+def test_exporter_writes_files(tmp_path: Path) -> None:
+    exporter = Exporter(
+        exports_dir=tmp_path / "exports",
+        artifacts_dir=tmp_path / "artifacts",
+    )
 
     tracks = [
         SimpleNamespace(track_id="t1", path="/music/t1.mp3"),

--- a/tests/unit/test_pipeline_export_integrity.py
+++ b/tests/unit/test_pipeline_export_integrity.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+
+from core.config.settings import get_settings
+from data.models.analysis_record import AnalysisRecord
+from data.models.track_record import TrackRecord
+from data.repositories.analysis_repository import AnalysisRepository
+from data.repositories.track_repository import TrackRepository
+from services.composer.composer import Composer
+from services.export.exporter import Exporter
+from services.orchestrator.pipeline import OrchestratorPipeline
+
+
+def _seed_candidates() -> set[str]:
+    analysis_repo = AnalysisRepository()
+    track_repo = TrackRepository()
+    expected_ids = set()
+
+    for index in range(3):
+        track_id = f"joined-{index}"
+        expected_ids.add(track_id)
+        track_repo.upsert(
+            TrackRecord(
+                track_id=track_id,
+                path=f"/music/{track_id}.wav",
+                title=f"Joined Track {index}",
+            )
+        )
+        analysis_repo.upsert(
+            AnalysisRecord(
+                track_id=track_id,
+                analysis_version="1",
+                features_version="1",
+                extractor_backend="test",
+                extractor_name="bundle-26",
+                bpm=126 + index,
+                camelot="8A",
+                energy=0.4 + (index * 0.1),
+            )
+        )
+
+    analysis_repo.upsert(
+        AnalysisRecord(
+            track_id="orphan-analysis",
+            analysis_version="1",
+            features_version="1",
+            extractor_backend="test",
+            extractor_name="bundle-26",
+            bpm=130,
+            camelot="9A",
+            energy=0.7,
+        )
+    )
+
+    return expected_ids
+
+
+def test_pipeline_exports_joined_paths_without_collisions(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path / 'pipeline.db'}")
+    get_settings.cache_clear()
+
+    try:
+        expected_ids = _seed_candidates()
+        pipeline = OrchestratorPipeline(
+            composer=Composer(),
+            exporter=Exporter(
+                exports_dir=tmp_path / "exports",
+                artifacts_dir=tmp_path / "artifacts",
+            ),
+        )
+
+        first = pipeline.run(path="/music", limit=3)
+        second = pipeline.run(path="/music", limit=3)
+
+        assert first["count"] == 3
+        assert set(first["tracks"]) == expected_ids
+        assert "orphan-analysis" not in first["tracks"]
+        assert first["export"]["resolved_count"] == first["count"]
+        assert first["export"]["skipped_count"] == 0
+
+        assert first["export"]["playlist_id"].startswith("pipeline-")
+        assert second["export"]["playlist_id"].startswith("pipeline-")
+        assert first["export"]["playlist_id"] != second["export"]["playlist_id"]
+        assert first["export"]["m3u_path"] != second["export"]["m3u_path"]
+
+        first_m3u = Path(first["export"]["m3u_path"])
+        second_m3u = Path(second["export"]["m3u_path"])
+        assert first_m3u.exists()
+        assert second_m3u.exists()
+
+        content = first_m3u.read_text(encoding="utf-8")
+        for track_id in expected_ids:
+            assert f"/music/{track_id}.wav" in content
+        assert "orphan-analysis" not in content
+    finally:
+        get_settings.cache_clear()


### PR DESCRIPTION
## Summary

- add an immutable playlist-candidate read model
- join `analyses` with `tracks` so composed tracks retain source paths
- exclude orphan analyses and empty paths fail-closed
- remove direct SQLite access from the composer
- inject export directories and pipeline dependencies for deterministic tests
- generate a unique `pipeline-<uuid>` identifier for every pipeline run
- prevent repeated or concurrent pipeline runs from overwriting artifacts

## Verification

- branch created directly from Bundle 25 squash commit `0fd698555706d1586450519e16cef3ca56689bb0`
- branch is ahead only; base history was not rewritten
- static diff is limited to 9 files in repository/composer/export/pipeline/tests/docs scope
- CI must verify install, compile, critical Ruff and full pytest on Python 3.11 and 3.12
- no local test execution is claimed

## Notes

- no database schema or migration change
- no public API response-shape change
- no provider or Essentia behavior change
- analyses without matching track metadata are intentionally excluded
- the existing `export.playlist_id` field now contains a unique value instead of the constant `pipeline_run`

## Bundle Context

- Bundle: 26 — Export Path Integrity and Unique Pipeline Runs
- Base branch: `feature/bundle-0-bootstrap`
- Base commit: `0fd698555706d1586450519e16cef3ca56689bb0`
- Related issue: #26
- Rollback: close this PR or revert its future squash commit; no data rollback required