### PR TITLE
Bundle 30: canonical deterministic composition engine

### DIFF
--- a/docs/bundles/BUNDLE_30_CANONICAL_COMPOSITION_ENGINE.md
+++ b/docs/bundles/BUNDLE_30_CANONICAL_COMPOSITION_ENGINE.md
@@ -1,0 +1,58 @@
+# Bundle 30 — Canonical Deterministic Composition Engine
+
+## Goal
+
+Introduce a pure and explainable DJ composition engine without switching the existing API, database or pipeline.
+
+## Baseline problem
+
+The existing composer selects the first repository result as its opening track and delegates candidate scoring to a module that owns a global Spotify client. Candidate evaluation can therefore depend on external I/O and does not enforce hard transition constraints.
+
+## Implemented boundary
+
+`services/composition/` is a new isolated domain package:
+
+- `models.py` defines immutable requests, tracks, constraints, decisions and results.
+- `camelot.py` validates Camelot keys and evaluates same, adjacent and relative-key compatibility.
+- `scoring.py` performs pure transition scoring.
+- `engine.py` performs deterministic candidate filtering, opening selection and playlist composition.
+
+The package imports no FastAPI, database repository, filesystem adapter or external provider client.
+
+## Deterministic contract
+
+- Input order does not affect output order.
+- Duplicate `track_id` values are reduced deterministically.
+- Every selection uses explicit tie-break fields.
+- Stage-aware BPM limits are hard gates.
+- Harmonic, energy, genre, artist, label and source rules produce explicit reasons.
+- A stalled composition returns a controlled partial result rather than silently selecting an invalid transition.
+
+## Donor provenance
+
+The algorithmic concepts were audited from `nulleimy/Applaylist-old` at commit `f04f65058e83620919b542f40029f04732761231`.
+
+No source branch, runtime configuration, dependency file, API route or persistence implementation was merged from that repository. The implementation was rebuilt against the canonical APPLAYLIST architecture and test contract.
+
+## Non-goals
+
+- no replacement of `services/composer/Composer`,
+- no pipeline or API feature flag,
+- no database adapter,
+- no removal of Spotify integration from the legacy scorer,
+- no frontend changes.
+
+## Verification
+
+- Camelot normalization and compatibility tests,
+- deterministic output under reversed input order,
+- BPM hard-gate partial result,
+- start-key opening selection,
+- artist, label and source spacing behavior,
+- duplicate identifier handling,
+- genre-filtered empty result,
+- full Python 3.11 and 3.12 CI.
+
+## Rollback
+
+Revert the future Bundle 30 squash commit. No database or data rollback is required.

--- a/services/composition/__init__.py
+++ b/services/composition/__init__.py
@@ -1,0 +1,33 @@
+from services.composition.engine import DeterministicCompositionEngine
+from services.composition.models import (
+    CompositionConstraints,
+    CompositionDecision,
+    CompositionFailureReason,
+    CompositionMode,
+    CompositionRequest,
+    CompositionResult,
+    CompositionStatus,
+    CompositionSummary,
+    CompositionTrack,
+    EnergyStage,
+    EnergyTarget,
+    TransitionReason,
+    TransitionScore,
+)
+
+__all__ = [
+    "CompositionConstraints",
+    "CompositionDecision",
+    "CompositionFailureReason",
+    "CompositionMode",
+    "CompositionRequest",
+    "CompositionResult",
+    "CompositionStatus",
+    "CompositionSummary",
+    "CompositionTrack",
+    "DeterministicCompositionEngine",
+    "EnergyStage",
+    "EnergyTarget",
+    "TransitionReason",
+    "TransitionScore",
+]

