### PR TITLE
Bundle 33: pipeline composition observability hook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@ CORS_ORIGINS=http://localhost:3000,http://localhost:5173,http://127.0.0.1:5173
 DATABASE_URL=sqlite:///./applaylist.db
 REDIS_URL=redis://redis:6379/0
 
+ENABLE_COMPOSITION_COMPARISON=false
+
 API_TOKEN=change-me
 JWT_SECRET=change-me
 JWT_ALGORITHM=HS256

--- a/core/config/settings.py
+++ b/core/config/settings.py
@@ -30,6 +30,7 @@ class Settings(BaseSettings):
     enable_external_connectors: bool = False
     enable_advanced_structure: bool = False
     enable_generative_preview: bool = False
+    enable_composition_comparison: bool = False
 
     artifacts_dir: str = "./artifacts"
     exports_dir: str = "./exports"

--- a/docs/bundles/BUNDLE_33_COMPOSITION_OBSERVABILITY_HOOK.md
+++ b/docs/bundles/BUNDLE_33_COMPOSITION_OBSERVABILITY_HOOK.md
@@ -1,0 +1,79 @@
+# Bundle 33 — Composition Observability Hook
+
+## Status
+
+Implementation candidate. Production comparison remains disabled by default.
+
+## Goal
+
+Attach the read-only composition comparison service to the legacy pipeline without changing which tracks are exported or what the API returns.
+
+## Runtime contract
+
+The pipeline remains ordered as follows:
+
+1. legacy composer selects tracks;
+2. exporter writes the legacy playlist;
+3. the optional comparison hook observes the completed legacy result;
+4. the existing pipeline response is returned unchanged.
+
+Comparison is controlled by:
+
+```text
+ENABLE_COMPOSITION_COMPARISON=false
+```
+
+The default is `false`.
+
+## Fail-open boundary
+
+The comparison hook is observability-only. Exceptions from:
+
+- request validation,
+- candidate repository reads,
+- adaptation,
+- canonical composition,
+- report sinks,
+- logging adapters,
+
+are caught at the pipeline boundary. The already completed legacy export remains authoritative and the existing response is returned.
+
+Export failures are not hidden. When export fails, the comparison hook is not invoked.
+
+## Data handling
+
+The hook receives only:
+
+- legacy track IDs,
+- requested target count,
+- requested BPM range,
+- requested mode.
+
+The comparison report is sent to an injected sink. Bundle 33 provides a standard logging sink and introduces no database table, artifact file, API field or external telemetry backend.
+
+## Rollout
+
+1. Keep the flag disabled after merge.
+2. Enable only in a controlled environment.
+3. Inspect comparison status, overlap, positional agreement, rejection and fallback counts.
+4. Disable immediately if latency or warning volume is unacceptable.
+5. Do not use comparison results to alter export behavior in this bundle.
+
+## Rollback
+
+Set:
+
+```text
+ENABLE_COMPOSITION_COMPARISON=false
+```
+
+No restart-time data repair or database rollback is required. The code change can also be reverted as one squash commit.
+
+## Non-goals
+
+- canonical export;
+- automatic playlist switching;
+- API response changes;
+- persistent comparison history;
+- asynchronous execution;
+- removal of the legacy composer.

