### PR TITLE
Bundle 32: composition comparison service

### DIFF
--- a/docs/bundles/BUNDLE_32_COMPOSITION_SHADOW_COMPARISON.md
+++ b/docs/bundles/BUNDLE_32_COMPOSITION_SHADOW_COMPARISON.md
@@ -1,0 +1,56 @@
+# Bundle 32 — Composition Shadow Comparison Service
+
+## Goal
+
+Measure the behavioral difference between the legacy composer and the canonical deterministic engine without changing production composition or export.
+
+## Confirmed baseline mismatch
+
+The pipeline request accepts BPM range and mode controls. The current orchestrator calls the legacy composer with only `limit`; BPM and mode values are retained only in the returned input section.
+
+## Shadow boundary
+
+`CompositionShadowService` is a read-only internal service:
+
+1. receives the already-produced legacy track identifiers,
+2. reads playlist candidates through an injected repository,
+3. adapts them through the fail-closed Bundle 31 adapter,
+4. runs the canonical engine with explicit target count, BPM range, genre, mode and start key,
+5. returns an immutable comparison report.
+
+It does not invoke the legacy composer, modify its output, export a playlist, write a database row or expose an API route.
+
+## Report evidence
+
+The report contains:
+
+- legacy and canonical ordered track identifiers,
+- canonical status and controlled failure reason,
+- candidate, adapted, rejected and fallback counts,
+- set overlap count,
+- positional agreement count,
+- legacy and canonical coverage ratios,
+- adapter issues,
+- canonical engine warnings.
+
+## Failure model
+
+- invalid request values fail during request construction,
+- unsupported modes fail before repository access,
+- invalid candidate features are represented by Bundle 31 issue codes,
+- an empty canonical candidate set remains a controlled engine result,
+- no shadow failure can alter an existing legacy playlist because this bundle does not integrate with the pipeline.
+
+## Verification
+
+- deterministic overlap and position metrics,
+- unchanged legacy tuple evidence,
+- adapter rejection and fallback propagation,
+- BPM-range behavior,
+- invalid mode before repository access,
+- empty legacy-output ratio behavior,
+- full Python 3.11 and 3.12 CI.
+
+## Rollback
+
+Revert the future Bundle 32 squash commit. No database, export or data rollback is required.

--- a/services/composition/__init__.py
+++ b/services/composition/__init__.py
@@ -21,6 +21,11 @@ from services.composition.models import (
     TransitionReason,
     TransitionScore,
 )
