### PR TITLE
Bundle 35: canonical composition runner

### DIFF
--- a/docs/bundles/BUNDLE_35_CANONICAL_COMPOSITION_RUNNER.md
+++ b/docs/bundles/BUNDLE_35_CANONICAL_COMPOSITION_RUNNER.md
@@ -1,0 +1,76 @@
+# Bundle 35 — Canonical Composition Runner
+
+## Status
+
+Implementation candidate. Production pipeline authority remains unchanged.
+
+## Goal
+
+Provide one reusable canonical execution boundary for loading analyzed tracks, adapting historical data and running deterministic composition.
+
+## Execution flow
+
+```text
+AnalysisRepository
+      │
+      ▼
+PlaylistCandidate[]
+      │
+      ▼
+fail-closed candidate adapter
+      │
+      ▼
+CompositionTrack[]
+      │
+      ▼
+DeterministicCompositionEngine
+      │
+      ▼
+CanonicalCompositionExecutionResult
+```
+
+## Contracts
+
+`CanonicalCompositionExecutionRequest` contains:
+
+- target track count,
+- BPM range,
+- composition mode,
+- optional genre,
+- optional start key,
+- explicit duration fallback.
+
+`CanonicalCompositionExecutionResult` contains:
+
+- the immutable `CompositionResult`,
+- directly exportable `CompositionTrack` values,
+- source candidate count,
+- adapted count,
+- rejected count,
+- fallback count,
+- complete adapter issue evidence.
+
+## Failure ordering
+
+Composition mode validation occurs before repository access. Candidate validation remains fail-closed for missing or malformed track ID, path, BPM, Camelot key and energy.
+
+A duration fallback is allowed only when explicitly represented by a `duration_fallback` issue.
+
+## Comparison integration
+
+`CompositionShadowService` delegates canonical execution to the runner and only calculates legacy/canonical comparison metrics. Existing repository and engine injection remain supported for compatibility.
+
+## Isolation
+
+Bundle 35 does not:
+
+- switch the production pipeline,
+- export a canonical playlist,
+- change API responses,
+- change receipt schemas,
+- create a database migration,
+- perform filesystem or network I/O beyond the existing repository read.
+
+## Rollback
+
+Revert the Bundle 35 squash commit. No data rollback is required.

--- a/services/composition/__init__.py
+++ b/services/composition/__init__.py
@@ -34,6 +34,12 @@ from services.composition.receipt_sink import (
     CompositeCompositionReceiptSink,
     JsonCompositionReceiptSink,
 )