--- a/services/composition/hook.py
+++ b/services/composition/hook.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from services.composition.shadow import (
+    CompositionShadowReport,
+    CompositionShadowService,
+    ShadowComparisonRequest,
+)
+
+
+class CompositionReportSink(Protocol):
+    def emit(self, report: CompositionShadowReport) -> None: ...
+
+
+class CompositionComparisonService(Protocol):
+    def compare(self, request: ShadowComparisonRequest) -> CompositionShadowReport: ...
+
+
+@dataclass(slots=True)
+class LoggingCompositionReportSink:
+    """Emit a compact comparison summary through the standard logging boundary."""
+
+    logger: logging.Logger = field(
+        default_factory=lambda: logging.getLogger("applaylist.composition.comparison")
+    )
+
+    def emit(self, report: CompositionShadowReport) -> None:
+        self.logger.info(
+            "composition comparison completed",
+            extra={
+                "canonical_status": report.canonical_status.value,
+                "candidate_count": report.candidate_count,
+                "adapted_count": report.adapted_count,
+                "rejected_count": report.rejected_count,
+                "fallback_count": report.fallback_count,
+                "overlap_count": report.overlap_count,
+                "position_match_count": report.position_match_count,
+                "legacy_coverage_ratio": report.legacy_coverage_ratio,
+                "canonical_coverage_ratio": report.canonical_coverage_ratio,
+            },
+        )
+
+
+class PipelineCompositionComparisonHook:
+    """Build and emit a read-only canonical comparison for one legacy run."""
+
+    def __init__(
+        self,
+        *,
+        service: CompositionComparisonService | None = None,
+        sink: CompositionReportSink | None = None,
+    ) -> None:
+        self._service = service if service is not None else CompositionShadowService()
+        self._sink = sink if sink is not None else LoggingCompositionReportSink()
+
+    def observe(
+        self,
+        *,
+        legacy_track_ids: tuple[str, ...],
+        target_track_count: int,
+        bpm_min: float | None,
+        bpm_max: float | None,
+        mode: str | None,
+    ) -> CompositionShadowReport:
+        report = self._service.compare(
+            ShadowComparisonRequest(
+                legacy_track_ids=legacy_track_ids,
+                target_track_count=target_track_count,
+                bpm_min=bpm_min if bpm_min is not None else 1.0,
+                bpm_max=bpm_max if bpm_max is not None else 300.0,
+                mode=mode if mode is not None else "club",
+            )
+        )
+        self._sink.emit(report)
+        return report

--- a/services/orchestrator/pipeline.py
+++ b/services/orchestrator/pipeline.py
@@ -1,10 +1,29 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
+from typing import Protocol
 from uuid import uuid4
 
+from core.config.settings import get_settings
 from services.composer.composer import Composer
+from services.composition.hook import PipelineCompositionComparisonHook
 from services.export.exporter import Exporter
+
+
+logger = logging.getLogger(__name__)
+
+
+class PipelineComparisonObserver(Protocol):
+    def observe(
+        self,
+        *,
+        legacy_track_ids: tuple[str, ...],
+        target_track_count: int,
+        bpm_min: float | None,
+        bpm_max: float | None,
+        mode: str | None,
+    ) -> object: ...
 
 
 def _new_pipeline_run_id() -> str:
@@ -18,10 +37,19 @@ class OrchestratorPipeline:
         composer: Composer | None = None,
         exporter: Exporter | None = None,
         run_id_factory: Callable[[], str] | None = None,
+        comparison_hook: PipelineComparisonObserver | None = None,
+        comparison_enabled: bool | None = None,
     ) -> None:
-        self.composer = composer or Composer()
-        self.exporter = exporter or Exporter()
+        self.composer = composer if composer is not None else Composer()
+        self.exporter = exporter if exporter is not None else Exporter()
         self._run_id_factory = run_id_factory or _new_pipeline_run_id
+
+        if comparison_enabled is None:
+            comparison_enabled = get_settings().enable_composition_comparison
+        self._comparison_enabled = comparison_enabled
+        self._comparison_hook = comparison_hook
+        if self._comparison_enabled and self._comparison_hook is None:
+            self._comparison_hook = PipelineCompositionComparisonHook()
 
     def run(
         self,
@@ -44,6 +72,14 @@ class OrchestratorPipeline:
             tracks=playlist,
         )
 