--- a/services/composition/camelot.py
+++ b/services/composition/camelot.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import re
+
+
+_CAMELOT_RE = re.compile(r"^(?P<number>[1-9]|1[0-2])(?P<letter>[AB])$")
+
+
+def normalize_camelot(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip().upper()
+    return normalized if _CAMELOT_RE.fullmatch(normalized) else None
+
+
+def camelot_compatible(
+    left: str | None,
+    right: str | None,
+    *,
+    allow_same: bool = True,
+    allow_adjacent: bool = True,
+    allow_relative: bool = True,
+) -> bool:
+    first = normalize_camelot(left)
+    second = normalize_camelot(right)
+    if first is None or second is None:
+        return False
+
+    first_number = int(first[:-1])
+    second_number = int(second[:-1])
+    first_letter = first[-1]
+    second_letter = second[-1]
+
+    if allow_same and first == second:
+        return True
+
+    if allow_relative and first_number == second_number and first_letter != second_letter:
+        return True
+
+    if allow_adjacent and first_letter == second_letter:
+        clockwise = 1 if first_number == 12 else first_number + 1
+        counterclockwise = 12 if first_number == 1 else first_number - 1
+        return second_number in {clockwise, counterclockwise}
+
+    return False

--- a/services/composition/engine.py
+++ b/services/composition/engine.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from services.composition.camelot import normalize_camelot
+from services.composition.models import (
+    CompositionDecision,
+    CompositionFailureReason,
+    CompositionMode,
+    CompositionRequest,
+    CompositionResult,
+    CompositionStatus,
+    CompositionSummary,
+    CompositionTrack,
+    EnergyStage,
+    TransitionReason,
+    TransitionScore,
+)
+from services.composition.scoring import score_transition, target_energy
+
+
+_MODE_STAGE_PLANS: dict[CompositionMode, tuple[EnergyStage, ...]] = {
+    CompositionMode.WARMUP: (
+        EnergyStage.INTRO,
+        EnergyStage.WARMUP,
+        EnergyStage.GROOVE,
+        EnergyStage.GROOVE,
+        EnergyStage.AFTERGLOW,
+        EnergyStage.CLOSING,
+    ),
+    CompositionMode.CLUB: (
+        EnergyStage.INTRO,
+        EnergyStage.WARMUP,
+        EnergyStage.GROOVE,
+        EnergyStage.LIFT,
+        EnergyStage.PEAK,
+        EnergyStage.AFTERGLOW,
+        EnergyStage.CLOSING,
+    ),
+    CompositionMode.FESTIVAL: (
+        EnergyStage.INTRO,
+        EnergyStage.GROOVE,
+        EnergyStage.LIFT,
+        EnergyStage.PEAK,
+        EnergyStage.PEAK,
+        EnergyStage.AFTERGLOW,
+        EnergyStage.CLOSING,
+    ),
+    CompositionMode.AFTERHOURS: (
+        EnergyStage.INTRO,
+        EnergyStage.WARMUP,
+        EnergyStage.GROOVE,
+        EnergyStage.AFTERGLOW,
+        EnergyStage.CLOSING,
+    ),
+    CompositionMode.CUSTOM: (
+        EnergyStage.INTRO,
+        EnergyStage.GROOVE,
+        EnergyStage.PEAK,
+        EnergyStage.CLOSING,
+    ),
+}
+
+
+class DeterministicCompositionEngine:
+    """Pure composition engine with no I/O, repositories, network or global state."""
+
+    def compose(self, request: CompositionRequest) -> CompositionResult:
+        candidates, duplicate_count = self._eligible_candidates(request)
+        warnings: list[str] = []
+        if duplicate_count:
+            warnings.append(f"Removed {duplicate_count} duplicate track_id candidate(s).")
+
+        if not candidates:
+            return CompositionResult(
+                status=CompositionStatus.FAILED,
+                failure_reason=CompositionFailureReason.NO_CANDIDATES,
+                tracks=(),
+                decisions=(),
+                summary=self._summarize(()),
+                warnings=tuple(warnings),
+            )
+
+        target_count = min(request.target_track_count, len(candidates))
+        if target_count < request.target_track_count:
+            warnings.append(
+                "Requested track count exceeds the number of eligible unique candidates."
+            )
+
+        stages = self._stage_plan(request, target_count)
+        opening = self._pick_opening_track(candidates, request, stages[0])
+        opening_score = TransitionScore(
+            total=0.0,
+            eligible=True,
+            bpm_delta=0.0,
+            harmonic_compatible=True,
+            energy_distance=abs(opening.energy - target_energy(request, stages[0])),
+            artist_spacing_ok=True,
+            label_spacing_ok=True,
+            source_rotation_ok=True,
+            reasons=(
+                TransitionReason(
+                    code="opening_track",
+                    value=1.0,
+                    weight=0.0,
+                    contribution=0.0,
+                    passed=True,
+                ),
+            ),
+        )
+
+        playlist = [opening]
+        decisions = [
+            CompositionDecision(
+                order_index=0,
+                track_id=opening.track_id,
+                stage=stages[0],
+                score=opening_score,
+            )
+        ]
+        used_ids = {opening.track_id}
+        stalled = False
+
+        while len(playlist) < target_count:
+            stage = stages[len(playlist)]
+            current = playlist[-1]
+            scored = [
+                (
+                    candidate,
+                    score_transition(
+                        current=current,
+                        candidate=candidate,
+                        playlist=playlist,
+                        stage=stage,
+                        request=request,
+                    ),
+                )
+                for candidate in candidates
+                if candidate.track_id not in used_ids
+            ]
+            eligible = [item for item in scored if item[1].eligible]
+            if not eligible:
+                stalled = True
+                warnings.append(
+                    "Composition stopped because no remaining candidate passed the BPM hard gate."
+                )
+                break
+
+            selected, selected_score = sorted(
+                eligible,
+                key=lambda item: (
+                    -item[1].total,
+                    item[1].energy_distance,
+                    item[1].bpm_delta,
+                    item[0].track_id,
+                    item[0].path,
+                ),
+            )[0]
+            playlist.append(selected)
+            used_ids.add(selected.track_id)
+            decisions.append(
+                CompositionDecision(
+                    order_index=len(playlist) - 1,
+                    track_id=selected.track_id,
+                    stage=stage,
+                    score=selected_score,
+                )
+            )
+
+        if len(playlist) == request.target_track_count:
+            status = CompositionStatus.SUCCESS
+            failure_reason = None
+        else:
+            status = CompositionStatus.PARTIAL
+            failure_reason = (
+                CompositionFailureReason.COMPOSITION_STALLED
+                if stalled
+                else CompositionFailureReason.NO_CANDIDATES
+            )
+
+        return CompositionResult(
+            status=status,
+            failure_reason=failure_reason,
+            tracks=tuple(playlist),
+            decisions=tuple(decisions),
+            summary=self._summarize(playlist),
+            warnings=tuple(warnings),
+        )
+
+    @staticmethod
+    def _eligible_candidates(
+        request: CompositionRequest,
+    ) -> tuple[list[CompositionTrack], int]:
+        genre_target = request.genre.strip().casefold() if request.genre else None
+        filtered = [
+            track
+            for track in request.tracks
+            if request.bpm_min <= track.bpm <= request.bpm_max
+            and (
+                genre_target is None
+                or genre_target in track.genre.strip().casefold()
+            )
+        ]
+        ordered = sorted(
+            filtered,
+            key=lambda track: (
+                track.track_id,
+                track.path,
+                track.bpm,
+                track.energy,
+                track.camelot,
+            ),
+        )
+        unique: dict[str, CompositionTrack] = {}
+        for track in ordered:
+            unique.setdefault(track.track_id, track)
+        return list(unique.values()), len(ordered) - len(unique)
+
+    @staticmethod
+    def _pick_opening_track(
+        candidates: list[CompositionTrack],
+        request: CompositionRequest,
+        stage: EnergyStage,
+    ) -> CompositionTrack:
+        pool = candidates
+        requested_key = normalize_camelot(request.start_key)
+        if requested_key is not None:
+            matching = [
+                track
+                for track in candidates
+                if normalize_camelot(track.camelot) == requested_key
+            ]
+            if matching:
+                pool = matching
+        target = target_energy(request, stage)
+        return sorted(
+            pool,
+            key=lambda track: (
+                abs(track.energy - target),
+                track.bpm,
+                track.track_id,
+                track.path,
+            ),
+        )[0]
+
+    @staticmethod
+    def _stage_plan(
+        request: CompositionRequest,
+        target_count: int,
+    ) -> tuple[EnergyStage, ...]:
+        base = (
+            tuple(point.stage for point in request.energy_curve)
+            if request.energy_curve
+            else _MODE_STAGE_PLANS[request.mode]
+        )
+        if not base:
+            base = (EnergyStage.GROOVE,)
+        return tuple(
+            base[min((index * len(base)) // target_count, len(base) - 1)]
+            for index in range(target_count)
+        )
+
+    @staticmethod
+    def _summarize(tracks: Iterable[CompositionTrack]) -> CompositionSummary:
+        materialized = tuple(tracks)
+        if not materialized:
+            return CompositionSummary(
+                track_count=0,
+                total_duration_seconds=0,
+                average_bpm=0.0,
+                minimum_bpm=0.0,
+                maximum_bpm=0.0,
+                average_energy=0.0,
+            )
+        bpms = [track.bpm for track in materialized]
+        energies = [track.energy for track in materialized]
+        return CompositionSummary(
+            track_count=len(materialized),
+            total_duration_seconds=sum(track.duration_seconds for track in materialized),
+            average_bpm=sum(bpms) / len(bpms),
+            minimum_bpm=min(bpms),
+            maximum_bpm=max(bpms),
+            average_energy=sum(energies) / len(energies),
+        )

--- a/services/composition/models.py
+++ b/services/composition/models.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+
+class CompositionStatus(str, Enum):
+    SUCCESS = "success"
+    PARTIAL = "partial"
+    FAILED = "failed"
+
+
+class CompositionFailureReason(str, Enum):
+    NO_CANDIDATES = "no_candidates"
+    INVALID_REQUEST = "invalid_request"
+    COMPOSITION_STALLED = "composition_stalled"
+
+
+class CompositionMode(str, Enum):
+    WARMUP = "warmup"
+    CLUB = "club"
+    FESTIVAL = "festival"
+    AFTERHOURS = "afterhours"
+    CUSTOM = "custom"
+
+
+class EnergyStage(str, Enum):
+    INTRO = "intro"
+    WARMUP = "warmup"
+    GROOVE = "groove"
+    LIFT = "lift"
+    PEAK = "peak"
+    AFTERGLOW = "afterglow"
+    CLOSING = "closing"
+
+
+@dataclass(frozen=True, slots=True)
+class CompositionTrack:
+    track_id: str
+    path: str
+    bpm: float
+    camelot: str
+    energy: float
+    duration_seconds: int = 300
+    genre: str = ""
+    title: Optional[str] = None
+    artist: Optional[str] = None
+    label: Optional[str] = None
+    source_folder: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not self.track_id.strip():
+            raise ValueError("track_id must not be empty")
+        if not self.path.strip():
+            raise ValueError("path must not be empty")
+        if self.bpm <= 0:
+            raise ValueError("bpm must be greater than zero")
+        if not 0.0 <= self.energy <= 1.0:
+            raise ValueError("energy must be between 0 and 1")
+        if self.duration_seconds <= 0:
+            raise ValueError("duration_seconds must be greater than zero")
+
+
+@dataclass(frozen=True, slots=True)
+class CompositionConstraints:
+    bpm_jump_max: float = 3.0
+    bpm_jump_max_peak: float = 5.0
+    same_artist_min_gap: int = 3
+    same_label_min_gap: int = 2
+    same_source_folder_max_consecutive: int = 2
+    allow_same_key: bool = True
+    allow_adjacent_camelot: bool = True
+    allow_relative_key: bool = True
+
+    def __post_init__(self) -> None:
+        if self.bpm_jump_max <= 0 or self.bpm_jump_max_peak <= 0:
+            raise ValueError("BPM jump limits must be greater than zero")
+        if self.same_artist_min_gap < 0 or self.same_label_min_gap < 0:
+            raise ValueError("spacing gaps must not be negative")
+        if self.same_source_folder_max_consecutive < 1:
+            raise ValueError("source folder consecutive limit must be at least one")
+
+
+@dataclass(frozen=True, slots=True)
+class EnergyTarget:
+    stage: EnergyStage
+    target: float
+    tolerance: float = 0.15
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.target <= 1.0:
+            raise ValueError("energy target must be between 0 and 1")
+        if not 0.0 <= self.tolerance <= 1.0:
+            raise ValueError("energy tolerance must be between 0 and 1")
+
+
+@dataclass(frozen=True, slots=True)
+class CompositionRequest:
+    tracks: tuple[CompositionTrack, ...]
+    target_track_count: int
+    mode: CompositionMode = CompositionMode.CLUB
+    bpm_min: float = 1.0
+    bpm_max: float = 300.0
+    genre: Optional[str] = None
+    start_key: Optional[str] = None
+    energy_curve: tuple[EnergyTarget, ...] = ()
+    constraints: CompositionConstraints = field(default_factory=CompositionConstraints)
+
+    def __post_init__(self) -> None:
+        if self.target_track_count <= 0:
+            raise ValueError("target_track_count must be greater than zero")
+        if self.bpm_min <= 0 or self.bpm_max <= 0:
+            raise ValueError("BPM range values must be greater than zero")
+        if self.bpm_min > self.bpm_max:
+            raise ValueError("bpm_min must be less than or equal to bpm_max")
+
+
+@dataclass(frozen=True, slots=True)
+class TransitionReason:
+    code: str
+    value: float
+    weight: float
+    contribution: float
+    passed: bool
+
+
+@dataclass(frozen=True, slots=True)
+class TransitionScore:
+    total: float
+    eligible: bool
+    bpm_delta: float
+    harmonic_compatible: bool
+    energy_distance: float
+    artist_spacing_ok: bool
+    label_spacing_ok: bool
+    source_rotation_ok: bool
+    reasons: tuple[TransitionReason, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class CompositionDecision:
+    order_index: int
+    track_id: str
+    stage: EnergyStage
+    score: TransitionScore
+
+
+@dataclass(frozen=True, slots=True)
+class CompositionSummary:
+    track_count: int
+    total_duration_seconds: int
+    average_bpm: float
+    minimum_bpm: float
+    maximum_bpm: float
+    average_energy: float
+
+
+@dataclass(frozen=True, slots=True)
+class CompositionResult:
+    status: CompositionStatus
+    tracks: tuple[CompositionTrack, ...]
+    decisions: tuple[CompositionDecision, ...]
+    summary: CompositionSummary
+    failure_reason: Optional[CompositionFailureReason] = None
+    warnings: tuple[str, ...] = ()

--- a/services/composition/scoring.py
+++ b/services/composition/scoring.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from services.composition.camelot import camelot_compatible
+from services.composition.models import (
+    CompositionRequest,
+    CompositionTrack,
+    EnergyStage,
+    TransitionReason,
+    TransitionScore,
+)
+
+
+DEFAULT_ENERGY_TARGETS: dict[EnergyStage, float] = {
+    EnergyStage.INTRO: 0.25,
+    EnergyStage.WARMUP: 0.35,
+    EnergyStage.GROOVE: 0.50,
+    EnergyStage.LIFT: 0.68,
+    EnergyStage.PEAK: 0.86,
+    EnergyStage.AFTERGLOW: 0.60,
+    EnergyStage.CLOSING: 0.42,
+}
+
+
+def target_energy(request: CompositionRequest, stage: EnergyStage) -> float:
+    for point in request.energy_curve:
+        if point.stage == stage:
+            return point.target
+    return DEFAULT_ENERGY_TARGETS[stage]
+
+
+def score_transition(
+    *,
+    current: CompositionTrack,
+    candidate: CompositionTrack,
+    playlist: list[CompositionTrack],
+    stage: EnergyStage,
+    request: CompositionRequest,
+) -> TransitionScore:
+    constraints = request.constraints
+    bpm_delta = abs(candidate.bpm - current.bpm)
+    bpm_limit = (
+        constraints.bpm_jump_max_peak
+        if stage == EnergyStage.PEAK
+        else constraints.bpm_jump_max
+    )
+    energy_distance = abs(candidate.energy - target_energy(request, stage))
+
+    if bpm_delta > bpm_limit:
+        return TransitionScore(
+            total=-1_000_000.0,
+            eligible=False,
+            bpm_delta=bpm_delta,
+            harmonic_compatible=False,
+            energy_distance=energy_distance,
+            artist_spacing_ok=False,
+            label_spacing_ok=False,
+            source_rotation_ok=False,
+            reasons=(
+                TransitionReason(
+                    code="bpm_hard_gate",
+                    value=bpm_delta,
+                    weight=1.0,
+                    contribution=-1_000_000.0,
+                    passed=False,
+                ),
+            ),
+        )
+
+    reasons: list[TransitionReason] = []
+    bpm_value = max(0.0, 1.0 - (bpm_delta / bpm_limit))
+    reasons.append(_weighted_reason("bpm_flow", bpm_value, 2.0))
+
+    harmonic_ok = camelot_compatible(
+        current.camelot,
+        candidate.camelot,
+        allow_same=constraints.allow_same_key,
+        allow_adjacent=constraints.allow_adjacent_camelot,
+        allow_relative=constraints.allow_relative_key,
+    )
+    reasons.append(
+        TransitionReason(
+            code="harmonic_compatibility",
+            value=1.0 if harmonic_ok else 0.0,
+            weight=2.0,
+            contribution=2.0 if harmonic_ok else -1.5,
+            passed=harmonic_ok,
+        )
+    )
+
+    energy_value = max(0.0, 1.0 - energy_distance)
+    reasons.append(_weighted_reason("energy_target", energy_value, 2.0))
+
+    genre_ok = (
+        request.genre is None
+        or request.genre.strip().casefold()
+        in candidate.genre.strip().casefold()
+    )
+    reasons.append(_binary_reason("genre_match", genre_ok, 0.5))
+
+    artist_ok = _spacing_ok(
+        candidate.artist,
+        playlist,
+        attribute="artist",
+        minimum_gap=constraints.same_artist_min_gap,
+    )
+    reasons.append(_binary_reason("artist_spacing", artist_ok, 0.75))
+
+    label_ok = _spacing_ok(
+        candidate.label,
+        playlist,
+        attribute="label",
+        minimum_gap=constraints.same_label_min_gap,
+    )
+    reasons.append(_binary_reason("label_spacing", label_ok, 0.5))
+
+    source_ok = _source_rotation_ok(
+        candidate.source_folder,
+        playlist,
+        constraints.same_source_folder_max_consecutive,
+    )
+    reasons.append(_binary_reason("source_rotation", source_ok, 0.5))
+
+    return TransitionScore(
+        total=sum(reason.contribution for reason in reasons),
+        eligible=True,
+        bpm_delta=bpm_delta,
+        harmonic_compatible=harmonic_ok,
+        energy_distance=energy_distance,
+        artist_spacing_ok=artist_ok,
+        label_spacing_ok=label_ok,
+        source_rotation_ok=source_ok,
+        reasons=tuple(reasons),
+    )
+
+
+def _weighted_reason(code: str, value: float, weight: float) -> TransitionReason:
+    return TransitionReason(
+        code=code,
+        value=value,
+        weight=weight,
+        contribution=value * weight,
+        passed=True,
+    )
+
+
+def _binary_reason(code: str, passed: bool, weight: float) -> TransitionReason:
+    return TransitionReason(
+        code=code,
+        value=1.0 if passed else 0.0,
+        weight=weight,
+        contribution=weight if passed else -weight,
+        passed=passed,
+    )
+
+
+def _spacing_ok(
+    value: str | None,
+    playlist: list[CompositionTrack],
+    *,
+    attribute: str,
+    minimum_gap: int,
+) -> bool:
+    if not value or minimum_gap <= 0:
+        return True
+    normalized = value.strip().casefold()
+    recent = playlist[-minimum_gap:]
+    return all(
+        not existing or existing.strip().casefold() != normalized
+        for existing in (getattr(track, attribute) for track in recent)
+    )
+
+
+def _source_rotation_ok(
+    source_folder: str | None,
+    playlist: list[CompositionTrack],
+    maximum_consecutive: int,
+) -> bool:
+    if not source_folder:
+        return True
+    normalized = source_folder.strip().casefold()
+    consecutive = 0
+    for track in reversed(playlist):
+        existing = track.source_folder
+        if not existing or existing.strip().casefold() != normalized:
+            break
+        consecutive += 1
+    return consecutive < maximum_consecutive

--- a/tests/test_composition_camelot.py
+++ b/tests/test_composition_camelot.py
@@ -1,0 +1,29 @@
+from services.composition.camelot import camelot_compatible, normalize_camelot
+
+
+def test_normalize_camelot_accepts_valid_case_and_spacing() -> None:
+    assert normalize_camelot(" 8a ") == "8A"
+    assert normalize_camelot("12B") == "12B"
+
+
+def test_normalize_camelot_rejects_invalid_values() -> None:
+    assert normalize_camelot(None) is None
+    assert normalize_camelot("") is None
+    assert normalize_camelot("0A") is None
+    assert normalize_camelot("13B") is None
+    assert normalize_camelot("C#m") is None
+
+
+def test_camelot_supports_same_adjacent_relative_and_wraparound() -> None:
+    assert camelot_compatible("8A", "8A")
+    assert camelot_compatible("8A", "9A")
+    assert camelot_compatible("1A", "12A")
+    assert camelot_compatible("8A", "8B")
+
+
+def test_camelot_respects_disabled_rules_and_invalid_keys() -> None:
+    assert not camelot_compatible("8A", "8A", allow_same=False)
+    assert not camelot_compatible("8A", "9A", allow_adjacent=False)
+    assert not camelot_compatible("8A", "8B", allow_relative=False)
+    assert not camelot_compatible("8A", "10A")
+    assert not camelot_compatible("invalid", "8A")

--- a/tests/test_composition_engine.py
+++ b/tests/test_composition_engine.py
@@ -1,0 +1,220 @@
+from services.composition import (
+    CompositionConstraints,
+    CompositionFailureReason,
+    CompositionMode,
+    CompositionRequest,
+    CompositionStatus,
+    CompositionTrack,
+    DeterministicCompositionEngine,
+    EnergyStage,
+)
+from services.composition.scoring import score_transition
+
+
+def _track(
+    track_id: str,
+    *,
+    bpm: float,
+    camelot: str,
+    energy: float,
+    artist: str | None = None,
+    label: str | None = None,
+    source: str | None = None,
+    genre: str = "tech house",
+    path: str | None = None,
+) -> CompositionTrack:
+    return CompositionTrack(
+        track_id=track_id,
+        path=path or f"/music/{track_id}.mp3",
+        bpm=bpm,
+        camelot=camelot,
+        energy=energy,
+        duration_seconds=300,
+        genre=genre,
+        artist=artist,
+        label=label,
+        source_folder=source,
+    )
+
+
+def test_engine_is_deterministic_and_input_order_independent() -> None:
+    tracks = (
+        _track("a", bpm=124, camelot="8A", energy=0.24, artist="A"),
+        _track("b", bpm=125, camelot="9A", energy=0.48, artist="B"),
+        _track("c", bpm=126, camelot="9A", energy=0.68, artist="C"),
+        _track("d", bpm=127, camelot="10A", energy=0.86, artist="D"),
+    )
+    engine = DeterministicCompositionEngine()
+
+    forward = engine.compose(
+        CompositionRequest(
+            tracks=tracks,
+            target_track_count=4,
+            mode=CompositionMode.FESTIVAL,
+        )
+    )
+    reverse = engine.compose(
+        CompositionRequest(
+            tracks=tuple(reversed(tracks)),
+            target_track_count=4,
+            mode=CompositionMode.FESTIVAL,
+        )
+    )
+
+    assert forward.status == CompositionStatus.SUCCESS
+    assert [track.track_id for track in forward.tracks] == ["a", "b", "c", "d"]
+    assert [track.track_id for track in reverse.tracks] == ["a", "b", "c", "d"]
+    assert forward.decisions == reverse.decisions
+    assert forward.summary.track_count == 4
+    assert forward.summary.total_duration_seconds == 1200
+
+
+def test_bpm_hard_gate_returns_controlled_partial_result() -> None:
+    result = DeterministicCompositionEngine().compose(
+        CompositionRequest(
+            tracks=(
+                _track("opening", bpm=120, camelot="8A", energy=0.25),
+                _track("jump", bpm=130, camelot="9A", energy=0.50),
+            ),
+            target_track_count=2,
+            mode=CompositionMode.CLUB,
+        )
+    )
+
+    assert result.status == CompositionStatus.PARTIAL
+    assert result.failure_reason == CompositionFailureReason.COMPOSITION_STALLED
+    assert [track.track_id for track in result.tracks] == ["opening"]
+    assert any("BPM hard gate" in warning for warning in result.warnings)
+
+
+def test_start_key_selects_matching_opening_track() -> None:
+    result = DeterministicCompositionEngine().compose(
+        CompositionRequest(
+            tracks=(
+                _track("default", bpm=124, camelot="8A", energy=0.25),
+                _track("keyed", bpm=126, camelot="5B", energy=0.30),
+            ),
+            target_track_count=1,
+            start_key=" 5b ",
+        )
+    )
+
+    assert result.status == CompositionStatus.SUCCESS
+    assert result.tracks[0].track_id == "keyed"
+
+
+def test_spacing_rules_change_selection_and_remain_explainable() -> None:
+    opening = _track(
+        "opening",
+        bpm=124,
+        camelot="8A",
+        energy=0.25,
+        artist="Same Artist",
+        label="Same Label",
+        source="same-source",
+    )
+    same = _track(
+        "a-same",
+        bpm=125,
+        camelot="9A",
+        energy=0.68,
+        artist="Same Artist",
+        label="Same Label",
+        source="same-source",
+    )
+    alternative = _track(
+        "z-alternative",
+        bpm=125,
+        camelot="9A",
+        energy=0.68,
+        artist="Other Artist",
+        label="Other Label",
+        source="other-source",
+    )
+    request = CompositionRequest(
+        tracks=(opening, same, alternative),
+        target_track_count=2,
+        mode=CompositionMode.CLUB,
+        constraints=CompositionConstraints(
+            same_artist_min_gap=3,
+            same_label_min_gap=2,
+            same_source_folder_max_consecutive=1,
+        ),
+    )
+
+    result = DeterministicCompositionEngine().compose(request)
+    rejected_score = score_transition(
+        current=opening,
+        candidate=same,
+        playlist=[opening],
+        stage=EnergyStage.LIFT,
+        request=request,
+    )
+
+    assert [track.track_id for track in result.tracks] == [
+        "opening",
+        "z-alternative",
+    ]
+    assert not rejected_score.artist_spacing_ok
+    assert not rejected_score.label_spacing_ok
+    assert not rejected_score.source_rotation_ok
+    assert {
+        reason.code for reason in result.decisions[1].score.reasons
+    } >= {
+        "bpm_flow",
+        "harmonic_compatibility",
+        "energy_target",
+        "artist_spacing",
+        "label_spacing",
+        "source_rotation",
+    }
+
+
+def test_duplicate_track_ids_are_removed_deterministically() -> None:
+    result = DeterministicCompositionEngine().compose(
+        CompositionRequest(
+            tracks=(
+                _track(
+                    "duplicate",
+                    bpm=124,
+                    camelot="8A",
+                    energy=0.25,
+                    path="/music/z.mp3",
+                ),
+                _track(
+                    "duplicate",
+                    bpm=124,
+                    camelot="8A",
+                    energy=0.25,
+                    path="/music/a.mp3",
+                ),
+            ),
+            target_track_count=1,
+        )
+    )
+
+    assert result.tracks[0].path == "/music/a.mp3"
+    assert any("duplicate track_id" in warning for warning in result.warnings)
+
+
+def test_genre_filter_can_fail_without_side_effects() -> None:
+    result = DeterministicCompositionEngine().compose(
+        CompositionRequest(
+            tracks=(
+                _track(
+                    "house",
+                    bpm=124,
+                    camelot="8A",
+                    energy=0.25,
+                    genre="house",
+                ),
+            ),
+            target_track_count=1,
+            genre="drum and bass",
+        )
+    )
+
+    assert result.status == CompositionStatus.FAILED
+    assert result.failure_reason == CompositionFailureReason.NO_CANDIDATES
+    assert result.tracks == ()
+    assert result.summary.track_count == 0


### PR DESCRIPTION
## Summary

- add immutable canonical composition models
- add validated Camelot normalization and same/adjacent/relative-key compatibility
- add a pure transition scorer with stage-aware BPM hard gates
- add deterministic composition with explicit tie-breakers
- score energy, harmonic, genre, artist, label and source rules
- return controlled status, failure reason, decision trace and summary
- add donor provenance for `nulleimy/Applaylist-old`
- add deterministic regression tests

## Verification

- branch created directly from Bundle 29 squash commit `5a03fb9d696b1a83a8d8c282d30488fa10e62db2`
- branch is ahead only; base history was not rewritten
- static diff is limited to 8 new composition/test/doc files
- CI must verify install, compile, critical Ruff and full pytest on Python 3.11 and 3.12
- no local test execution is claimed

## Isolation

- no FastAPI, database, filesystem or external-provider imports in the new engine
- no replacement of the existing composer
- no pipeline or API feature flag
- no source branch or dependency file copied from `Applaylist-old`

## Bundle Context

- Bundle: 30 — Canonical Deterministic Composition Engine
- Base branch: `feature/bundle-0-bootstrap`
- Base commit: `5a03fb9d696b1a83a8d8c282d30488fa10e62db2`
- Related issue: #34
- Rollback: close this PR or revert its future squash commit; no data rollback required