+from services.composition.shadow import (
+    CompositionShadowReport,
+    CompositionShadowService,
+    ShadowComparisonRequest,
+)
 
 __all__ = [
     "CandidateAdaptationResult",
@@ -33,12 +38,15 @@ __all__ = [
     "CompositionMode",
     "CompositionRequest",
     "CompositionResult",
+    "CompositionShadowReport",
+    "CompositionShadowService",
     "CompositionStatus",
     "CompositionSummary",
     "CompositionTrack",
     "DeterministicCompositionEngine",
     "EnergyStage",
     "EnergyTarget",
+    "ShadowComparisonRequest",
     "TransitionReason",
     "TransitionScore",
     "adapt_playlist_candidates",

--- a/services/composition/shadow.py
+++ b/services/composition/shadow.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -75,17 +74,21 @@ class CompositionShadowService:
         repository: PlaylistCandidateRepository | None = None,
         engine: DeterministicCompositionEngine | None = None,
     ) -> None:
-        self._repository = repository or AnalysisRepository()
-        self._engine = engine or DeterministicCompositionEngine()
+        self._repository = (
+            repository if repository is not None else AnalysisRepository()
+        )
+        self._engine = (
+            engine if engine is not None else DeterministicCompositionEngine()
+        )
 
     def compare(self, request: ShadowComparisonRequest) -> CompositionShadowReport:
+        mode = _parse_mode(request.mode)
         legacy_ids = tuple(track_id.strip() for track_id in request.legacy_track_ids)
         candidates = self._repository.list_playlist_candidates()
         adaptation = adapt_playlist_candidates(
             candidates,
             duration_fallback_seconds=request.duration_fallback_seconds,
         )
-        mode = _parse_mode(request.mode)
         canonical = self._engine.compose(
             CompositionRequest(
                 tracks=adaptation.tracks,
@@ -132,7 +135,9 @@ def _parse_mode(value: CompositionMode | str) -> CompositionMode:
         return CompositionMode(normalized)
     except ValueError as exc:
         allowed = ", ".join(mode.value for mode in CompositionMode)
-        raise ValueError(f"Unsupported composition mode: {value!r}; allowed: {allowed}") from exc
+        raise ValueError(
+            f"Unsupported composition mode: {value!r}; allowed: {allowed}"
+        ) from exc
 
 
 def _ratio(numerator: int, denominator: int) -> float:

--- a/services/composition/shadow.py
+++ b/services/composition/shadow.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+from data.models.playlist_candidate import PlaylistCandidate
+from data.repositories.analysis_repository import AnalysisRepository
+from services.composition.adapter import (
+    CandidateIssue,
+    adapt_playlist_candidates,
+)
+from services.composition.engine import DeterministicCompositionEngine
+from services.composition.models import (
+    CompositionFailureReason,
+    CompositionMode,
+    CompositionRequest,
+    CompositionStatus,
+)
+
+
+class PlaylistCandidateRepository(Protocol):
+    def list_playlist_candidates(self) -> list[PlaylistCandidate]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ShadowComparisonRequest:
+    legacy_track_ids: tuple[str, ...]
+    target_track_count: int
+    bpm_min: float = 1.0
+    bpm_max: float = 300.0
+    mode: CompositionMode | str = CompositionMode.CLUB
+    genre: str | None = None
+    start_key: str | None = None
+    duration_fallback_seconds: int = 300
+
+    def __post_init__(self) -> None:
+        if self.target_track_count <= 0:
+            raise ValueError("target_track_count must be greater than zero")
+        if self.bpm_min <= 0 or self.bpm_max <= 0:
+            raise ValueError("BPM range values must be greater than zero")
+        if self.bpm_min > self.bpm_max:
+            raise ValueError("bpm_min must be less than or equal to bpm_max")
+        if self.duration_fallback_seconds <= 0:
+            raise ValueError("duration_fallback_seconds must be greater than zero")
+        for track_id in self.legacy_track_ids:
+            if not isinstance(track_id, str) or not track_id.strip():
+                raise ValueError("legacy_track_ids must contain non-empty strings")
+
+
+@dataclass(frozen=True, slots=True)
+class CompositionShadowReport:
+    legacy_track_ids: tuple[str, ...]
+    canonical_track_ids: tuple[str, ...]
+    canonical_status: CompositionStatus
+    canonical_failure_reason: CompositionFailureReason | None
+    candidate_count: int
+    adapted_count: int
+    rejected_count: int
+    fallback_count: int
+    overlap_count: int
+    position_match_count: int
+    legacy_coverage_ratio: float
+    canonical_coverage_ratio: float
+    adaptation_issues: tuple[CandidateIssue, ...]
+    canonical_warnings: tuple[str, ...]
+
+
+class CompositionShadowService:
+    """Read-only comparator. It never changes legacy output or writes artifacts."""
+
+    def __init__(
+        self,
+        *,
+        repository: PlaylistCandidateRepository | None = None,
+        engine: DeterministicCompositionEngine | None = None,
+    ) -> None:
+        self._repository = repository or AnalysisRepository()
+        self._engine = engine or DeterministicCompositionEngine()
+
+    def compare(self, request: ShadowComparisonRequest) -> CompositionShadowReport:
+        legacy_ids = tuple(track_id.strip() for track_id in request.legacy_track_ids)
+        candidates = self._repository.list_playlist_candidates()
+        adaptation = adapt_playlist_candidates(
+            candidates,
+            duration_fallback_seconds=request.duration_fallback_seconds,
+        )
+        mode = _parse_mode(request.mode)
+        canonical = self._engine.compose(
+            CompositionRequest(
+                tracks=adaptation.tracks,
+                target_track_count=request.target_track_count,
+                bpm_min=request.bpm_min,
+                bpm_max=request.bpm_max,
+                mode=mode,
+                genre=request.genre,
+                start_key=request.start_key,
+            )
+        )
+        canonical_ids = tuple(track.track_id for track in canonical.tracks)
+        legacy_set = set(legacy_ids)
+        canonical_set = set(canonical_ids)
+        overlap_count = len(legacy_set & canonical_set)
+        position_match_count = sum(
+            left == right
+            for left, right in zip(legacy_ids, canonical_ids, strict=False)
+        )
+
+        return CompositionShadowReport(
+            legacy_track_ids=legacy_ids,
+            canonical_track_ids=canonical_ids,
+            canonical_status=canonical.status,
+            canonical_failure_reason=canonical.failure_reason,
+            candidate_count=len(candidates),
+            adapted_count=len(adaptation.tracks),
+            rejected_count=adaptation.rejected_count,
+            fallback_count=adaptation.fallback_count,
+            overlap_count=overlap_count,
+            position_match_count=position_match_count,
+            legacy_coverage_ratio=_ratio(overlap_count, len(legacy_set)),
+            canonical_coverage_ratio=_ratio(overlap_count, len(canonical_set)),
+            adaptation_issues=adaptation.issues,
+            canonical_warnings=canonical.warnings,
+        )
+
+
+def _parse_mode(value: CompositionMode | str) -> CompositionMode:
+    if isinstance(value, CompositionMode):
+        return value
+    normalized = value.strip().casefold()
+    try:
+        return CompositionMode(normalized)
+    except ValueError as exc:
+        allowed = ", ".join(mode.value for mode in CompositionMode)
+        raise ValueError(f"Unsupported composition mode: {value!r}; allowed: {allowed}") from exc
+
+
+def _ratio(numerator: int, denominator: int) -> float:
+    return 0.0 if denominator == 0 else numerator / denominator

--- a/tests/test_composition_shadow.py
+++ b/tests/test_composition_shadow.py
@@ -1,0 +1,160 @@
+import pytest
+
+from data.models.playlist_candidate import PlaylistCandidate
+from services.composition import (
+    CandidateIssueCode,
+    CompositionShadowService,
+    CompositionStatus,
+    ShadowComparisonRequest,
+)
+
+
+class FakeRepository:
+    def __init__(self, candidates: list[PlaylistCandidate]) -> None:
+        self.candidates = candidates
+        self.calls = 0
+
+    def list_playlist_candidates(self) -> list[PlaylistCandidate]:
+        self.calls += 1
+        return list(self.candidates)
+
+
+def _candidate(
+    track_id: str,
+    *,
+    bpm: float | None,
+    camelot: str | None,
+    energy: float | None,
+    duration_seconds: float | None = 300.0,
+) -> PlaylistCandidate:
+    return PlaylistCandidate(
+        track_id=track_id,
+        path=f"/music/{track_id}.mp3",
+        title=track_id,
+        artist=f"artist-{track_id}",
+        genre="tech house",
+        source=f"pool-{track_id}",
+        duration_seconds=duration_seconds,
+        bpm=bpm,
+        camelot=camelot,
+        energy=energy,
+    )
+
+
+def test_shadow_report_compares_overlap_and_position_without_mutating_legacy() -> None:
+    legacy_ids = ("b", "a")
+    repository = FakeRepository(
+        [
+            _candidate("a", bpm=124.0, camelot="8A", energy=0.25),
+            _candidate("b", bpm=125.0, camelot="9A", energy=0.60),
+        ]
+    )
+
+    report = CompositionShadowService(repository=repository).compare(
+        ShadowComparisonRequest(
+            legacy_track_ids=legacy_ids,
+            target_track_count=2,
+            bpm_min=120,
+            bpm_max=130,
+            mode="club",
+            genre="tech house",
+        )
+    )
+
+    assert legacy_ids == ("b", "a")
+    assert report.legacy_track_ids == ("b", "a")
+    assert report.canonical_track_ids == ("a", "b")
+    assert report.canonical_status == CompositionStatus.SUCCESS
+    assert report.overlap_count == 2
+    assert report.position_match_count == 0
+    assert report.legacy_coverage_ratio == 1.0
+    assert report.canonical_coverage_ratio == 1.0
+    assert repository.calls == 1
+
+
+def test_shadow_report_preserves_adapter_rejection_and_fallback_evidence() -> None:
+    repository = FakeRepository(
+        [
+            _candidate(
+                "fallback",
+                bpm=124.0,
+                camelot="8A",
+                energy=0.25,
+                duration_seconds=None,
+            ),
+            _candidate("rejected", bpm=None, camelot="9A", energy=0.5),
+        ]
+    )
+
+    report = CompositionShadowService(repository=repository).compare(
+        ShadowComparisonRequest(
+            legacy_track_ids=("fallback", "rejected"),
+            target_track_count=1,
+        )
+    )
+
+    assert report.candidate_count == 2
+    assert report.adapted_count == 1
+    assert report.rejected_count == 1
+    assert report.fallback_count == 1
+    assert {issue.code for issue in report.adaptation_issues} == {
+        CandidateIssueCode.INVALID_BPM,
+        CandidateIssueCode.DURATION_FALLBACK,
+    }
+
+
+def test_shadow_uses_requested_bpm_range() -> None:
+    repository = FakeRepository(
+        [
+            _candidate("inside", bpm=126.0, camelot="8A", energy=0.25),
+            _candidate("outside", bpm=140.0, camelot="9A", energy=0.50),
+        ]
+    )
+
+    report = CompositionShadowService(repository=repository).compare(
+        ShadowComparisonRequest(
+            legacy_track_ids=("outside",),
+            target_track_count=1,
+            bpm_min=124,
+            bpm_max=128,
+        )
+    )
+
+    assert report.canonical_track_ids == ("inside",)
+    assert report.overlap_count == 0
+    assert report.legacy_coverage_ratio == 0.0
+    assert report.canonical_coverage_ratio == 0.0
+
+
+def test_invalid_mode_fails_before_repository_access() -> None:
+    repository = FakeRepository([])
+    service = CompositionShadowService(repository=repository)
+
+    with pytest.raises(ValueError, match="Unsupported composition mode"):
+        service.compare(
+            ShadowComparisonRequest(
+                legacy_track_ids=(),
+                target_track_count=1,
+                mode="not-a-mode",
+            )
+        )
+
+    assert repository.calls == 0
+
+
+def test_empty_legacy_output_has_zero_coverage_ratios() -> None:
+    repository = FakeRepository(
+        [_candidate("canonical", bpm=124.0, camelot="8A", energy=0.25)]
+    )
+
+    report = CompositionShadowService(repository=repository).compare(
+        ShadowComparisonRequest(
+            legacy_track_ids=(),
+            target_track_count=1,
+        )
+    )
+
+    assert report.overlap_count == 0
+    assert report.position_match_count == 0
+    assert report.legacy_coverage_ratio == 0.0
+    assert report.canonical_coverage_ratio == 0.0


### PR DESCRIPTION
## Summary
- add a read-only comparison service for legacy and canonical composition results
- apply BPM, mode, genre and start-key controls to the canonical run
- report overlap, ordered agreement, adapter issues and canonical status
- add deterministic tests and documentation

## Verification
- base commit: `d6263c8859916ed9b67913d9dacdddf4e7aa4710`
- ahead-only diff limited to four composition, test and documentation files
- Python 3.11 and 3.12 CI required
- no local execution claimed

## Isolation
No production pipeline, API, export or persistence behavior is changed.

## Bundle Context
- Bundle: 32 — Composition Comparison Service
- Base branch: `feature/bundle-0-bootstrap`
- Related issue: #38
- Rollback: close this PR or revert its future squash commit; no data rollback required