### PR TITLE
Bundle 28: production CORS fail-closed

### DIFF
--- a/api/middleware/cors 2.py
+++ b/api/middleware/cors 2.py
@@ -1,17 +1,8 @@
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi import FastAPI
+"""Deprecated duplicate retained only because remote deletion was blocked.
 
-from core.config.settings import get_settings
+The canonical implementation lives in :mod:`api.middleware.cors`.
+"""
 
+from api.middleware.cors import install_cors
 
-def install_cors(app: FastAPI) -> None:
-    settings = get_settings()
-    origins = [origin.strip() for origin in settings.cors_origins.split(",") if origin.strip()]
-
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=origins,
-        allow_credentials=True,
-        allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-        allow_headers=["*"],
-    )
+__all__ = ["install_cors"]

--- a/api/middleware/cors.py
+++ b/api/middleware/cors.py
@@ -1,17 +1,22 @@
+from __future__ import annotations
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from core.config.settings import get_settings
+from api.security.settings import SecuritySettings, settings
 
 
-def install_cors(app: FastAPI) -> None:
-    settings = get_settings()
-    origins = [origin.strip() for origin in settings.cors_origins.split(",") if origin.strip()]
+def install_cors(
+    app: FastAPI,
+    security_settings: SecuritySettings | None = None,
+) -> None:
+    """Install the single canonical CORS policy for the application."""
+    config = security_settings or settings
 
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=origins,
-        allow_credentials=True,
+        allow_origins=config.allowed_origins,
+        allow_credentials=config.cors_allow_credentials,
         allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
         allow_headers=["*"],
     )

--- a/api/security/bootstrap.py
+++ b/api/security/bootstrap.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from fastapi.middleware.cors import CORSMiddleware
-
+from api.middleware.cors import install_cors
 from api.middleware.rate_limit import RateLimitMiddleware
 from api.middleware.request_size_guard import RequestSizeGuardMiddleware
 from api.middleware.security_headers import SecurityHeadersMiddleware
