### PR TITLE
Bundle 29: trusted proxy rate-limit identity

### DIFF
--- a/api/middleware/rate_limit.py
+++ b/api/middleware/rate_limit.py
@@ -2,25 +2,99 @@ from __future__ import annotations
 
 import time
 from collections import defaultdict, deque
-from typing import Deque, DefaultDict
+from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network, ip_address
+from typing import Deque, DefaultDict, Iterable
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
 
+IPAddress = IPv4Address | IPv6Address
+ProxyNetwork = IPv4Network | IPv6Network
+
+
+def _parse_ip(value: str | None) -> IPAddress | None:
+    if value is None:
+        return None
+    candidate = value.strip()
+    if not candidate:
+        return None
+    try:
+        return ip_address(candidate)
+    except ValueError:
+        return None
+
+
+def _is_trusted(address: IPAddress, networks: Iterable[ProxyNetwork]) -> bool:
+    return any(address in network for network in networks)
+
+
+def resolve_client_key(
+    *,
+    direct_peer: str | None,
+    forwarded_for: str | None,
+    trusted_proxy_depth: int,
+    trusted_proxy_networks: tuple[ProxyNetwork, ...],
+) -> str:
+    """Resolve a stable rate-limit identity without trusting spoofable headers.
+
+    The forwarded chain is used only when the direct peer and every configured
+    trusted proxy hop belong to the explicit CIDR allowlist. Any malformed,
+    incomplete or untrusted chain falls back to the direct peer.
+    """
+    direct_ip = _parse_ip(direct_peer)
+    direct_key = str(direct_ip) if direct_ip is not None else (direct_peer or "unknown")
+
+    if trusted_proxy_depth <= 0 or not trusted_proxy_networks:
+        return direct_key
+
+    if direct_ip is None or not _is_trusted(direct_ip, trusted_proxy_networks):
+        return direct_key
+
+    forwarded_values = [
+        item.strip()
+        for item in (forwarded_for or "").split(",")
+        if item.strip()
+    ]
+    forwarded_ips = [_parse_ip(item) for item in forwarded_values]
+    if not forwarded_ips or any(item is None for item in forwarded_ips):
+        return direct_key
+
+    chain = [item for item in forwarded_ips if item is not None] + [direct_ip]
+    if len(chain) <= trusted_proxy_depth:
+        return direct_key
+
+    trusted_hops = chain[-trusted_proxy_depth:]
+    if not all(_is_trusted(item, trusted_proxy_networks) for item in trusted_hops):
+        return direct_key
+
+    client = chain[-(trusted_proxy_depth + 1)]
+    return str(client)
+
+
 class RateLimitMiddleware(BaseHTTPMiddleware):
-    def __init__(self, app, limit_per_minute: int = 120) -> None:
+    def __init__(
+        self,
+        app,
+        limit_per_minute: int = 120,
+        trusted_proxy_depth: int = 0,
+        trusted_proxy_networks: tuple[ProxyNetwork, ...] = (),
+    ) -> None:
         super().__init__(app)
         self.limit_per_minute = max(1, int(limit_per_minute))
+        self.trusted_proxy_depth = max(0, int(trusted_proxy_depth))
+        self.trusted_proxy_networks = trusted_proxy_networks
         self._hits: DefaultDict[str, Deque[float]] = defaultdict(deque)
 
     def _client_key(self, request: Request) -> str:
-        forwarded = request.headers.get("x-forwarded-for", "").split(",")[0].strip()
-        if forwarded:
-            return forwarded
-        client = request.client.host if request.client else "unknown"
-        return client or "unknown"
+        direct_peer = request.client.host if request.client else None
+        return resolve_client_key(
+            direct_peer=direct_peer,
+            forwarded_for=request.headers.get("x-forwarded-for"),
+            trusted_proxy_depth=self.trusted_proxy_depth,
+            trusted_proxy_networks=self.trusted_proxy_networks,
+        )
 
     async def dispatch(self, request: Request, call_next) -> Response:
         key = self._client_key(request)

