### PR TITLE
Bundle 34: composition comparison receipts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,8 @@ DATABASE_URL=sqlite:///./applaylist.db
 REDIS_URL=redis://redis:6379/0
 
 ENABLE_COMPOSITION_COMPARISON=false
+ENABLE_COMPOSITION_RECEIPTS=false
+COMPOSITION_RECEIPTS_DIR=./artifacts/composition-comparisons
 
 API_TOKEN=change-me
 JWT_SECRET=change-me

--- a/core/config/settings.py
+++ b/core/config/settings.py
@@ -31,6 +31,8 @@ class Settings(BaseSettings):
     enable_advanced_structure: bool = False
     enable_generative_preview: bool = False
     enable_composition_comparison: bool = False
+    enable_composition_receipts: bool = False
+    composition_receipts_dir: str = "./artifacts/composition-comparisons"
 
     artifacts_dir: str = "./artifacts"
     exports_dir: str = "./exports"

--- a/docs/bundles/BUNDLE_34_COMPOSITION_COMPARISON_RECEIPTS.md
+++ b/docs/bundles/BUNDLE_34_COMPOSITION_COMPARISON_RECEIPTS.md
@@ -1,0 +1,81 @@
+# Bundle 34 — Composition Comparison Receipts
+
+## Status
+
+Implementation candidate. Comparison and local receipt persistence remain disabled by default.
+
+## Goal
+
+Create durable, correlated evidence for legacy-versus-canonical composition comparisons without changing playlist selection, export behavior or API responses.
+
+## Receipt contract
+
+Each receipt contains:
+
+- schema version;
+- the same pipeline run ID used as the export playlist ID;
+- a timezone-aware UTC creation timestamp;
+- requested target count, BPM range and mode;
+- legacy and canonical track IDs;
+- canonical status and failure reason;
+- candidate, adapted, rejected and fallback counts;
+- adaptation issues and canonical warnings;
+- overlap, position agreement and coverage ratios.
+
+Serialization is deterministic and JSON-safe. Enum values are emitted as stable strings.
+
+## Runtime ordering
+
+1. Legacy composition completes.
+2. Legacy export completes.
+3. Optional comparison executes.
+4. A receipt is built with the export run ID.
+5. Configured receipt sinks are invoked.
+6. The original pipeline response is returned unchanged.
+
+Any failure in steps 3–5 remains inside the existing fail-open observability boundary.
+
+## Configuration
+
+```text
+ENABLE_COMPOSITION_COMPARISON=false
+ENABLE_COMPOSITION_RECEIPTS=false
+COMPOSITION_RECEIPTS_DIR=./artifacts/composition-comparisons
+```
+
+Local receipts are written only when both comparison and receipt persistence are enabled.
+
+## Filesystem contract
+
+The local JSON sink:
+
+- accepts only bounded safe run IDs;
+- creates the configured receipt directory when needed;
+- writes a uniquely named temporary file;
+- atomically replaces the final `<run-id>.json` artifact;
+- removes the temporary file on failure;
+- never adds receipt paths to the API response.
+
+Generated artifacts remain excluded by `.gitignore` through the existing `artifacts/` rule.
+
+## Rollout
+
+1. Merge with both flags disabled.
+2. Enable comparison in a controlled environment.
+3. Verify logging-only evidence.
+4. Enable local receipts for a bounded test window.
+5. Inspect file volume, latency, schema stability and warning rate.
+6. Disable receipt persistence before any production anomaly investigation if disk pressure appears.
+
+## Rollback
+
+Set either flag to `false`. No database migration or data repair is required. Existing receipt files may be archived or removed independently of the application.
+
+## Non-goals
+
+- database-backed receipt history;
+- external telemetry delivery;
+- API receipt endpoints;
+- canonical playlist export;
+- asynchronous processing;
+- automated switching away from the legacy composer.

--- a/services/composition/__init__.py
+++ b/services/composition/__init__.py
@@ -6,6 +6,10 @@ from services.composition.adapter import (
     adapt_playlist_candidates,
 )
 from services.composition.engine import DeterministicCompositionEngine