@@ -17,13 +16,7 @@ def apply_security_hardening(
     names = {mw.cls.__name__ for mw in existing if getattr(mw, "cls", None)}
 
     if "CORSMiddleware" not in names:
-        app.add_middleware(
-            CORSMiddleware,
-            allow_origins=config.allowed_origins,
-            allow_credentials=True,
-            allow_methods=["*"],
-            allow_headers=["*"],
-        )
+        install_cors(app, config)
 
     if config.enable_security_headers and "SecurityHeadersMiddleware" not in names:
         app.add_middleware(SecurityHeadersMiddleware)

--- a/api/security/settings.py
+++ b/api/security/settings.py
@@ -4,6 +4,10 @@ import os
 from dataclasses import dataclass, field
 
 
+class SecurityConfigurationError(RuntimeError):
+    """Raised when security settings cannot be applied safely."""
+
+
 def _as_bool(value: str | None, default: bool) -> bool:
     if value is None:
         return default
@@ -15,6 +19,20 @@ def _as_int(value: str | None, default: int) -> int:
         return int(value) if value is not None else default
     except (TypeError, ValueError):
         return default
+
+
+def _parse_origins(raw: str) -> list[str]:
+    origins: list[str] = []
+    seen: set[str] = set()
+
+    for item in raw.split(","):
+        origin = item.strip()
+        if not origin or origin in seen:
+            continue
+        seen.add(origin)
+        origins.append(origin)
+
+    return origins
 
 
 @dataclass(frozen=True)
@@ -55,10 +73,26 @@ class SecuritySettings:
 
     @property
     def allowed_origins(self) -> list[str]:
-        raw = self.allowed_origins_raw.strip()
-        if not raw:
+        origins = _parse_origins(self.allowed_origins_raw)
+
+        if "*" in origins and len(origins) > 1:
+            raise SecurityConfigurationError(
+                "ALLOW_ORIGINS cannot combine '*' with explicit origins"
+            )
+
+        if self.is_production and (not origins or "*" in origins):
+            raise SecurityConfigurationError(
+                "Production requires an explicit non-wildcard ALLOW_ORIGINS allowlist"
+            )
+
+        if not origins:
             return ["*"]
-        return [item.strip() for item in raw.split(",") if item.strip()]
+
+        return origins
+
+    @property
+    def cors_allow_credentials(self) -> bool:
+        return "*" not in self.allowed_origins
 
     @property
     def auth_enabled(self) -> bool:

--- a/data/config/security.env.example
+++ b/data/config/security.env.example
@@ -1,5 +1,7 @@
 APP_ENV=production
-ALLOW_ORIGINS=*
+# Replace with the exact deployed frontend origin(s), comma-separated.
+# Wildcard and empty values are rejected in production.
+ALLOW_ORIGINS=https://app.example.com
 ENABLE_SECURITY_HEADERS=true
 ENABLE_REQUEST_SIZE_GUARD=true
 ENABLE_RATE_LIMIT=true

--- a/docs/bundles/BUNDLE_28_PRODUCTION_CORS_FAIL_CLOSED.md
+++ b/docs/bundles/BUNDLE_28_PRODUCTION_CORS_FAIL_CLOSED.md
@@ -1,0 +1,50 @@
+# Bundle 28 — Production CORS Fail-Closed
+
+## Goal
+
+Prevent production deployments from starting with wildcard or empty CORS origins and prevent wildcard CORS from being combined with browser credentials.
+
+## Confirmed baseline defect
+
+The active security bootstrap installed `CORSMiddleware` with:
+
+- `ALLOW_ORIGINS=*` by default,
+- `allow_credentials=True` unconditionally,
+- a production example that also used the wildcard.
+
+The repository also tracked an unimported duplicate `api/middleware/cors 2.py`.
+
+## Implemented contract
+
+- `api/middleware/cors.py` owns the single CORS middleware policy.
+- `api/security/bootstrap.py` delegates CORS installation to that module.
+- Production requires at least one explicit non-wildcard origin.
+- Empty or wildcard production configuration raises `SecurityConfigurationError` during application creation.
+- Wildcard may be used only outside production and always disables CORS credentials.
+- Explicit allowlists enable credentialed CORS.
+- Origins are whitespace-normalized and de-duplicated while preserving order.
+- A wildcard cannot be mixed with explicit origins.
+- The production env example contains an explicit placeholder origin.
+- The redundant `cors 2.py` copy is removed.
+
+## Compatibility
+
+- No endpoint or response schema changes.
+- No authentication or authorization changes.
+- Development keeps wildcard convenience without credential support.
+- Existing explicit local origins remain supported.
+
+## Verification gate
+
+- startup rejection tests for production wildcard and empty configuration,
+- normalization and duplicate-removal test,
+- wildcard-mixing rejection test,
+- allowed production preflight test,
+- unlisted production origin rejection test,
+- development wildcard response without credential headers,
+- Python 3.11 and 3.12 CI,
+- compile, critical Ruff and full pytest.
+
+## Rollback
+
+Revert the future Bundle 28 squash commit. There is no database or data rollback.

--- a/docs/bundles/BUNDLE_28_PRODUCTION_CORS_FAIL_CLOSED.md
+++ b/docs/bundles/BUNDLE_28_PRODUCTION_CORS_FAIL_CLOSED.md
@@ -25,7 +25,7 @@ The repository also tracked an unimported duplicate `api/middleware/cors 2.py`.
 - Origins are whitespace-normalized and de-duplicated while preserving order.
 - A wildcard cannot be mixed with explicit origins.
 - The production env example contains an explicit placeholder origin.
-- The redundant `cors 2.py` copy is removed.
+- Remote deletion of `cors 2.py` was blocked by the connector, so the file is neutralized to a compatibility re-export with no independent policy.
 
 ## Compatibility
 

--- a/tests/test_auth_gate.py
+++ b/tests/test_auth_gate.py
@@ -14,6 +14,10 @@ def _set_auth_env(enabled: bool, api_key: str, *, app_env: str = "development") 
     os.environ["APP_ENV"] = app_env
     os.environ["AUTH_ENABLED"] = "true" if enabled else "false"
     os.environ["API_KEY"] = api_key
+    if app_env.lower() in {"prod", "production"}:
+        os.environ["ALLOW_ORIGINS"] = "https://app.example.test"
+    else:
+        os.environ.pop("ALLOW_ORIGINS", None)
 
 
 def _clear_auth_env() -> None:
@@ -21,6 +25,7 @@ def _clear_auth_env() -> None:
     os.environ.pop("API_KEY", None)
     os.environ.pop("API_KEY_HEADER_NAME", None)
     os.environ.pop("APP_ENV", None)
+    os.environ.pop("ALLOW_ORIGINS", None)
 
 
 def test_write_endpoint_rejects_missing_api_key_when_auth_enabled() -> None:

--- a/tests/test_cors_security.py
+++ b/tests/test_cors_security.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import create_app
+from api.security.settings import SecurityConfigurationError, SecuritySettings
+
+
+def _settings(*, app_env: str, origins: str) -> SecuritySettings:
+    return SecuritySettings(
+        app_env=app_env,
+        allowed_origins_raw=origins,
+        enable_rate_limit=False,
+    )
+
+
+@pytest.mark.parametrize("origins", ["*", "", "   "])
+def test_production_rejects_wildcard_or_empty_origins(origins: str) -> None:
+    with pytest.raises(SecurityConfigurationError, match="explicit non-wildcard"):
+        create_app(_settings(app_env="production", origins=origins))
+
+
+def test_cors_origin_list_is_normalized_and_deduplicated() -> None:
+    config = _settings(
+        app_env="production",
+        origins=" https://app.example.com,https://admin.example.com,https://app.example.com ",
+    )
+
+    assert config.allowed_origins == [
+        "https://app.example.com",
+        "https://admin.example.com",
+    ]
+    assert config.cors_allow_credentials is True
+
+
+def test_cors_rejects_wildcard_mixed_with_explicit_origins() -> None:
+    config = _settings(
+        app_env="development",
+        origins="*,https://app.example.com",
+    )
+
+    with pytest.raises(SecurityConfigurationError, match="cannot combine"):
+        _ = config.allowed_origins
+
+
+def test_explicit_production_origin_receives_credentialed_preflight_headers() -> None:
+    client = TestClient(
+        create_app(
+            _settings(
+                app_env="production",
+                origins="https://app.example.com",
+            )
+        )
+    )
+
+    response = client.options(
+        "/pipeline/run",
+        headers={
+            "Origin": "https://app.example.com",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "Content-Type,X-API-Key",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://app.example.com"
+    assert response.headers["access-control-allow-credentials"] == "true"
+
+
+def test_unlisted_production_origin_receives_no_allow_origin_header() -> None:
+    client = TestClient(
+        create_app(
+            _settings(
+                app_env="production",
+                origins="https://app.example.com",
+            )
+        )
+    )
+
+    response = client.options(
+        "/pipeline/run",
+        headers={
+            "Origin": "https://evil.example.com",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_development_wildcard_disables_cors_credentials() -> None:
+    client = TestClient(create_app(_settings(app_env="development", origins="*")))
+
+    response = client.get(
+        "/health",
+        headers={"Origin": "https://local-tool.example.com"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "*"
+    assert "access-control-allow-credentials" not in response.headers


### PR DESCRIPTION
## Summary

- centralize the active CORS policy in `api/middleware/cors.py`
- reject empty or wildcard CORS origins during production application startup
- prevent wildcard origins from being combined with credentialed CORS
- preserve development wildcard convenience with credentials disabled
- normalize and de-duplicate explicit origin allowlists
- delegate security bootstrap CORS installation to the canonical policy
- replace the production wildcard example with an explicit placeholder origin
- neutralize the redundant `cors 2.py` implementation after remote deletion was blocked
- add startup, preflight, rejection and development-mode regression tests

## Verification

- branch created directly from Bundle 27 squash commit `fc0a9a05bd435e71da2e962f462832ba66ad6a9e`
- branch is ahead only; base history was not rewritten
- static diff is limited to 7 CORS/security/config/test/doc files
- CI must verify install, compile, critical Ruff and full pytest on Python 3.11 and 3.12
- no local test execution is claimed

## Notes

- no authentication or authorization behavior change
- no database or public API response-shape change
- production deployments must replace `https://app.example.com` with the exact deployed frontend origin
- the duplicate file remains tracked only as a compatibility re-export because the connector blocked deletion

## Bundle Context

- Bundle: 28 — Production CORS Fail-Closed
- Base branch: `feature/bundle-0-bootstrap`
- Base commit: `fc0a9a05bd435e71da2e962f462832ba66ad6a9e`
- Related issue: #30
- Rollback: close this PR or revert its future squash commit; no data rollback required