### PR TITLE
Bundle 27: production authentication fail-closed

### DIFF
--- a/api/security/auth_gate.py
+++ b/api/security/auth_gate.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from hmac import compare_digest
+
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
@@ -55,7 +57,7 @@ class ApiKeyAuthMiddleware(BaseHTTPMiddleware):
                 headers={"X-Request-ID": request_id},
             )
 
-        if supplied != expected:
+        if supplied is None or not compare_digest(supplied, expected):
             return JSONResponse(
                 status_code=401,
                 content={

--- a/api/security/settings.py
+++ b/api/security/settings.py
@@ -62,8 +62,10 @@ class SecuritySettings:
 
     @property
     def auth_enabled(self) -> bool:
+        # Production cannot opt out of authentication. A missing key is handled
+        # by the middleware as a controlled 503 misconfiguration response.
         if self.is_production:
-            return bool(self.auth_enabled_raw or self.api_key)
+            return True
         return self.auth_enabled_raw
 
 

--- a/data/config/security.env.example
+++ b/data/config/security.env.example
@@ -7,7 +7,8 @@ RATE_LIMIT_PER_MINUTE=120
 MAX_REQUEST_BYTES=2097152
 TRUSTED_PROXY_DEPTH=0
 
-# Bundle 13
+# Production always enforces authentication.
+# Generate a strong random secret before deployment; an empty value fails closed with HTTP 503.
 AUTH_ENABLED=true
-API_KEY=change-me
+API_KEY=
 API_KEY_HEADER_NAME=X-API-Key

--- a/docs/bundles/BUNDLE_27_PRODUCTION_AUTH_FAIL_CLOSED.md
+++ b/docs/bundles/BUNDLE_27_PRODUCTION_AUTH_FAIL_CLOSED.md
@@ -1,0 +1,43 @@
+# Bundle 27 — Production Authentication Fail-Closed
+
+## Goal
+
+Guarantee that production write routes cannot become unauthenticated because environment configuration is missing or explicitly disables authentication.
+
+## Confirmed defect
+
+The previous `SecuritySettings.auth_enabled` implementation returned `False` in production when both `AUTH_ENABLED` and `API_KEY` were unset. `ApiKeyAuthMiddleware` then bypassed authentication entirely.
+
+## Security contract
+
+- `APP_ENV=production|prod` always enables API-key enforcement
+- `AUTH_ENABLED=false` cannot disable authentication in production
+- a missing production `API_KEY` returns HTTP 503 with `auth_misconfigured`
+- a missing or incorrect configured key returns HTTP 401
+- key comparison uses `hmac.compare_digest`
+- safe read methods remain available
+- development may explicitly disable authentication
+
+## Configuration
+
+The production example no longer ships with `API_KEY=change-me`. Operators must generate a strong secret. Leaving the value empty is safe because write routes fail closed with HTTP 503.
+
+## Non-goals
+
+- no JWT or identity redesign
+- no route authorization expansion
+- no CORS change
+- no API response-shape change
+
+## Verification contract
+
+- production without a key rejects write requests
+- production with `AUTH_ENABLED=false` still enforces authentication
+- production with a valid key accepts write requests
+- health remains available without a key
+- development auth-disable behavior remains supported
+- Python 3.11 and 3.12 CI must pass before merge
+
+## Rollback
+
+Revert the future Bundle 27 squash commit. No database or data rollback is required.

--- a/tests/test_auth_gate.py
+++ b/tests/test_auth_gate.py
@@ -10,7 +10,8 @@ def _build_app():
     return create_app(SecuritySettings())
 
 
-def _set_auth_env(enabled: bool, api_key: str) -> None:
+def _set_auth_env(enabled: bool, api_key: str, *, app_env: str = "development") -> None:
+    os.environ["APP_ENV"] = app_env
     os.environ["AUTH_ENABLED"] = "true" if enabled else "false"
     os.environ["API_KEY"] = api_key
 
@@ -56,6 +57,57 @@ def test_get_endpoint_does_not_require_api_key() -> None:
         client = TestClient(_build_app())
 
         response = client.get("/health")
+        assert response.status_code == 200
+    finally:
+        _clear_auth_env()
+
+
+def test_production_without_api_key_fails_closed_even_when_disabled() -> None:
+    try:
+        _set_auth_env(False, "", app_env="production")
+        client = TestClient(_build_app())
+
+        response = client.post("/pipeline/run", json={"path": "/tmp", "limit": 1})
+        assert response.status_code == 503
+        body = response.json()
+        assert body["error"]["type"] == "auth_misconfigured"
+        assert body["error"]["request_id"] == response.headers["X-Request-ID"]
+    finally:
+        _clear_auth_env()
+
+
+def test_production_accepts_valid_key_even_when_flag_is_false() -> None:
+    try:
+        _set_auth_env(False, "production-secret", app_env="production")
+        client = TestClient(_build_app())
+
+        response = client.post(
+            "/pipeline/run",
+            json={"path": "/tmp", "limit": 1},
+            headers={"X-API-Key": "production-secret"},
+        )
+        assert response.status_code == 200
+    finally:
+        _clear_auth_env()
+
+
+def test_production_health_remains_available_without_api_key() -> None:
+    try:
+        _set_auth_env(False, "", app_env="production")
+        client = TestClient(_build_app())
+
+        response = client.get("/health")
+        assert response.status_code == 200
+    finally:
+        _clear_auth_env()
+
+
+def test_development_can_explicitly_disable_authentication() -> None:
+    try:
+        _set_auth_env(False, "", app_env="development")
+        client = TestClient(_build_app())
+
+        response = client.post("/pipeline/run", json={"path": "/tmp", "limit": 1})
         assert response.status_code == 200
     finally:
         _clear_auth_env()


### PR DESCRIPTION
## Summary

- force API-key authentication enforcement in production
- prevent `AUTH_ENABLED=false` from disabling production write-route protection
- return the existing 503 `auth_misconfigured` response when a production key is absent
- compare configured API keys with `hmac.compare_digest`
- remove the weak `API_KEY=change-me` value from the production env example
- add explicit production fail-closed regression coverage

## Verification

- branch created directly from Bundle 26 squash commit `43f6f9e25c7baac34d4b7b811bc8eb66fde40232`
- branch is ahead only; base history was not rewritten
- static diff is limited to 5 auth/config/test/doc files
- CI must verify install, compile, critical Ruff and full pytest on Python 3.11 and 3.12
- no local test execution is claimed

## Notes

- no identity/JWT redesign
- no route authorization expansion
- no CORS behavior change
- no database or public API response-shape change
- safe read methods remain available without an API key

## Bundle Context

- Bundle: 27 — Production Authentication Fail-Closed
- Base branch: `feature/bundle-0-bootstrap`
- Base commit: `43f6f9e25c7baac34d4b7b811bc8eb66fde40232`
- Related issue: #28
- Rollback: close this PR or revert its future squash commit; no data rollback required