+from services.composition.runner import (
+    CanonicalCompositionExecutionRequest,
+    CanonicalCompositionExecutionResult,
+    CanonicalCompositionRunner,
+    parse_composition_mode,
+)
 from services.composition.shadow import (
     CompositionShadowReport,
     CompositionShadowService,
@@ -45,6 +51,9 @@ __all__ = [
     "CandidateIssue",
     "CandidateIssueCode",
     "CandidateIssueSeverity",
+    "CanonicalCompositionExecutionRequest",
+    "CanonicalCompositionExecutionResult",
+    "CanonicalCompositionRunner",
     "CompositeCompositionReceiptSink",
     "CompositionComparisonReceipt",
     "CompositionConstraints",
@@ -70,4 +79,5 @@ __all__ = [
     "TransitionScore",
     "adapt_playlist_candidates",
     "build_composition_comparison_receipt",
+    "parse_composition_mode",
 ]

--- a/services/composition/runner.py
+++ b/services/composition/runner.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from data.models.playlist_candidate import PlaylistCandidate
+from data.repositories.analysis_repository import AnalysisRepository
+from services.composition.adapter import CandidateIssue, adapt_playlist_candidates
+from services.composition.engine import DeterministicCompositionEngine
+from services.composition.models import (
+    CompositionMode,
+    CompositionRequest,
+    CompositionResult,
+    CompositionTrack,
+)
+
+
+class PlaylistCandidateRepository(Protocol):
+    def list_playlist_candidates(self) -> list[PlaylistCandidate]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalCompositionExecutionRequest:
+    target_track_count: int
+    bpm_min: float = 1.0
+    bpm_max: float = 300.0
+    mode: CompositionMode | str = CompositionMode.CLUB
+    genre: str | None = None
+    start_key: str | None = None
+    duration_fallback_seconds: int = 300
+
+    def __post_init__(self) -> None:
+        if self.target_track_count <= 0:
+            raise ValueError("target_track_count must be greater than zero")
+        if self.bpm_min <= 0 or self.bpm_max <= 0:
+            raise ValueError("BPM range values must be greater than zero")
+        if self.bpm_min > self.bpm_max:
+            raise ValueError("bpm_min must be less than or equal to bpm_max")
+        if self.duration_fallback_seconds <= 0:
+            raise ValueError("duration_fallback_seconds must be greater than zero")
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalCompositionExecutionResult:
+    composition: CompositionResult
+    candidate_count: int
+    adapted_count: int
+    rejected_count: int
+    fallback_count: int
+    adaptation_issues: tuple[CandidateIssue, ...]
+
+    @property
+    def tracks(self) -> tuple[CompositionTrack, ...]:
+        return self.composition.tracks
+
+
+class CanonicalCompositionRunner:
+    """Execute canonical composition without exporting or mutating source data."""
+
+    def __init__(
+        self,
+        *,
+        repository: PlaylistCandidateRepository | None = None,
+        engine: DeterministicCompositionEngine | None = None,
+    ) -> None:
+        self._repository = (
+            repository if repository is not None else AnalysisRepository()
+        )
+        self._engine = (
+            engine if engine is not None else DeterministicCompositionEngine()
+        )
+
+    def run(
+        self,
+        request: CanonicalCompositionExecutionRequest,
+    ) -> CanonicalCompositionExecutionResult:
+        mode = parse_composition_mode(request.mode)
+        candidates = self._repository.list_playlist_candidates()
+        adaptation = adapt_playlist_candidates(
+            candidates,
+            duration_fallback_seconds=request.duration_fallback_seconds,
+        )
+        composition = self._engine.compose(
+            CompositionRequest(
+                tracks=adaptation.tracks,
+                target_track_count=request.target_track_count,
+                bpm_min=request.bpm_min,
+                bpm_max=request.bpm_max,
+                mode=mode,
+                genre=request.genre,
+                start_key=request.start_key,
+            )
+        )
+        return CanonicalCompositionExecutionResult(
+            composition=composition,
+            candidate_count=len(candidates),
+            adapted_count=len(adaptation.tracks),
+            rejected_count=adaptation.rejected_count,
+            fallback_count=adaptation.fallback_count,
+            adaptation_issues=adaptation.issues,
+        )
+
+
+def parse_composition_mode(value: CompositionMode | str) -> CompositionMode:
+    if isinstance(value, CompositionMode):
+        return value
+    if not isinstance(value, str):
+        raise ValueError(f"Unsupported composition mode: {value!r}")
+    normalized = value.strip().casefold()
+    try:
+        return CompositionMode(normalized)
+    except ValueError as exc:
+        allowed = ", ".join(mode.value for mode in CompositionMode)
+        raise ValueError(
+            f"Unsupported composition mode: {value!r}; allowed: {allowed}"
+        ) from exc

--- a/services/composition/shadow.py
+++ b/services/composition/shadow.py
@@ -3,23 +3,26 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Protocol
 
-from data.models.playlist_candidate import PlaylistCandidate
-from data.repositories.analysis_repository import AnalysisRepository
-from services.composition.adapter import (
-    CandidateIssue,
-    adapt_playlist_candidates,
-)
+from services.composition.adapter import CandidateIssue
 from services.composition.engine import DeterministicCompositionEngine
 from services.composition.models import (
     CompositionFailureReason,
     CompositionMode,
-    CompositionRequest,
     CompositionStatus,
+)
+from services.composition.runner import (
+    CanonicalCompositionExecutionRequest,
+    CanonicalCompositionExecutionResult,
+    CanonicalCompositionRunner,
+    PlaylistCandidateRepository,
 )
 
 
-class PlaylistCandidateRepository(Protocol):
-    def list_playlist_candidates(self) -> list[PlaylistCandidate]: ...
+class CanonicalCompositionExecutor(Protocol):
+    def run(
+        self,
+        request: CanonicalCompositionExecutionRequest,
+    ) -> CanonicalCompositionExecutionResult: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -71,36 +74,33 @@ class CompositionShadowService:
     def __init__(
         self,
         *,
+        runner: CanonicalCompositionExecutor | None = None,
         repository: PlaylistCandidateRepository | None = None,
         engine: DeterministicCompositionEngine | None = None,
     ) -> None:
-        self._repository = (
-            repository if repository is not None else AnalysisRepository()
-        )
-        self._engine = (
-            engine if engine is not None else DeterministicCompositionEngine()
+        if runner is not None and (repository is not None or engine is not None):
+            raise ValueError("runner cannot be combined with repository or engine")
+        self._runner = (
+            runner
+            if runner is not None
+            else CanonicalCompositionRunner(repository=repository, engine=engine)
         )
 
     def compare(self, request: ShadowComparisonRequest) -> CompositionShadowReport:
-        mode = _parse_mode(request.mode)
         legacy_ids = tuple(track_id.strip() for track_id in request.legacy_track_ids)
-        candidates = self._repository.list_playlist_candidates()
-        adaptation = adapt_playlist_candidates(
-            candidates,
-            duration_fallback_seconds=request.duration_fallback_seconds,
-        )
-        canonical = self._engine.compose(
-            CompositionRequest(
-                tracks=adaptation.tracks,
+        execution = self._runner.run(
+            CanonicalCompositionExecutionRequest(
                 target_track_count=request.target_track_count,
                 bpm_min=request.bpm_min,
                 bpm_max=request.bpm_max,
-                mode=mode,
+                mode=request.mode,
                 genre=request.genre,
                 start_key=request.start_key,
+                duration_fallback_seconds=request.duration_fallback_seconds,
             )
         )
-        canonical_ids = tuple(track.track_id for track in canonical.tracks)
+        canonical = execution.composition
+        canonical_ids = tuple(track.track_id for track in execution.tracks)
         legacy_set = set(legacy_ids)
         canonical_set = set(canonical_ids)
         overlap_count = len(legacy_set & canonical_set)
@@ -114,30 +114,17 @@ class CompositionShadowService:
             canonical_track_ids=canonical_ids,
             canonical_status=canonical.status,
             canonical_failure_reason=canonical.failure_reason,
-            candidate_count=len(candidates),
-            adapted_count=len(adaptation.tracks),
-            rejected_count=adaptation.rejected_count,
-            fallback_count=adaptation.fallback_count,
+            candidate_count=execution.candidate_count,
+            adapted_count=execution.adapted_count,
+            rejected_count=execution.rejected_count,
+            fallback_count=execution.fallback_count,
             overlap_count=overlap_count,
             position_match_count=position_match_count,
             legacy_coverage_ratio=_ratio(overlap_count, len(legacy_set)),
             canonical_coverage_ratio=_ratio(overlap_count, len(canonical_set)),
-            adaptation_issues=adaptation.issues,
+            adaptation_issues=execution.adaptation_issues,
             canonical_warnings=canonical.warnings,
         )
-
-
-def _parse_mode(value: CompositionMode | str) -> CompositionMode:
-    if isinstance(value, CompositionMode):
-        return value
-    normalized = value.strip().casefold()
-    try:
-        return CompositionMode(normalized)
-    except ValueError as exc:
-        allowed = ", ".join(mode.value for mode in CompositionMode)
-        raise ValueError(
-            f"Unsupported composition mode: {value!r}; allowed: {allowed}"
-        ) from exc
 
 
 def _ratio(numerator: int, denominator: int) -> float:

--- a/tests/test_canonical_composition_runner.py
+++ b/tests/test_canonical_composition_runner.py
@@ -1,0 +1,157 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from data.models.playlist_candidate import PlaylistCandidate
+from services.composition import (
+    CandidateIssueCode,
+    CanonicalCompositionExecutionRequest,
+    CanonicalCompositionRunner,
+    CompositionMode,
+    CompositionResult,
+    CompositionStatus,
+    CompositionSummary,
+)
+
+
+class FakeRepository:
+    def __init__(self, candidates: list[PlaylistCandidate]) -> None:
+        self.candidates = candidates
+        self.calls = 0
+
+    def list_playlist_candidates(self) -> list[PlaylistCandidate]:
+        self.calls += 1
+        return list(self.candidates)
+
+
+def candidate(
+    track_id: str,
+    *,
+    bpm: float | None,
+    camelot: str | None,
+    energy: float | None,
+    duration_seconds: float | None = 300.0,
+) -> PlaylistCandidate:
+    return PlaylistCandidate(
+        track_id=track_id,
+        path=f"/music/{track_id}.mp3",
+        title=track_id,
+        artist=f"artist-{track_id}",
+        genre="tech house",
+        source=f"pool-{track_id}",
+        duration_seconds=duration_seconds,
+        bpm=bpm,
+        camelot=camelot,
+        energy=energy,
+    )
+
+
+def test_runner_returns_exportable_tracks_and_quality_evidence() -> None:
+    repository = FakeRepository(
+        [
+            candidate("a", bpm=124.0, camelot="8A", energy=0.3),
+            candidate(
+                "b",
+                bpm=125.0,
+                camelot="9A",
+                energy=0.6,
+                duration_seconds=None,
+            ),
+            candidate("bad", bpm=None, camelot="10A", energy=0.5),
+        ]
+    )
+
+    result = CanonicalCompositionRunner(repository=repository).run(
+        CanonicalCompositionExecutionRequest(
+            target_track_count=2,
+            bpm_min=120.0,
+            bpm_max=130.0,
+            mode="club",
+            genre="tech house",
+        )
+    )
+
+    assert repository.calls == 1
+    assert result.composition.status == CompositionStatus.SUCCESS
+    assert {track.track_id for track in result.tracks} == {"a", "b"}
+    assert all(track.path.startswith("/music/") for track in result.tracks)
+    assert result.candidate_count == 3
+    assert result.adapted_count == 2
+    assert result.rejected_count == 1
+    assert result.fallback_count == 1
+    assert {issue.code for issue in result.adaptation_issues} == {
+        CandidateIssueCode.INVALID_BPM,
+        CandidateIssueCode.DURATION_FALLBACK,
+    }
+
+
+def test_invalid_mode_fails_before_repository_access() -> None:
+    repository = FakeRepository([])
+    runner = CanonicalCompositionRunner(repository=repository)
+
+    with pytest.raises(ValueError, match="Unsupported composition mode"):
+        runner.run(
+            CanonicalCompositionExecutionRequest(
+                target_track_count=1,
+                mode="not-a-mode",
+            )
+        )
+
+    assert repository.calls == 0
+
+
+class RecordingEngine:
+    def __init__(self) -> None:
+        self.requests = []
+
+    def compose(self, request) -> CompositionResult:
+        self.requests.append(request)
+        return CompositionResult(
+            status=CompositionStatus.FAILED,
+            tracks=(),
+            decisions=(),
+            summary=CompositionSummary(
+                track_count=0,
+                total_duration_seconds=0,
+                average_bpm=0.0,
+                minimum_bpm=0.0,
+                maximum_bpm=0.0,
+                average_energy=0.0,
+            ),
+        )
+
+
+def test_runner_forwards_explicit_controls_to_injected_engine() -> None:
+    engine = RecordingEngine()
+    runner = CanonicalCompositionRunner(
+        repository=FakeRepository([]),
+        engine=engine,
+    )
+
+    runner.run(
+        CanonicalCompositionExecutionRequest(
+            target_track_count=7,
+            bpm_min=126.0,
+            bpm_max=134.0,
+            mode=CompositionMode.AFTERHOURS,
+            genre="hypnotic techno",
+            start_key="8A",
+        )
+    )
+
+    request = engine.requests[0]
+    assert request.target_track_count == 7
+    assert request.bpm_min == 126.0
+    assert request.bpm_max == 134.0
+    assert request.mode == CompositionMode.AFTERHOURS
+    assert request.genre == "hypnotic techno"
+    assert request.start_key == "8A"
+
+
+def test_execution_result_is_immutable() -> None:
+    result = CanonicalCompositionRunner(repository=FakeRepository([])).run(
+        CanonicalCompositionExecutionRequest(target_track_count=1)
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        result.candidate_count = 99

--- a/tests/test_composition_shadow_runner_delegation.py
+++ b/tests/test_composition_shadow_runner_delegation.py
@@ -1,0 +1,85 @@
+import pytest
+
+from services.composition import (
+    CanonicalCompositionExecutionResult,
+    CompositionResult,
+    CompositionShadowService,
+    CompositionStatus,
+    CompositionSummary,
+    CompositionTrack,
+    ShadowComparisonRequest,
+)
+
+
+class RecordingRunner:
+    def __init__(self) -> None:
+        self.requests = []
+
+    def run(self, request) -> CanonicalCompositionExecutionResult:
+        self.requests.append(request)
+        track = CompositionTrack(
+            track_id="canonical-1",
+            path="/music/canonical-1.mp3",
+            bpm=128.0,
+            camelot="8A",
+            energy=0.6,
+        )
+        return CanonicalCompositionExecutionResult(
+            composition=CompositionResult(
+                status=CompositionStatus.SUCCESS,
+                tracks=(track,),
+                decisions=(),
+                summary=CompositionSummary(
+                    track_count=1,
+                    total_duration_seconds=300,
+                    average_bpm=128.0,
+                    minimum_bpm=128.0,
+                    maximum_bpm=128.0,
+                    average_energy=0.6,
+                ),
+            ),
+            candidate_count=4,
+            adapted_count=3,
+            rejected_count=1,
+            fallback_count=1,
+            adaptation_issues=(),
+        )
+
+
+def test_shadow_service_delegates_canonical_execution_to_runner() -> None:
+    runner = RecordingRunner()
+    service = CompositionShadowService(runner=runner)
+
+    report = service.compare(
+        ShadowComparisonRequest(
+            legacy_track_ids=("canonical-1", "legacy-2"),
+            target_track_count=3,
+            bpm_min=124.0,
+            bpm_max=132.0,
+            mode="afterhours",
+            genre="hypnotic techno",
+            start_key="8A",
+            duration_fallback_seconds=240,
+        )
+    )
+
+    request = runner.requests[0]
+    assert request.target_track_count == 3
+    assert request.bpm_min == 124.0
+    assert request.bpm_max == 132.0
+    assert request.mode == "afterhours"
+    assert request.genre == "hypnotic techno"
+    assert request.start_key == "8A"
+    assert request.duration_fallback_seconds == 240
+    assert report.canonical_track_ids == ("canonical-1",)
+    assert report.overlap_count == 1
+    assert report.position_match_count == 1
+    assert report.candidate_count == 4
+    assert report.adapted_count == 3
+    assert report.rejected_count == 1
+    assert report.fallback_count == 1
+
+
+def test_shadow_service_rejects_ambiguous_dependency_configuration() -> None:
+    with pytest.raises(ValueError, match="runner cannot be combined"):
+        CompositionShadowService(runner=RecordingRunner(), repository=object())


### PR DESCRIPTION
## Summary
- add a reusable canonical composition runner
- return immutable exportable tracks plus adaptation and quality evidence
- validate composition mode before repository access
- delegate comparison execution to the runner
- preserve repository and engine injection compatibility
- add runner, delegation and regression tests

## Verification
- branch created directly from Bundle 34 squash commit `87fbca432edf4fa6f32d1e3a5f506b1abd73ce4c`
- ahead-only diff limited to six composition, test and documentation files
- Python 3.11 and 3.12 CI required
- install, compile, critical Ruff and full pytest must pass
- no local test execution is claimed

## Isolation
- production pipeline remains legacy-authoritative
- no canonical export or API response change
- no database migration, receipt schema change or new filesystem write

## Bundle Context
- Bundle: 35 — Canonical Composition Runner
- Base branch: `feature/bundle-0-bootstrap`
- Base commit: `87fbca432edf4fa6f32d1e3a5f506b1abd73ce4c`
- Related issue: #45
- Rollback: close this PR or revert the future squash commit; no data rollback required