--- a/api/security/bootstrap.py
+++ b/api/security/bootstrap.py
@@ -31,4 +31,6 @@ def apply_security_hardening(
         app.add_middleware(
             RateLimitMiddleware,
             limit_per_minute=config.rate_limit_per_minute,
+            trusted_proxy_depth=config.trusted_proxy_depth,
+            trusted_proxy_networks=config.trusted_proxy_networks,
         )

--- a/api/security/settings.py
+++ b/api/security/settings.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
+from ipaddress import IPv4Network, IPv6Network, ip_network
+
+
+ProxyNetwork = IPv4Network | IPv6Network
 
 
 class SecurityConfigurationError(RuntimeError):
@@ -35,6 +39,25 @@ def _parse_origins(raw: str) -> list[str]:
     return origins
 
 
+def _parse_proxy_networks(raw: str) -> tuple[ProxyNetwork, ...]:
+    networks: list[ProxyNetwork] = []
+    seen: set[str] = set()
+
+    for item in raw.split(","):
+        value = item.strip()
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        try:
+            networks.append(ip_network(value, strict=False))
+        except ValueError as exc:
+            raise SecurityConfigurationError(
+                f"Invalid TRUSTED_PROXY_CIDRS entry: {value}"
+            ) from exc
+
+    return tuple(networks)
+
+
 @dataclass(frozen=True)
 class SecuritySettings:
     """Immutable security configuration captured from the current environment."""
@@ -49,6 +72,9 @@ class SecuritySettings:
     )
     trusted_proxy_depth: int = field(
         default_factory=lambda: _as_int(os.getenv("TRUSTED_PROXY_DEPTH"), 0)
+    )
+    trusted_proxy_cidrs_raw: str = field(
+        default_factory=lambda: os.getenv("TRUSTED_PROXY_CIDRS", "")
     )
     enable_security_headers: bool = field(
         default_factory=lambda: _as_bool(os.getenv("ENABLE_SECURITY_HEADERS"), True)
@@ -93,6 +119,20 @@ class SecuritySettings:
     @property
     def cors_allow_credentials(self) -> bool:
         return "*" not in self.allowed_origins
+
+    @property
+    def trusted_proxy_networks(self) -> tuple[ProxyNetwork, ...]:
+        if self.trusted_proxy_depth < 0:
+            raise SecurityConfigurationError(
+                "TRUSTED_PROXY_DEPTH cannot be negative"
+            )
+
+        networks = _parse_proxy_networks(self.trusted_proxy_cidrs_raw)
+        if self.trusted_proxy_depth > 0 and not networks:
+            raise SecurityConfigurationError(
+                "TRUSTED_PROXY_CIDRS is required when TRUSTED_PROXY_DEPTH is greater than zero"
+            )
+        return networks
 
     @property
     def auth_enabled(self) -> bool:

--- a/data/config/security.env.example
+++ b/data/config/security.env.example
@@ -7,7 +7,11 @@ ENABLE_REQUEST_SIZE_GUARD=true
 ENABLE_RATE_LIMIT=true
 RATE_LIMIT_PER_MINUTE=120
 MAX_REQUEST_BYTES=2097152
+
+# Keep depth 0 unless APPLAYLIST is deployed behind known reverse proxies.
+# When depth is greater than zero, list every trusted proxy network explicitly.
 TRUSTED_PROXY_DEPTH=0
+TRUSTED_PROXY_CIDRS=
 
 # Production always enforces authentication.
 # Generate a strong random secret before deployment; an empty value fails closed with HTTP 503.

--- a/docs/audits/APPLAYLIST_OLD_DONOR_AUDIT_20260717.md
+++ b/docs/audits/APPLAYLIST_OLD_DONOR_AUDIT_20260717.md
@@ -1,0 +1,36 @@
+# Applaylist-old donor audit
+
+Source: `nulleimy/Applaylist-old` at `f04f65058e83620919b542f40029f04732761231`.
+
+## Decision
+
+Treat the repository as read-only donor material. Do not merge it, use it as a runtime dependency, or cherry-pick broad commits.
+
+## Candidate capabilities
+
+- deterministic playlist composer with BPM, Camelot, energy-stage and spacing rules,
+- structured M3U/M3U8/JSON export contracts and sidecars,
+- missing-path repair workflow,
+- React export dialog.
+
+Each capability must be ported in a new bundle from the canonical APPLAYLIST head.
+
+## Rejected baseline patterns
+
+- empty `pyproject.toml` and unpinned dependencies,
+- Python 3.13 CI with `pip install ... || true`,
+- global FastAPI bootstrap and wildcard CORS,
+- raw exception text returned by routes,
+- unbounded recursive filesystem search,
+- filename-only path cache,
+- working-directory-relative runtime files,
+- broad exception swallowing.
+
+## Migration order
+
+1. Pure canonical composition engine.
+2. Structured export service and API.
+3. Bounded path resolution with explicit roots and search budgets.
+4. Frontend export and repair UX using canonical APIs.
+
+Bundle 29 imports no code from this repository.

--- a/docs/bundles/BUNDLE_29_TRUSTED_PROXY_RATE_LIMIT.md
+++ b/docs/bundles/BUNDLE_29_TRUSTED_PROXY_RATE_LIMIT.md
@@ -1,0 +1,25 @@
+# Bundle 29 — Trusted Proxy Rate-Limit Identity
+
+## Purpose
+
+Stop direct clients from changing rate-limit identity with spoofed forwarded headers.
+
+## Rules
+
+- Forwarded headers are ignored when proxy depth is zero.
+- Positive proxy depth requires explicit trusted proxy CIDRs.
+- The direct peer and configured proxy hops must be trusted.
+- Invalid, incomplete or untrusted chains use the direct peer.
+- Invalid proxy configuration fails application creation.
+
+## Verification
+
+Tests cover default spoofing, trusted one-hop and multi-hop chains, untrusted peers, malformed chains, startup rejection and middleware bucket behavior on Python 3.11 and 3.12.
+
+## Donor note
+
+`nulleimy/Applaylist-old` is classified as read-only donor material. No code from it is imported in this bundle.
+
+## Rollback
+
+Revert the Bundle 29 squash commit. No data rollback is required.

--- a/tests/test_rate_limit_proxy_trust.py
+++ b/tests/test_rate_limit_proxy_trust.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from ipaddress import ip_network
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.main import create_app
+from api.middleware.rate_limit import RateLimitMiddleware, resolve_client_key
+from api.security.settings import SecurityConfigurationError, SecuritySettings
+
+
+def _networks(*values: str):
+    return tuple(ip_network(value) for value in values)
+
+
+def test_default_policy_ignores_forwarded_header() -> None:
+    assert resolve_client_key(
+        direct_peer="203.0.113.10",
+        forwarded_for="198.51.100.1",
+        trusted_proxy_depth=0,
+        trusted_proxy_networks=(),
+    ) == "203.0.113.10"
+
+
+def test_untrusted_direct_peer_cannot_override_client_identity() -> None:
+    assert resolve_client_key(
+        direct_peer="203.0.113.10",
+        forwarded_for="198.51.100.1",
+        trusted_proxy_depth=1,
+        trusted_proxy_networks=_networks("10.0.0.0/8"),
+    ) == "203.0.113.10"
+
+
+def test_trusted_one_hop_chain_resolves_original_client() -> None:
+    assert resolve_client_key(
+        direct_peer="10.0.0.2",
+        forwarded_for="198.51.100.7",
+        trusted_proxy_depth=1,
+        trusted_proxy_networks=_networks("10.0.0.0/8"),
+    ) == "198.51.100.7"
+
+
+def test_trusted_multi_hop_chain_resolves_original_client() -> None:
+    assert resolve_client_key(
+        direct_peer="10.0.0.3",
+        forwarded_for="198.51.100.7, 10.0.0.2",
+        trusted_proxy_depth=2,
+        trusted_proxy_networks=_networks("10.0.0.0/8"),
+    ) == "198.51.100.7"
+
+
+def test_untrusted_intermediate_proxy_falls_back_to_direct_peer() -> None:
+    assert resolve_client_key(
+        direct_peer="10.0.0.3",
+        forwarded_for="198.51.100.7, 192.0.2.2",
+        trusted_proxy_depth=2,
+        trusted_proxy_networks=_networks("10.0.0.0/8"),
+    ) == "10.0.0.3"
+
+
+@pytest.mark.parametrize(
+    "forwarded_for",
+    [None, "", "not-an-ip", "198.51.100.7, not-an-ip"],
+)
+def test_malformed_forwarded_chain_falls_back_to_direct_peer(
+    forwarded_for: str | None,
+) -> None:
+    assert resolve_client_key(
+        direct_peer="10.0.0.3",
+        forwarded_for=forwarded_for,
+        trusted_proxy_depth=1,
+        trusted_proxy_networks=_networks("10.0.0.0/8"),
+    ) == "10.0.0.3"
+
+
+def test_incomplete_forwarded_chain_falls_back_to_direct_peer() -> None:
+    assert resolve_client_key(
+        direct_peer="10.0.0.3",
+        forwarded_for="198.51.100.7",
+        trusted_proxy_depth=2,
+        trusted_proxy_networks=_networks("10.0.0.0/8"),
+    ) == "10.0.0.3"
+
+
+def test_proxy_depth_without_cidrs_fails_application_startup() -> None:
+    config = SecuritySettings(
+        app_env="development",
+        allowed_origins_raw="*",
+        trusted_proxy_depth=1,
+        trusted_proxy_cidrs_raw="",
+    )
+
+    with pytest.raises(SecurityConfigurationError, match="TRUSTED_PROXY_CIDRS"):
+        create_app(config)
+
+
+def test_invalid_proxy_cidr_fails_application_startup() -> None:
+    config = SecuritySettings(
+        app_env="development",
+        allowed_origins_raw="*",
+        trusted_proxy_depth=1,
+        trusted_proxy_cidrs_raw="not-a-cidr",
+    )
+
+    with pytest.raises(SecurityConfigurationError, match="Invalid TRUSTED_PROXY_CIDRS"):
+        create_app(config)
+
+
+def test_rotating_forwarded_header_does_not_bypass_default_rate_limit() -> None:
+    app = FastAPI()
+
+    @app.get("/probe")
+    def probe() -> dict[str, bool]:
+        return {"ok": True}
+
+    app.add_middleware(
+        RateLimitMiddleware,
+        limit_per_minute=1,
+        trusted_proxy_depth=0,
+        trusted_proxy_networks=(),
+    )
+    client = TestClient(app)
+
+    first = client.get("/probe", headers={"X-Forwarded-For": "198.51.100.1"})
+    second = client.get("/probe", headers={"X-Forwarded-For": "198.51.100.2"})
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+    assert second.json()["detail"] == "rate_limit_exceeded"


### PR DESCRIPTION
## Summary

- ignore `X-Forwarded-For` by default
- require explicit trusted proxy CIDRs when proxy depth is enabled
- trust forwarded client identity only when the direct peer and configured proxy hops are trusted
- fall back to the direct peer for malformed, incomplete or untrusted chains
- fail application creation for invalid proxy CIDRs, negative depth or depth without CIDRs
- inject the validated proxy policy into the rate limiter
- add deterministic parser and middleware bucket tests
- record `nulleimy/Applaylist-old` as read-only donor material with a controlled migration order

## Verification

- branch created directly from Bundle 28 squash commit `061e5107adf3d2a8d3ef5e7ee02236b92ba351e3`
- branch is ahead only; base history was not rewritten
- static diff is limited to 7 security/config/test/doc files
- CI must verify install, compile, critical Ruff and full pytest on Python 3.11 and 3.12
- no local test execution is claimed

## Notes

- no database, API response-shape, audio or composer runtime change
- direct deployments should keep proxy depth zero
- `Applaylist-old` is not merged, imported or used as a dependency

## Bundle Context

- Bundle: 29 — Trusted Proxy Rate-Limit Identity
- Base branch: `feature/bundle-0-bootstrap`
- Base commit: `061e5107adf3d2a8d3ef5e7ee02236b92ba351e3`
- Related issue: #32
- Rollback: close this PR or revert its future squash commit; no data rollback required