+        self._observe_composition(
+            playlist=playlist,
+            limit=limit,
+            bpm_min=bpm_min,
+            bpm_max=bpm_max,
+            mode=mode,
+        )
+
         return {
             "input": {
                 "path": path,
@@ -56,3 +92,29 @@ class OrchestratorPipeline:
             "count": len(playlist),
             "export": export,
         }
+
+    def _observe_composition(
+        self,
+        *,
+        playlist: list,
+        limit: int,
+        bpm_min: float | None,
+        bpm_max: float | None,
+        mode: str | None,
+    ) -> None:
+        if not self._comparison_enabled or self._comparison_hook is None:
+            return
+
+        try:
+            self._comparison_hook.observe(
+                legacy_track_ids=tuple(track.track_id for track in playlist),
+                target_track_count=limit,
+                bpm_min=bpm_min,
+                bpm_max=bpm_max,
+                mode=mode,
+            )
+        except Exception:
+            logger.warning(
+                "composition comparison hook failed; legacy export preserved",
+                exc_info=True,
+            )

--- a/tests/test_pipeline_composition_observability.py
+++ b/tests/test_pipeline_composition_observability.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from core.config.settings import Settings
+from data.models.playlist_candidate import PlaylistCandidate
+from services.composition.hook import PipelineCompositionComparisonHook
+from services.composition.models import CompositionStatus
+from services.composition.shadow import CompositionShadowReport
+from services.orchestrator.pipeline import OrchestratorPipeline
+
+
+class FakeComposer:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    def compose(self, limit: int) -> list[PlaylistCandidate]:
+        self.events.append("compose")
+        return [
+            PlaylistCandidate(
+                track_id="legacy-1",
+                path="/music/legacy-1.mp3",
+                bpm=128.0,
+                camelot="8A",
+                energy=0.7,
+            )
+        ][:limit]
+
+
+class FakeExporter:
+    def __init__(self, events: list[str], *, fail: bool = False) -> None:
+        self.events = events
+        self.fail = fail
+
+    def export_m3u(self, *, playlist_id: str, tracks: list) -> dict:
+        self.events.append("export")
+        if self.fail:
+            raise RuntimeError("export failed")
+        return {
+            "playlist_id": playlist_id,
+            "track_count": len(tracks),
+            "m3u_path": f"exports/{playlist_id}.m3u",
+        }
+
+
+class RecordingHook:
+    def __init__(self, events: list[str], *, fail: bool = False) -> None:
+        self.events = events
+        self.fail = fail
+        self.calls: list[dict] = []
+
+    def observe(self, **kwargs) -> object:
+        self.events.append("observe")
+        self.calls.append(kwargs)
+        if self.fail:
+            raise RuntimeError("comparison failed")
+        return object()
+
+
+class StaticComparisonService:
+    def compare(self, request) -> CompositionShadowReport:
+        return CompositionShadowReport(
+            legacy_track_ids=request.legacy_track_ids,
+            canonical_track_ids=request.legacy_track_ids,
+            canonical_status=CompositionStatus.SUCCESS,
+            canonical_failure_reason=None,
+            candidate_count=1,
+            adapted_count=1,
+            rejected_count=0,
+            fallback_count=0,
+            overlap_count=1,
+            position_match_count=1,
+            legacy_coverage_ratio=1.0,
+            canonical_coverage_ratio=1.0,
+            adaptation_issues=(),
+            canonical_warnings=(),
+        )
+
+
+class FailingSink:
+    def emit(self, report: CompositionShadowReport) -> None:
+        raise RuntimeError("sink failed")
+
+
+def build_pipeline(
+    events: list[str],
+    *,
+    hook=None,
+    enabled: bool,
+    export_fail: bool = False,
+) -> OrchestratorPipeline:
+    return OrchestratorPipeline(
+        composer=FakeComposer(events),
+        exporter=FakeExporter(events, fail=export_fail),
+        run_id_factory=lambda: "pipeline-test",
+        comparison_hook=hook,
+        comparison_enabled=enabled,
+    )
+
+
+def assert_legacy_result_unchanged(result: dict) -> None:
+    assert result == {
+        "input": {
+            "path": "/music",
+            "limit": 1,
+            "bpm_min": 126.0,
+            "bpm_max": 132.0,
+            "mode": "club",
+        },
+        "tracks": ["legacy-1"],
+        "count": 1,
+        "export": {
+            "playlist_id": "pipeline-test",
+            "track_count": 1,
+            "m3u_path": "exports/pipeline-test.m3u",
+        },
+    }
+
+
+def test_comparison_is_disabled_by_default_and_hook_is_not_called() -> None:
+    assert Settings(_env_file=None).enable_composition_comparison is False
+
+    events: list[str] = []
+    hook = RecordingHook(events)
+    pipeline = build_pipeline(events, hook=hook, enabled=False)
+
+    result = pipeline.run(
+        path="/music",
+        limit=1,
+        bpm_min=126.0,
+        bpm_max=132.0,
+        mode="club",
+    )
+
+    assert events == ["compose", "export"]
+    assert hook.calls == []
+    assert_legacy_result_unchanged(result)
+
+
+def test_enabled_hook_runs_after_export_with_requested_controls() -> None:
+    events: list[str] = []
+    hook = RecordingHook(events)
+    pipeline = build_pipeline(events, hook=hook, enabled=True)
+
+    result = pipeline.run(
+        path="/music",
+        limit=1,
+        bpm_min=126.0,
+        bpm_max=132.0,
+        mode="club",
+    )
+
+    assert events == ["compose", "export", "observe"]
+    assert hook.calls == [
+        {
+            "legacy_track_ids": ("legacy-1",),
+            "target_track_count": 1,
+            "bpm_min": 126.0,
+            "bpm_max": 132.0,
+            "mode": "club",
+        }
+    ]
+    assert_legacy_result_unchanged(result)
+
+
+def test_hook_failure_is_fail_open_and_logged(caplog) -> None:
+    events: list[str] = []
+    hook = RecordingHook(events, fail=True)
+    pipeline = build_pipeline(events, hook=hook, enabled=True)
+
+    with caplog.at_level(logging.WARNING, logger="services.orchestrator.pipeline"):
+        result = pipeline.run(
+            path="/music",
+            limit=1,
+            bpm_min=126.0,
+            bpm_max=132.0,
+            mode="club",
+        )
+
+    assert events == ["compose", "export", "observe"]
+    assert "legacy export preserved" in caplog.text
+    assert_legacy_result_unchanged(result)
+
+
+def test_sink_failure_is_fail_open() -> None:
+    events: list[str] = []
+    hook = PipelineCompositionComparisonHook(
+        service=StaticComparisonService(),
+        sink=FailingSink(),
+    )
+    pipeline = build_pipeline(events, hook=hook, enabled=True)
+
+    result = pipeline.run(
+        path="/music",
+        limit=1,
+        bpm_min=126.0,
+        bpm_max=132.0,
+        mode="club",
+    )
+
+    assert events == ["compose", "export"]
+    assert_legacy_result_unchanged(result)
+
+
+def test_export_failure_prevents_observability_invocation() -> None:
+    events: list[str] = []
+    hook = RecordingHook(events)
+    pipeline = build_pipeline(
+        events,
+        hook=hook,
+        enabled=True,
+        export_fail=True,
+    )
+
+    with pytest.raises(RuntimeError, match="export failed"):
+        pipeline.run(path="/music", limit=1)
+
+    assert events == ["compose", "export"]
+    assert hook.calls == []


### PR DESCRIPTION
## Summary
- add a disabled-by-default composition comparison setting
- add an injectable comparison hook and logging sink
- invoke comparison only after a successful legacy export
- preserve the exact existing pipeline response and exported playlist
- catch hook and sink exceptions at the pipeline boundary
- add deterministic rollout tests and documentation

## Verification
- branch created directly from Bundle 32 squash commit `f8b2094195e582c3ca607f7c83c63b7d50f7eefd`
- ahead-only diff limited to six configuration, pipeline, hook, test and documentation files
- Python 3.11 and 3.12 CI required
- install, compile, critical Ruff and full pytest must pass
- no local test execution is claimed

## Isolation
- comparison is opt-in through `ENABLE_COMPOSITION_COMPARISON=false`
- no canonical playlist is exported
- no API response field is added
- no database migration, artifact persistence or external telemetry backend

## Bundle Context
- Bundle: 33 — Pipeline Composition Observability Hook
- Base branch: `feature/bundle-0-bootstrap`
- Base commit: `f8b2094195e582c3ca607f7c83c63b7d50f7eefd`
- Related issue: #40
- Rollback: disable the flag or revert the future squash commit; no data rollback required