+from services.composition.hook import (
+    LoggingCompositionReceiptSink,
+    PipelineCompositionComparisonHook,
+)
 from services.composition.models import (
     CompositionConstraints,
     CompositionDecision,
@@ -21,6 +25,15 @@ from services.composition.models import (
     TransitionReason,
     TransitionScore,
 )
+from services.composition.receipt import (
+    CompositionComparisonReceipt,
+    CompositionReceiptIssue,
+    build_composition_comparison_receipt,
+)
+from services.composition.receipt_sink import (
+    CompositeCompositionReceiptSink,
+    JsonCompositionReceiptSink,
+)
 from services.composition.shadow import (
     CompositionShadowReport,
     CompositionShadowService,
@@ -32,10 +45,13 @@ __all__ = [
     "CandidateIssue",
     "CandidateIssueCode",
     "CandidateIssueSeverity",
+    "CompositeCompositionReceiptSink",
+    "CompositionComparisonReceipt",
     "CompositionConstraints",
     "CompositionDecision",
     "CompositionFailureReason",
     "CompositionMode",
+    "CompositionReceiptIssue",
     "CompositionRequest",
     "CompositionResult",
     "CompositionShadowReport",
@@ -46,8 +62,12 @@ __all__ = [
     "DeterministicCompositionEngine",
     "EnergyStage",
     "EnergyTarget",
+    "JsonCompositionReceiptSink",
+    "LoggingCompositionReceiptSink",
+    "PipelineCompositionComparisonHook",
     "ShadowComparisonRequest",
     "TransitionReason",
     "TransitionScore",
     "adapt_playlist_candidates",
+    "build_composition_comparison_receipt",
 ]

--- a/services/composition/hook.py
+++ b/services/composition/hook.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Protocol
 
+from services.composition.receipt import (
+    CompositionComparisonReceipt,
+    build_composition_comparison_receipt,
+)
 from services.composition.shadow import (
     CompositionShadowReport,
     CompositionShadowService,
@@ -11,8 +17,8 @@ from services.composition.shadow import (
 )
 
 
-class CompositionReportSink(Protocol):
-    def emit(self, report: CompositionShadowReport) -> None: ...
+class CompositionReceiptSink(Protocol):
+    def emit(self, receipt: CompositionComparisonReceipt) -> None: ...
 
 
 class CompositionComparisonService(Protocol):
@@ -20,59 +26,76 @@ class CompositionComparisonService(Protocol):
 
 
 @dataclass(slots=True)
-class LoggingCompositionReportSink:
-    """Emit a compact comparison summary through the standard logging boundary."""
+class LoggingCompositionReceiptSink:
+    """Emit a compact comparison receipt summary through the logging boundary."""
 
     logger: logging.Logger = field(
         default_factory=lambda: logging.getLogger("applaylist.composition.comparison")
     )
 
-    def emit(self, report: CompositionShadowReport) -> None:
+    def emit(self, receipt: CompositionComparisonReceipt) -> None:
         self.logger.info(
             "composition comparison completed",
             extra={
-                "canonical_status": report.canonical_status.value,
-                "candidate_count": report.candidate_count,
-                "adapted_count": report.adapted_count,
-                "rejected_count": report.rejected_count,
-                "fallback_count": report.fallback_count,
-                "overlap_count": report.overlap_count,
-                "position_match_count": report.position_match_count,
-                "legacy_coverage_ratio": report.legacy_coverage_ratio,
-                "canonical_coverage_ratio": report.canonical_coverage_ratio,
+                "run_id": receipt.run_id,
+                "receipt_schema_version": receipt.schema_version,
+                "canonical_status": receipt.canonical_status,
+                "candidate_count": receipt.candidate_count,
+                "adapted_count": receipt.adapted_count,
+                "rejected_count": receipt.rejected_count,
+                "fallback_count": receipt.fallback_count,
+                "overlap_count": receipt.overlap_count,
+                "position_match_count": receipt.position_match_count,
+                "legacy_coverage_ratio": receipt.legacy_coverage_ratio,
+                "canonical_coverage_ratio": receipt.canonical_coverage_ratio,
             },
         )
 
 
 class PipelineCompositionComparisonHook:
-    """Build and emit a read-only canonical comparison for one legacy run."""
+    """Build and emit a correlated read-only receipt for one legacy run."""
 
     def __init__(
         self,
         *,
         service: CompositionComparisonService | None = None,
-        sink: CompositionReportSink | None = None,
+        sink: CompositionReceiptSink | None = None,
+        clock: Callable[[], datetime] | None = None,
     ) -> None:
         self._service = service if service is not None else CompositionShadowService()
-        self._sink = sink if sink is not None else LoggingCompositionReportSink()
+        self._sink = sink if sink is not None else LoggingCompositionReceiptSink()
+        self._clock = clock if clock is not None else lambda: datetime.now(timezone.utc)
 
     def observe(
         self,
         *,
+        run_id: str,
         legacy_track_ids: tuple[str, ...],
         target_track_count: int,
         bpm_min: float | None,
         bpm_max: float | None,
         mode: str | None,
-    ) -> CompositionShadowReport:
+    ) -> CompositionComparisonReceipt:
+        resolved_bpm_min = bpm_min if bpm_min is not None else 1.0
+        resolved_bpm_max = bpm_max if bpm_max is not None else 300.0
+        resolved_mode = mode if mode is not None else "club"
         report = self._service.compare(
             ShadowComparisonRequest(
                 legacy_track_ids=legacy_track_ids,
                 target_track_count=target_track_count,
-                bpm_min=bpm_min if bpm_min is not None else 1.0,
-                bpm_max=bpm_max if bpm_max is not None else 300.0,
-                mode=mode if mode is not None else "club",
+                bpm_min=resolved_bpm_min,
+                bpm_max=resolved_bpm_max,
+                mode=resolved_mode,
             )
         )
-        self._sink.emit(report)
-        return report
+        receipt = build_composition_comparison_receipt(
+            run_id=run_id,
+            generated_at=self._clock(),
+            target_track_count=target_track_count,
+            bpm_min=resolved_bpm_min,
+            bpm_max=resolved_bpm_max,
+            mode=resolved_mode,
+            report=report,
+        )
+        self._sink.emit(receipt)
+        return receipt

--- a/services/composition/hook.py
+++ b/services/composition/hook.py
@@ -66,7 +66,7 @@ class PipelineCompositionComparisonHook:
         self._sink = sink if sink is not None else LoggingCompositionReceiptSink()
         self._clock = clock if clock is not None else lambda: datetime.now(timezone.utc)
 
-    def observe(
+    def observe_run(
         self,
         *,
         run_id: str,

--- a/services/composition/hook.py
+++ b/services/composition/hook.py
@@ -99,3 +99,7 @@ class PipelineCompositionComparisonHook:
         )
         self._sink.emit(receipt)
         return receipt
+
+    def observe(self, **kwargs) -> CompositionComparisonReceipt:
+        """Backward-compatible direct alias for callers already using observe()."""
+        return self.observe_run(**kwargs)

--- a/services/composition/receipt.py
+++ b/services/composition/receipt.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from services.composition.shadow import CompositionShadowReport
+
+
+RECEIPT_SCHEMA_VERSION = "1.0"
+
+
+@dataclass(frozen=True, slots=True)
+class CompositionReceiptIssue:
+    track_id: str
+    code: str
+    severity: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "track_id": self.track_id,
+            "code": self.code,
+            "severity": self.severity,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CompositionComparisonReceipt:
+    schema_version: str
+    run_id: str
+    generated_at: str
+    target_track_count: int
+    bpm_min: float
+    bpm_max: float
+    mode: str
+    legacy_track_ids: tuple[str, ...]
+    canonical_track_ids: tuple[str, ...]
+    canonical_status: str
+    canonical_failure_reason: str | None
+    candidate_count: int
+    adapted_count: int
+    rejected_count: int
+    fallback_count: int
+    overlap_count: int
+    position_match_count: int
+    legacy_coverage_ratio: float
+    canonical_coverage_ratio: float
+    adaptation_issues: tuple[CompositionReceiptIssue, ...]
+    canonical_warnings: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "run_id": self.run_id,
+            "generated_at": self.generated_at,
+            "request": {
+                "target_track_count": self.target_track_count,
+                "bpm_min": self.bpm_min,
+                "bpm_max": self.bpm_max,
+                "mode": self.mode,
+            },
+            "legacy": {
+                "track_ids": list(self.legacy_track_ids),
+            },
+            "canonical": {
+                "track_ids": list(self.canonical_track_ids),
+                "status": self.canonical_status,
+                "failure_reason": self.canonical_failure_reason,
+                "warnings": list(self.canonical_warnings),
+            },
+            "quality": {
+                "candidate_count": self.candidate_count,
+                "adapted_count": self.adapted_count,
+                "rejected_count": self.rejected_count,
+                "fallback_count": self.fallback_count,
+                "adaptation_issues": [
+                    issue.to_dict() for issue in self.adaptation_issues
+                ],
+            },
+            "comparison": {
+                "overlap_count": self.overlap_count,
+                "position_match_count": self.position_match_count,
+                "legacy_coverage_ratio": self.legacy_coverage_ratio,
+                "canonical_coverage_ratio": self.canonical_coverage_ratio,
+            },
+        }
+
+
+def build_composition_comparison_receipt(
+    *,
+    run_id: str,
+    generated_at: datetime,
+    target_track_count: int,
+    bpm_min: float,
+    bpm_max: float,
+    mode: str,
+    report: CompositionShadowReport,
+) -> CompositionComparisonReceipt:
+    normalized_run_id = run_id.strip()
+    if not normalized_run_id:
+        raise ValueError("run_id must be a non-empty string")
+    if generated_at.tzinfo is None or generated_at.utcoffset() is None:
+        raise ValueError("generated_at must be timezone-aware")
+
+    normalized_time = generated_at.astimezone(timezone.utc)
+    generated_at_text = normalized_time.isoformat().replace("+00:00", "Z")
+
+    return CompositionComparisonReceipt(
+        schema_version=RECEIPT_SCHEMA_VERSION,
+        run_id=normalized_run_id,
+        generated_at=generated_at_text,
+        target_track_count=target_track_count,
+        bpm_min=bpm_min,
+        bpm_max=bpm_max,
+        mode=mode,
+        legacy_track_ids=report.legacy_track_ids,
+        canonical_track_ids=report.canonical_track_ids,
+        canonical_status=report.canonical_status.value,
+        canonical_failure_reason=(
+            report.canonical_failure_reason.value
+            if report.canonical_failure_reason is not None
+            else None
+        ),
+        candidate_count=report.candidate_count,
+        adapted_count=report.adapted_count,
+        rejected_count=report.rejected_count,
+        fallback_count=report.fallback_count,
+        overlap_count=report.overlap_count,
+        position_match_count=report.position_match_count,
+        legacy_coverage_ratio=report.legacy_coverage_ratio,
+        canonical_coverage_ratio=report.canonical_coverage_ratio,
+        adaptation_issues=tuple(
+            CompositionReceiptIssue(
+                track_id=issue.track_id,
+                code=issue.code.value,
+                severity=issue.severity.value,
+            )
+            for issue in report.adaptation_issues
+        ),
+        canonical_warnings=report.canonical_warnings,
+    )

--- a/services/composition/receipt_sink.py
+++ b/services/composition/receipt_sink.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from uuid import uuid4
+
+from services.composition.receipt import CompositionComparisonReceipt
+
+
+_SAFE_RUN_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+@dataclass(slots=True)
+class JsonCompositionReceiptSink:
+    directory: Path
+
+    def __init__(self, directory: str | Path) -> None:
+        self.directory = Path(directory)
+
+    def emit(self, receipt: CompositionComparisonReceipt) -> None:
+        if _SAFE_RUN_ID.fullmatch(receipt.run_id) is None:
+            raise ValueError("run_id contains unsafe characters")
+
+        root = self.directory.resolve()
+        root.mkdir(parents=True, exist_ok=True)
+        target = root / f"{receipt.run_id}.json"
+        if target.parent != root:
+            raise ValueError("receipt target escaped configured directory")
+
+        temporary = root / f".{receipt.run_id}.{uuid4().hex}.tmp"
+        payload = json.dumps(
+            receipt.to_dict(),
+            indent=2,
+            sort_keys=True,
+            ensure_ascii=False,
+        )
+
+        try:
+            temporary.write_text(payload + "\n", encoding="utf-8")
+            temporary.replace(target)
+        except Exception:
+            temporary.unlink(missing_ok=True)
+            raise
+
+
+@dataclass(slots=True)
+class CompositeCompositionReceiptSink:
+    sinks: tuple[object, ...]
+
+    def emit(self, receipt: CompositionComparisonReceipt) -> None:
+        errors: list[Exception] = []
+        for sink in self.sinks:
+            try:
+                sink.emit(receipt)
+            except Exception as exc:
+                errors.append(exc)
+        if errors:
+            raise RuntimeError(
+                f"{len(errors)} composition receipt sink(s) failed"
+            ) from errors[0]

--- a/services/orchestrator/pipeline.py
+++ b/services/orchestrator/pipeline.py
@@ -7,7 +7,14 @@ from uuid import uuid4
 
 from core.config.settings import get_settings
 from services.composer.composer import Composer
-from services.composition.hook import PipelineCompositionComparisonHook
+from services.composition.hook import (
+    LoggingCompositionReceiptSink,
+    PipelineCompositionComparisonHook,
+)
+from services.composition.receipt_sink import (
+    CompositeCompositionReceiptSink,
+    JsonCompositionReceiptSink,
+)
 from services.export.exporter import Exporter
 
 
@@ -18,6 +25,7 @@ class PipelineComparisonObserver(Protocol):
     def observe(
         self,
         *,
+        run_id: str,
         legacy_track_ids: tuple[str, ...],
         target_track_count: int,
         bpm_min: float | None,
@@ -44,12 +52,30 @@ class OrchestratorPipeline:
         self.exporter = exporter if exporter is not None else Exporter()
         self._run_id_factory = run_id_factory or _new_pipeline_run_id
 
+        settings = None
+        if comparison_enabled is None or (
+            comparison_enabled and comparison_hook is None
+        ):
+            settings = get_settings()
         if comparison_enabled is None:
-            comparison_enabled = get_settings().enable_composition_comparison
+            assert settings is not None
+            comparison_enabled = settings.enable_composition_comparison
+
         self._comparison_enabled = comparison_enabled
         self._comparison_hook = comparison_hook
         if self._comparison_enabled and self._comparison_hook is None:
-            self._comparison_hook = PipelineCompositionComparisonHook()
+            assert settings is not None
+            receipt_sinks: list[object] = [LoggingCompositionReceiptSink()]
+            if settings.enable_composition_receipts:
+                receipt_sinks.append(
+                    JsonCompositionReceiptSink(settings.composition_receipts_dir)
+                )
+            sink = (
+                receipt_sinks[0]
+                if len(receipt_sinks) == 1
+                else CompositeCompositionReceiptSink(tuple(receipt_sinks))
+            )
+            self._comparison_hook = PipelineCompositionComparisonHook(sink=sink)
 
     def run(
         self,
@@ -66,13 +92,15 @@ class OrchestratorPipeline:
 
         if not isinstance(playlist_id, str) or not playlist_id.strip():
             raise RuntimeError("Pipeline run ID factory returned an invalid identifier")
+        normalized_playlist_id = playlist_id.strip()
 
         export = self.exporter.export_m3u(
-            playlist_id=playlist_id.strip(),
+            playlist_id=normalized_playlist_id,
             tracks=playlist,
         )
 
         self._observe_composition(
+            run_id=normalized_playlist_id,
             playlist=playlist,
             limit=limit,
             bpm_min=bpm_min,
@@ -96,6 +124,7 @@ class OrchestratorPipeline:
     def _observe_composition(
         self,
         *,
+        run_id: str,
         playlist: list,
         limit: int,
         bpm_min: float | None,
@@ -107,6 +136,7 @@ class OrchestratorPipeline:
 
         try:
             self._comparison_hook.observe(
+                run_id=run_id,
                 legacy_track_ids=tuple(track.track_id for track in playlist),
                 target_track_count=limit,
                 bpm_min=bpm_min,

--- a/services/orchestrator/pipeline.py
+++ b/services/orchestrator/pipeline.py
@@ -25,7 +25,6 @@ class PipelineComparisonObserver(Protocol):
     def observe(
         self,
         *,
-        run_id: str,
         legacy_track_ids: tuple[str, ...],
         target_track_count: int,
         bpm_min: float | None,
@@ -45,7 +44,7 @@ class OrchestratorPipeline:
         composer: Composer | None = None,
         exporter: Exporter | None = None,
         run_id_factory: Callable[[], str] | None = None,
-        comparison_hook: PipelineComparisonObserver | None = None,
+        comparison_hook: object | None = None,
         comparison_enabled: bool | None = None,
     ) -> None:
         self.composer = composer if composer is not None else Composer()
@@ -85,8 +84,6 @@ class OrchestratorPipeline:
         bpm_max: float | None = None,
         mode: str | None = None,
     ) -> dict:
-        # Current clean MVP behavior:
-        # compose from precomputed DB analyses joined to track paths, then export.
         playlist = self.composer.compose(limit=limit)
         playlist_id = self._run_id_factory()
 
@@ -134,15 +131,22 @@ class OrchestratorPipeline:
         if not self._comparison_enabled or self._comparison_hook is None:
             return
 
+        arguments = {
+            "legacy_track_ids": tuple(track.track_id for track in playlist),
+            "target_track_count": limit,
+            "bpm_min": bpm_min,
+            "bpm_max": bpm_max,
+            "mode": mode,
+        }
+
         try:
-            self._comparison_hook.observe(
-                run_id=run_id,
-                legacy_track_ids=tuple(track.track_id for track in playlist),
-                target_track_count=limit,
-                bpm_min=bpm_min,
-                bpm_max=bpm_max,
-                mode=mode,
-            )
+            observe_run = getattr(self._comparison_hook, "observe_run", None)
+            if callable(observe_run):
+                observe_run(run_id=run_id, **arguments)
+                return
+
+            observe = getattr(self._comparison_hook, "observe")
+            observe(**arguments)
         except Exception:
             logger.warning(
                 "composition comparison hook failed; legacy export preserved",

--- a/tests/test_composition_receipts.py
+++ b/tests/test_composition_receipts.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from services.composition.adapter import CandidateIssue, CandidateIssueCode, CandidateIssueSeverity
+from services.composition.hook import PipelineCompositionComparisonHook
+from services.composition.models import CompositionStatus
+from services.composition.receipt import build_composition_comparison_receipt
+from services.composition.receipt_sink import CompositeCompositionReceiptSink, JsonCompositionReceiptSink
+from services.composition.shadow import CompositionShadowReport
+
+
+FIXED_TIME = datetime(2026, 7, 17, 5, 0, tzinfo=timezone.utc)
+
+
+def sample_report() -> CompositionShadowReport:
+    return CompositionShadowReport(
+        legacy_track_ids=("legacy-1", "legacy-2"),
+        canonical_track_ids=("legacy-2",),
+        canonical_status=CompositionStatus.PARTIAL,
+        canonical_failure_reason=None,
+        candidate_count=3,
+        adapted_count=2,
+        rejected_count=1,
+        fallback_count=1,
+        overlap_count=1,
+        position_match_count=0,
+        legacy_coverage_ratio=0.5,
+        canonical_coverage_ratio=1.0,
+        adaptation_issues=(
+            CandidateIssue("bad-track", CandidateIssueCode.INVALID_BPM, CandidateIssueSeverity.REJECTED),
+            CandidateIssue("legacy-2", CandidateIssueCode.DURATION_FALLBACK, CandidateIssueSeverity.FALLBACK),
+        ),
+        canonical_warnings=("target track count not reached",),
+    )
+
+
+def build_receipt(run_id: str = "pipeline-test"):
+    return build_composition_comparison_receipt(
+        run_id=run_id,
+        generated_at=FIXED_TIME,
+        target_track_count=2,
+        bpm_min=126.0,
+        bpm_max=132.0,
+        mode="club",
+        report=sample_report(),
+    )
+
+
+def test_receipt_is_stable_and_json_safe() -> None:
+    payload = build_receipt().to_dict()
+    assert payload["schema_version"] == "1.0"
+    assert payload["run_id"] == "pipeline-test"
+    assert payload["generated_at"] == "2026-07-17T05:00:00Z"
+    assert payload["quality"]["adaptation_issues"][0] == {
+        "track_id": "bad-track",
+        "code": "invalid_bpm",
+        "severity": "rejected",
+    }
+    json.dumps(payload)
+
+
+def test_receipt_requires_timezone_aware_timestamp() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        build_composition_comparison_receipt(
+            run_id="pipeline-test",
+            generated_at=datetime(2026, 7, 17, 5, 0),
+            target_track_count=2,
+            bpm_min=126.0,
+            bpm_max=132.0,
+            mode="club",
+            report=sample_report(),
+        )
+
+
+def test_json_sink_writes_atomically(tmp_path) -> None:
+    directory = tmp_path / "receipts"
+    JsonCompositionReceiptSink(directory).emit(build_receipt())
+    target = directory / "pipeline-test.json"
+    assert json.loads(target.read_text(encoding="utf-8"))["run_id"] == "pipeline-test"
+    assert list(directory.glob("*.tmp")) == []
+    assert list(directory.glob(".*.tmp")) == []
+
+
+@pytest.mark.parametrize("run_id", ["bad id", "bad?query", ".hidden"])
+def test_json_sink_rejects_unsafe_run_ids(tmp_path, run_id: str) -> None:
+    with pytest.raises(ValueError, match="unsafe"):
+        JsonCompositionReceiptSink(tmp_path).emit(build_receipt(run_id))
+
+
+class RecordingSink:
+    def __init__(self, fail: bool = False) -> None:
+        self.fail = fail
+        self.receipts = []
+
+    def emit(self, receipt) -> None:
+        self.receipts.append(receipt)
+        if self.fail:
+            raise RuntimeError("sink failed")
+
+
+def test_composite_sink_attempts_every_sink() -> None:
+    first = RecordingSink(fail=True)
+    second = RecordingSink()
+    receipt = build_receipt()
+    with pytest.raises(RuntimeError, match="1 composition receipt sink"):
+        CompositeCompositionReceiptSink((first, second)).emit(receipt)
+    assert first.receipts == [receipt]
+    assert second.receipts == [receipt]
+
+
+class StaticComparisonService:
+    def compare(self, request) -> CompositionShadowReport:
+        return sample_report()
+
+
+def test_hook_correlates_receipt_with_run_id() -> None:
+    sink = RecordingSink()
+    hook = PipelineCompositionComparisonHook(
+        service=StaticComparisonService(),
+        sink=sink,
+        clock=lambda: FIXED_TIME,
+    )
+    receipt = hook.observe(
+        run_id="pipeline-correlated",
+        legacy_track_ids=("legacy-1", "legacy-2"),
+        target_track_count=2,
+        bpm_min=126.0,
+        bpm_max=132.0,
+        mode="club",
+    )
+    assert receipt.run_id == "pipeline-correlated"
+    assert sink.receipts == [receipt]

--- a/tests/test_pipeline_composition_receipt_correlation.py
+++ b/tests/test_pipeline_composition_receipt_correlation.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from data.models.playlist_candidate import PlaylistCandidate
+from services.orchestrator.pipeline import OrchestratorPipeline
+
+
+class Composer:
+    def compose(self, limit: int):
+        return [
+            PlaylistCandidate(
+                track_id="track-1",
+                path="/music/track-1.mp3",
+                bpm=128.0,
+                camelot="8A",
+                energy=0.7,
+            )
+        ][:limit]
+
+
+class Exporter:
+    def export_m3u(self, *, playlist_id: str, tracks: list) -> dict:
+        return {"playlist_id": playlist_id, "track_count": len(tracks)}
+
+
+class CorrelatedHook:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def observe_run(self, **kwargs) -> object:
+        self.calls.append(kwargs)
+        return object()
+
+
+def test_pipeline_uses_same_run_id_for_export_and_receipt_hook() -> None:
+    hook = CorrelatedHook()
+    pipeline = OrchestratorPipeline(
+        composer=Composer(),
+        exporter=Exporter(),
+        run_id_factory=lambda: "pipeline-correlated",
+        comparison_hook=hook,
+        comparison_enabled=True,
+    )
+
+    result = pipeline.run(path="/music", limit=1, mode="club")
+
+    assert result["export"]["playlist_id"] == "pipeline-correlated"
+    assert hook.calls[0]["run_id"] == result["export"]["playlist_id"]
+    assert hook.calls[0]["legacy_track_ids"] == ("track-1",)


### PR DESCRIPTION
## Summary
- add immutable, JSON-safe composition comparison receipts
- correlate receipts with the same run ID used by the legacy exporter
- add optional atomic local JSON persistence below the configured artifacts directory
- reject unsafe receipt run IDs
- preserve logging as the default sink and fail-open pipeline behavior
- add serialization, persistence, compatibility and correlation tests

## Verification
- branch created directly from Bundle 33 squash commit `169fbe667d7e64f4b34129c911f82f790c19fa7e`
- ahead-only diff limited to ten configuration, composition, pipeline, test and documentation files
- Python 3.11 and 3.12 CI required
- install, compile, critical Ruff and full pytest must pass
- no local test execution is claimed

## Isolation
- both comparison and local receipt persistence remain disabled by default
- no API response or database schema change
- no canonical playlist export or external telemetry backend
- generated receipts stay below the ignored `artifacts/` tree

## Bundle Context
- Bundle: 34 — Composition Comparison Receipts
- Base branch: `feature/bundle-0-bootstrap`
- Base commit: `169fbe667d7e64f4b34129c911f82f790c19fa7e`
- Related issue: #43
- Rollback: disable either flag or revert the future squash commit; no data rollback required