### PR TITLE
Bundle 31: playlist candidate composition adapter

### DIFF
--- a/data/models/playlist_candidate.py
+++ b/data/models/playlist_candidate.py
@@ -6,12 +6,15 @@ from typing import Optional
 
 @dataclass(frozen=True, slots=True)
 class PlaylistCandidate:
-    """Read model combining track identity/path with analysis features."""
+    """Read model combining track identity/path with composition features."""
 
     track_id: str
     path: str
     title: Optional[str] = None
     artist: Optional[str] = None
+    genre: Optional[str] = None
+    source: Optional[str] = None
+    duration_seconds: Optional[float] = None
     bpm: Optional[float] = None
     camelot: Optional[str] = None
     energy: Optional[float] = None

--- a/data/repositories/analysis_repository.py
+++ b/data/repositories/analysis_repository.py
@@ -61,8 +61,7 @@ class AnalysisRepository:
                     duration_seconds=excluded.duration_seconds,
                     harmonic_ratio=excluded.harmonic_ratio,
                     percussive_ratio=excluded.percussive_ratio
-                '''
-                ,
+                ''',
                 (
                     record.track_id,
                     record.analysis_version,
@@ -95,7 +94,7 @@ class AnalysisRepository:
             return AnalysisRecord(**dict(row))
 
     def list_playlist_candidates(self) -> list[PlaylistCandidate]:
-        """Return only analyses that have a non-empty resolvable track path."""
+        """Return joined analysis and track metadata for composition adaptation."""
         self.ensure_schema()
         TrackRepository().ensure_schema()
 
@@ -107,6 +106,10 @@ class AnalysisRepository:
                     tracks.path,
                     tracks.title,
                     tracks.artist,
+                    tracks.genre,
+                    tracks.source,
+                    COALESCE(analyses.duration_seconds, tracks.duration_seconds)
+                        AS duration_seconds,
                     analyses.bpm,
                     analyses.camelot,
                     analyses.energy

--- a/docs/bundles/BUNDLE_31_COMPOSITION_CANDIDATE_ADAPTER.md
+++ b/docs/bundles/BUNDLE_31_COMPOSITION_CANDIDATE_ADAPTER.md
@@ -1,0 +1,55 @@
+# Bundle 31 — Playlist Candidate Composition Adapter
+
+## Goal
+
+Create an explicit and auditable boundary between persisted playlist candidates and the canonical deterministic composition engine.
+
+## Read-model enrichment
+
+The existing database schema already contains track genre, source and duration metadata. The composition candidate JOIN now exposes:
+
+- `genre`,
+- `source`,
+- analyzed duration when available,
+- track metadata duration as a fallback through SQL `COALESCE`.
+
+No database migration is required.
+
+## Adapter contract
+
+`adapt_playlist_candidates()` processes candidates in deterministic `track_id` and path order.
+
+Required composition fields fail closed:
+
+- non-empty track identifier,
+- non-empty path,
+- finite positive BPM,
+- valid Camelot key,
+- finite energy in the inclusive range 0–1.
+
+Invalid candidates are excluded and receive stable issue codes.
+
+Duration is not a transition-safety metric. A missing or invalid duration may therefore use the explicitly configured fallback. Every fallback is recorded as a `duration_fallback` issue and is never silent.
+
+## Isolation
+
+- The production pipeline is not switched.
+- The legacy composer remains unchanged.
+- The adapter performs no database query itself.
+- The adapter performs no network, filesystem or provider call.
+- No schema migration or public API change is included.
+
+## Verification
+
+- deterministic candidate ordering,
+- metadata preservation,
+- malformed BPM, key, energy and path rejection,
+- boolean metric rejection,
+- explicit duration fallback evidence,
+- invalid fallback configuration rejection,
+- repository JOIN integration with analyzed-duration precedence,
+- full Python 3.11 and 3.12 CI.
+
+## Rollback
+
+Revert the future Bundle 31 squash commit. No data rollback is required.

--- a/services/composition/__init__.py
+++ b/services/composition/__init__.py
@@ -1,3 +1,10 @@
+from services.composition.adapter import (
+    CandidateAdaptationResult,
+    CandidateIssue,
+    CandidateIssueCode,
+    CandidateIssueSeverity,
+    adapt_playlist_candidates,
+)
 from services.composition.engine import DeterministicCompositionEngine
 from services.composition.models import (
     CompositionConstraints,
@@ -16,6 +23,10 @@ from services.composition.models import (
 )
 
 __all__ = [
+    "CandidateAdaptationResult",
+    "CandidateIssue",
+    "CandidateIssueCode",
+    "CandidateIssueSeverity",
     "CompositionConstraints",
     "CompositionDecision",
     "CompositionFailureReason",
@@ -30,4 +41,5 @@ __all__ = [
     "EnergyTarget",
     "TransitionReason",
     "TransitionScore",
+    "adapt_playlist_candidates",
 ]

--- a/services/composition/adapter.py
+++ b/services/composition/adapter.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+
+from data.models.playlist_candidate import PlaylistCandidate
+from services.composition.camelot import normalize_camelot
+from services.composition.models import CompositionTrack
+
+
+class CandidateIssueCode(str, Enum):
+    INVALID_TRACK_ID = "invalid_track_id"
+    INVALID_PATH = "invalid_path"
+    INVALID_BPM = "invalid_bpm"
+    INVALID_CAMELOT = "invalid_camelot"
+    INVALID_ENERGY = "invalid_energy"
+    DURATION_FALLBACK = "duration_fallback"
+
+
+class CandidateIssueSeverity(str, Enum):
+    REJECTED = "rejected"
+    FALLBACK = "fallback"
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateIssue:
+    track_id: str
+    code: CandidateIssueCode
+    severity: CandidateIssueSeverity
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateAdaptationResult:
+    tracks: tuple[CompositionTrack, ...]
+    issues: tuple[CandidateIssue, ...]
+
+    @property
+    def rejected_count(self) -> int:
+        return len(
+            {
+                issue.track_id
+                for issue in self.issues
+                if issue.severity == CandidateIssueSeverity.REJECTED
+            }
+        )
+
+    @property
+    def fallback_count(self) -> int:
+        return sum(
+            issue.severity == CandidateIssueSeverity.FALLBACK
+            for issue in self.issues
+        )
+
+
+def adapt_playlist_candidates(
+    candidates: list[PlaylistCandidate] | tuple[PlaylistCandidate, ...],
+    *,
+    duration_fallback_seconds: int = 300,
+) -> CandidateAdaptationResult:
+    if duration_fallback_seconds <= 0:
+        raise ValueError("duration_fallback_seconds must be greater than zero")
+
+    tracks: list[CompositionTrack] = []
+    issues: list[CandidateIssue] = []
+
+    for candidate in sorted(candidates, key=lambda item: (item.track_id, item.path)):
+        track_id = candidate.track_id.strip()
+        path = candidate.path.strip()
+        fatal_codes: list[CandidateIssueCode] = []
+
+        if not track_id:
+            fatal_codes.append(CandidateIssueCode.INVALID_TRACK_ID)
+        if not path:
+            fatal_codes.append(CandidateIssueCode.INVALID_PATH)
+        if not _finite_positive(candidate.bpm):
+            fatal_codes.append(CandidateIssueCode.INVALID_BPM)
+
+        camelot = normalize_camelot(candidate.camelot)
+        if camelot is None:
+            fatal_codes.append(CandidateIssueCode.INVALID_CAMELOT)
+
+        if not _finite_range(candidate.energy, minimum=0.0, maximum=1.0):
+            fatal_codes.append(CandidateIssueCode.INVALID_ENERGY)
+
+        if fatal_codes:
+            issue_track_id = track_id or candidate.track_id
+            issues.extend(
+                CandidateIssue(
+                    track_id=issue_track_id,
+                    code=code,
+                    severity=CandidateIssueSeverity.REJECTED,
+                )
+                for code in fatal_codes
+            )
+            continue
+
+        duration = candidate.duration_seconds
+        if not _finite_positive(duration):
+            duration = float(duration_fallback_seconds)
+            issues.append(
+                CandidateIssue(
+                    track_id=track_id,
+                    code=CandidateIssueCode.DURATION_FALLBACK,
+                    severity=CandidateIssueSeverity.FALLBACK,
+                )
+            )
+
+        tracks.append(
+            CompositionTrack(
+                track_id=track_id,
+                path=path,
+                title=candidate.title,
+                artist=candidate.artist,
+                genre=candidate.genre or "",
+                source_folder=candidate.source,
+                bpm=float(candidate.bpm),
+                camelot=camelot,
+                energy=float(candidate.energy),
+                duration_seconds=max(1, round(float(duration))),
+            )
+        )
+
+    return CandidateAdaptationResult(
+        tracks=tuple(tracks),
+        issues=tuple(issues),
+    )
+
+
+def _finite_positive(value: float | int | None) -> bool:
+    return value is not None and math.isfinite(float(value)) and float(value) > 0
+
+
+def _finite_range(
+    value: float | int | None,
+    *,
+    minimum: float,
+    maximum: float,
+) -> bool:
+    return (
+        value is not None
+        and math.isfinite(float(value))
+        and minimum <= float(value) <= maximum
+    )

--- a/services/composition/adapter.py
+++ b/services/composition/adapter.py
@@ -63,31 +63,39 @@ def adapt_playlist_candidates(
 
     tracks: list[CompositionTrack] = []
     issues: list[CandidateIssue] = []
+    ordered = sorted(
+        candidates,
+        key=lambda item: (
+            _clean_text(item.track_id),
+            _clean_text(item.path),
+        ),
+    )
 
-    for candidate in sorted(candidates, key=lambda item: (item.track_id, item.path)):
-        track_id = candidate.track_id.strip()
-        path = candidate.path.strip()
+    for candidate in ordered:
+        track_id = _clean_text(candidate.track_id)
+        path = _clean_text(candidate.path)
+        bpm = _as_finite_float(candidate.bpm)
+        energy = _as_finite_float(candidate.energy)
+        camelot = normalize_camelot(
+            _clean_text(candidate.camelot) if candidate.camelot is not None else None
+        )
         fatal_codes: list[CandidateIssueCode] = []
 
         if not track_id:
             fatal_codes.append(CandidateIssueCode.INVALID_TRACK_ID)
         if not path:
             fatal_codes.append(CandidateIssueCode.INVALID_PATH)
-        if not _finite_positive(candidate.bpm):
+        if bpm is None or bpm <= 0:
             fatal_codes.append(CandidateIssueCode.INVALID_BPM)
-
-        camelot = normalize_camelot(candidate.camelot)
         if camelot is None:
             fatal_codes.append(CandidateIssueCode.INVALID_CAMELOT)
-
-        if not _finite_range(candidate.energy, minimum=0.0, maximum=1.0):
+        if energy is None or not 0.0 <= energy <= 1.0:
             fatal_codes.append(CandidateIssueCode.INVALID_ENERGY)
 
         if fatal_codes:
-            issue_track_id = track_id or candidate.track_id
             issues.extend(
                 CandidateIssue(
-                    track_id=issue_track_id,
+                    track_id=track_id,
                     code=code,
                     severity=CandidateIssueSeverity.REJECTED,
                 )
@@ -95,8 +103,8 @@ def adapt_playlist_candidates(
             )
             continue
 
-        duration = candidate.duration_seconds
-        if not _finite_positive(duration):
+        duration = _as_finite_float(candidate.duration_seconds)
+        if duration is None or duration <= 0:
             duration = float(duration_fallback_seconds)
             issues.append(
                 CandidateIssue(
@@ -114,10 +122,10 @@ def adapt_playlist_candidates(
                 artist=candidate.artist,
                 genre=candidate.genre or "",
                 source_folder=candidate.source,
-                bpm=float(candidate.bpm),
+                bpm=bpm,
                 camelot=camelot,
-                energy=float(candidate.energy),
-                duration_seconds=max(1, round(float(duration))),
+                energy=energy,
+                duration_seconds=max(1, round(duration)),
             )
         )
 
@@ -127,18 +135,17 @@ def adapt_playlist_candidates(
     )
 
 
-def _finite_positive(value: float | int | None) -> bool:
-    return value is not None and math.isfinite(float(value)) and float(value) > 0
+def _clean_text(value: object) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
 
 
-def _finite_range(
-    value: float | int | None,
-    *,
-    minimum: float,
-    maximum: float,
-) -> bool:
-    return (
-        value is not None
-        and math.isfinite(float(value))
-        and minimum <= float(value) <= maximum
-    )
+def _as_finite_float(value: object) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        converted = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return converted if math.isfinite(converted) else None

--- a/tests/test_composition_adapter.py
+++ b/tests/test_composition_adapter.py
@@ -1,0 +1,103 @@
+import pytest
+
+from data.models.playlist_candidate import PlaylistCandidate
+from services.composition import (
+    CandidateIssueCode,
+    CandidateIssueSeverity,
+    adapt_playlist_candidates,
+)
+
+
+def _candidate(
+    track_id: str,
+    *,
+    path: str | None = None,
+    bpm=124.0,
+    camelot="8A",
+    energy=0.5,
+    duration_seconds=320.0,
+) -> PlaylistCandidate:
+    return PlaylistCandidate(
+        track_id=track_id,
+        path=path or f"/music/{track_id}.mp3",
+        title=f"Track {track_id}",
+        artist="Artist",
+        genre="tech house",
+        source="pool-a",
+        duration_seconds=duration_seconds,
+        bpm=bpm,
+        camelot=camelot,
+        energy=energy,
+    )
+
+
+def test_adapter_is_deterministic_and_preserves_metadata() -> None:
+    candidates = (
+        _candidate("b", bpm=125, camelot="9a", energy=0.6),
+        _candidate("a", bpm=124, camelot="8A", energy=0.4),
+    )
+
+    result = adapt_playlist_candidates(candidates)
+
+    assert [track.track_id for track in result.tracks] == ["a", "b"]
+    assert result.tracks[0].genre == "tech house"
+    assert result.tracks[0].source_folder == "pool-a"
+    assert result.tracks[1].camelot == "9A"
+    assert result.issues == ()
+
+
+def test_adapter_rejects_invalid_required_metrics_with_stable_codes() -> None:
+    candidates = (
+        _candidate("bad-bpm", bpm="not-a-number"),
+        _candidate("bad-key", camelot="C#m"),
+        _candidate("bad-energy", energy=float("inf")),
+        _candidate("bad-path", path="   "),
+    )
+
+    result = adapt_playlist_candidates(candidates)
+    codes = {(issue.track_id, issue.code) for issue in result.issues}
+
+    assert result.tracks == ()
+    assert result.rejected_count == 4
+    assert codes == {
+        ("bad-bpm", CandidateIssueCode.INVALID_BPM),
+        ("bad-key", CandidateIssueCode.INVALID_CAMELOT),
+        ("bad-energy", CandidateIssueCode.INVALID_ENERGY),
+        ("bad-path", CandidateIssueCode.INVALID_PATH),
+    }
+    assert all(
+        issue.severity == CandidateIssueSeverity.REJECTED
+        for issue in result.issues
+    )
+
+
+def test_duration_fallback_is_explicit_and_evidenced() -> None:
+    result = adapt_playlist_candidates(
+        (_candidate("fallback", duration_seconds=None),),
+        duration_fallback_seconds=360,
+    )
+
+    assert result.tracks[0].duration_seconds == 360
+    assert result.fallback_count == 1
+    assert result.issues[0].code == CandidateIssueCode.DURATION_FALLBACK
+    assert result.issues[0].severity == CandidateIssueSeverity.FALLBACK
+
+
+def test_invalid_fallback_configuration_is_rejected() -> None:
+    with pytest.raises(ValueError, match="duration_fallback_seconds"):
+        adapt_playlist_candidates((_candidate("track"),), duration_fallback_seconds=0)
+
+
+def test_boolean_numeric_values_are_not_accepted_as_metrics() -> None:
+    result = adapt_playlist_candidates(
+        (
+            _candidate("boolean-bpm", bpm=True),
+            _candidate("boolean-energy", energy=False),
+        )
+    )
+
+    assert result.tracks == ()
+    assert {(issue.track_id, issue.code) for issue in result.issues} == {
+        ("boolean-bpm", CandidateIssueCode.INVALID_BPM),
+        ("boolean-energy", CandidateIssueCode.INVALID_ENERGY),
+    }

--- a/tests/unit/test_composition_candidate_repository.py
+++ b/tests/unit/test_composition_candidate_repository.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+from core.config.settings import get_settings
+from data.models.analysis_record import AnalysisRecord
+from data.models.track_record import TrackRecord
+from data.repositories.analysis_repository import AnalysisRepository
+from data.repositories.track_repository import TrackRepository
+
+
+def _analysis(track_id: str, *, duration_seconds: float | None) -> AnalysisRecord:
+    return AnalysisRecord(
+        track_id=track_id,
+        analysis_version="1",
+        features_version="1",
+        extractor_backend="test",
+        extractor_name="test",
+        bpm=126.0,
+        camelot="9A",
+        energy=0.65,
+        duration_seconds=duration_seconds,
+    )
+
+
+def test_candidate_join_includes_track_metadata_and_prefers_analysis_duration(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path / 'candidates.db'}")
+    get_settings.cache_clear()
+
+    try:
+        track_repo = TrackRepository()
+        analysis_repo = AnalysisRepository()
+        track_repo.upsert(
+            TrackRecord(
+                track_id="analysis-duration",
+                path="/music/analysis-duration.mp3",
+                title="Analysis Duration",
+                artist="Artist A",
+                genre="tech house",
+                source="pool-a",
+                duration_seconds=300.0,
+            )
+        )
+        analysis_repo.upsert(
+            _analysis("analysis-duration", duration_seconds=321.5)
+        )
+        track_repo.upsert(
+            TrackRecord(
+                track_id="track-duration",
+                path="/music/track-duration.mp3",
+                title="Track Duration",
+                artist="Artist B",
+                genre="hypnotic techno",
+                source="pool-b",
+                duration_seconds=280.0,
+            )
+        )
+        analysis_repo.upsert(_analysis("track-duration", duration_seconds=None))
+
+        candidates = analysis_repo.list_playlist_candidates()
+
+        assert [candidate.track_id for candidate in candidates] == [
+            "analysis-duration",
+            "track-duration",
+        ]
+        assert candidates[0].genre == "tech house"
+        assert candidates[0].source == "pool-a"
+        assert candidates[0].duration_seconds == 321.5
+        assert candidates[1].genre == "hypnotic techno"
+        assert candidates[1].source == "pool-b"
+        assert candidates[1].duration_seconds == 280.0
+    finally:
+        get_settings.cache_clear()


### PR DESCRIPTION
## Summary

- enrich `PlaylistCandidate` with genre, source and duration metadata
- extend the existing analyses/tracks JOIN without a schema migration
- prefer analyzed duration and fall back to track metadata duration in SQL
- add a deterministic fail-closed adapter to canonical `CompositionTrack`
- reject invalid track IDs, paths, BPM, Camelot keys and energy with stable issue codes
- make duration fallback explicit and evidenced
- add adapter and repository integration tests

## Verification

- branch created directly from Bundle 30 squash commit `9e09a2223bc5796ad656f46578408068a178c944`
- branch is ahead only; base history was not rewritten
- static diff is limited to 7 read-model/adapter/test/doc files
- CI must verify install, compile, critical Ruff and full pytest on Python 3.11 and 3.12
- no local test execution is claimed

## Isolation

- no database migration
- no replacement of the legacy composer
- no pipeline or API feature flag
- no network, filesystem or provider calls in the adapter

## Bundle Context

- Bundle: 31 — Playlist Candidate Composition Adapter
- Base branch: `feature/bundle-0-bootstrap`
- Base commit: `9e09a2223bc5796ad656f46578408068a178c944`
- Related issue: #36
- Rollback: close this PR or revert its future squash commit; no data rollback required