### PR TITLE
Bundle 36: canonical composition export service

### DIFF
--- a/docs/bundles/BUNDLE_36_CANONICAL_COMPOSITION_EXPORT.md
+++ b/docs/bundles/BUNDLE_36_CANONICAL_COMPOSITION_EXPORT.md
@@ -1,0 +1,75 @@
+# Bundle 36 — Canonical Composition Export Service
+
+## Status
+
+Implementation candidate. The production pipeline remains legacy-authoritative.
+
+## Goal
+
+Provide an explicit service that can execute the canonical composition runner and materialize its result through the existing exporter without changing API or pipeline behavior.
+
+## Flow
+
+```text
+CanonicalCompositionExecutionRequest
+                │
+                ▼
+CanonicalCompositionRunner
+                │
+                ▼
+CanonicalCompositionExecutionResult
+                │
+      failed or empty? ── yes ──► no export
+                │ no
+                ▼
+validated canonical run ID
+                │
+                ▼
+Exporter.export_m3u
+                │
+                ▼
+validated immutable export artifact
+```
+
+## Postconditions
+
+A successful canonical export requires:
+
+- a run ID matching `canonical-[A-Za-z0-9_-]+`,
+- exporter `playlist_id` equal to the generated run ID,
+- `resolved_count` equal to the canonical track count,
+- `skipped_count` equal to zero,
+- non-empty M3U, manifest, warnings and audit paths.
+
+Any violated postcondition raises a controlled runtime error instead of returning a misleading success contract.
+
+## Empty and failed results
+
+Failed canonical composition or an empty track set returns an immutable result with:
+
+- `run_id=None`,
+- `artifact=None`,
+- `exported=False`.
+
+The exporter is not invoked.
+
+## Isolation
+
+Bundle 36 does not:
+
+- switch `OrchestratorPipeline`,
+- add or modify API routes,
+- change comparison receipts,
+- activate a feature flag,
+- change the database schema,
+- call external services.
+
+The service must be invoked explicitly by future controlled rollout code.
+
+## Filesystem behavior
+
+The existing `Exporter` owns filesystem writes. Integration tests use isolated temporary export and artifact directories and verify M3U, manifest, warnings and audit outputs.
+
+## Rollback
+
+Revert the Bundle 36 squash commit. No data rollback is required because the service is not automatically invoked.

--- a/services/composition/__init__.py
+++ b/services/composition/__init__.py
@@ -6,6 +6,11 @@ from services.composition.adapter import (
     adapt_playlist_candidates,
 )
 from services.composition.engine import DeterministicCompositionEngine
+from services.composition.export_service import (
+    CanonicalCompositionExportArtifact,
+    CanonicalCompositionExportResult,
+    CanonicalCompositionExportService,
+)
 from services.composition.hook import (
     LoggingCompositionReceiptSink,
     PipelineCompositionComparisonHook,
@@ -53,6 +58,9 @@ __all__ = [
     "CandidateIssueSeverity",
     "CanonicalCompositionExecutionRequest",
     "CanonicalCompositionExecutionResult",
+    "CanonicalCompositionExportArtifact",
+    "CanonicalCompositionExportResult",
+    "CanonicalCompositionExportService",
     "CanonicalCompositionRunner",
     "CompositeCompositionReceiptSink",
     "CompositionComparisonReceipt",

--- a/services/composition/export_service.py
+++ b/services/composition/export_service.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Protocol
+from uuid import uuid4
+
+from services.composition.models import CompositionStatus, CompositionTrack
+from services.composition.runner import (
+    CanonicalCompositionExecutionRequest,
+    CanonicalCompositionExecutionResult,
+    CanonicalCompositionRunner,
+)
+from services.export.exporter import Exporter
+
+
+_SAFE_RUN_ID = re.compile(r"^canonical-[A-Za-z0-9_-]{1,96}$")
+
+
+class CanonicalCompositionExecutor(Protocol):
+    def run(
+        self,
+        request: CanonicalCompositionExecutionRequest,
+    ) -> CanonicalCompositionExecutionResult: ...
+
+
+class PlaylistExporter(Protocol):
+    def export_m3u(
+        self,
+        *,
+        playlist_id: str,
+        tracks: list[CompositionTrack],
+    ) -> dict: ...
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalCompositionExportArtifact:
+    playlist_id: str
+    m3u_path: str
+    manifest_path: str
+    warnings_path: str
+    audit_path: str
+    resolved_count: int
+    skipped_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalCompositionExportResult:
+    execution: CanonicalCompositionExecutionResult
+    run_id: str | None
+    artifact: CanonicalCompositionExportArtifact | None
+
+    @property
+    def exported(self) -> bool:
+        return self.artifact is not None
+
+
+class CanonicalCompositionExportService:
+    """Explicit canonical export boundary; never invoked by the legacy pipeline."""
+
+    def __init__(
+        self,
+        *,
+        runner: CanonicalCompositionExecutor | None = None,
+        exporter: PlaylistExporter | None = None,
+        run_id_factory: Callable[[], str] | None = None,
+    ) -> None:
+        self._runner = runner if runner is not None else CanonicalCompositionRunner()
+        self._exporter = exporter if exporter is not None else Exporter()
+        self._run_id_factory = run_id_factory or _new_canonical_run_id
+
+    def execute(
+        self,
+        request: CanonicalCompositionExecutionRequest,
+    ) -> CanonicalCompositionExportResult:
+        execution = self._runner.run(request)
+        if (
+            execution.composition.status == CompositionStatus.FAILED
+            or not execution.tracks
+        ):
+            return CanonicalCompositionExportResult(
+                execution=execution,
+                run_id=None,
+                artifact=None,
+            )
+
+        run_id = _validate_run_id(self._run_id_factory())
+        raw_artifact = self._exporter.export_m3u(
+            playlist_id=run_id,
+            tracks=list(execution.tracks),
+        )
+        artifact = _materialize_artifact(
+            raw_artifact,
+            expected_run_id=run_id,
+            expected_track_count=len(execution.tracks),
+        )
+        return CanonicalCompositionExportResult(
+            execution=execution,
+            run_id=run_id,
+            artifact=artifact,
+        )
+
+
+def _new_canonical_run_id() -> str:
+    return f"canonical-{uuid4().hex}"
+
+
+def _validate_run_id(value: object) -> str:
+    if not isinstance(value, str):
+        raise RuntimeError("Canonical run ID factory returned a non-string identifier")
+    normalized = value.strip()
+    if not _SAFE_RUN_ID.fullmatch(normalized):
+        raise RuntimeError("Canonical run ID factory returned an unsafe identifier")
+    return normalized
+
+
+def _materialize_artifact(
+    payload: Mapping[str, object],
+    *,
+    expected_run_id: str,
+    expected_track_count: int,
+) -> CanonicalCompositionExportArtifact:
+    playlist_id = _required_text(payload, "playlist_id")
+    if playlist_id != expected_run_id:
+        raise RuntimeError("Exporter returned a mismatched playlist identifier")
+
+    resolved_count = _required_count(payload, "resolved_count")
+    skipped_count = _required_count(payload, "skipped_count")
+    if resolved_count != expected_track_count:
+        raise RuntimeError("Exporter did not resolve every canonical track")
+    if skipped_count != 0:
+        raise RuntimeError("Exporter skipped one or more canonical tracks")
+
+    return CanonicalCompositionExportArtifact(
+        playlist_id=playlist_id,
+        m3u_path=_required_text(payload, "m3u_path"),
+        manifest_path=_required_text(payload, "manifest_path"),
+        warnings_path=_required_text(payload, "warnings_path"),
+        audit_path=_required_text(payload, "audit_path"),
+        resolved_count=resolved_count,
+        skipped_count=skipped_count,
+    )
+
+
+def _required_text(payload: Mapping[str, object], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise RuntimeError(f"Exporter returned an invalid {key}")
+    return value.strip()
+
+
+def _required_count(payload: Mapping[str, object], key: str) -> int:
+    value = payload.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise RuntimeError(f"Exporter returned an invalid {key}")
+    return value

--- a/tests/test_canonical_composition_export_integration.py
+++ b/tests/test_canonical_composition_export_integration.py
@@ -1,0 +1,104 @@
+import json
+
+from services.composition import (
+    CanonicalCompositionExecutionRequest,
+    CanonicalCompositionExecutionResult,
+    CanonicalCompositionExportService,
+    CompositionResult,
+    CompositionStatus,
+    CompositionSummary,
+    CompositionTrack,
+)
+from services.export.exporter import Exporter
+
+
+class StaticRunner:
+    def run(self, request) -> CanonicalCompositionExecutionResult:
+        tracks = (
+            CompositionTrack(
+                track_id="canonical-a",
+                path="/music/canonical-a.mp3",
+                bpm=126.0,
+                camelot="8A",
+                energy=0.4,
+            ),
+            CompositionTrack(
+                track_id="canonical-b",
+                path="/music/canonical-b.mp3",
+                bpm=128.0,
+                camelot="9A",
+                energy=0.7,
+            ),
+        )
+        return CanonicalCompositionExecutionResult(
+            composition=CompositionResult(
+                status=CompositionStatus.SUCCESS,
+                tracks=tracks,
+                decisions=(),
+                summary=CompositionSummary(
+                    track_count=2,
+                    total_duration_seconds=600,
+                    average_bpm=127.0,
+                    minimum_bpm=126.0,
+                    maximum_bpm=128.0,
+                    average_energy=0.55,
+                ),
+            ),
+            candidate_count=2,
+            adapted_count=2,
+            rejected_count=0,
+            fallback_count=0,
+            adaptation_issues=(),
+        )
+
+
+def test_real_exporter_materializes_canonical_playlist_and_evidence(tmp_path) -> None:
+    exports_dir = tmp_path / "exports"
+    artifacts_dir = tmp_path / "artifacts"
+    service = CanonicalCompositionExportService(
+        runner=StaticRunner(),
+        exporter=Exporter(
+            exports_dir=exports_dir,
+            artifacts_dir=artifacts_dir,
+        ),
+        run_id_factory=lambda: "canonical-integration",
+    )
+
+    result = service.execute(
+        CanonicalCompositionExecutionRequest(target_track_count=2)
+    )
+
+    assert result.artifact is not None
+    artifact = result.artifact
+    assert artifact.resolved_count == 2
+    assert artifact.skipped_count == 0
+
+    m3u = (exports_dir / "canonical-integration.m3u").read_text(encoding="utf-8")
+    assert "/music/canonical-a.mp3" in m3u
+    assert "/music/canonical-b.mp3" in m3u
+
+    manifest = json.loads(
+        (artifacts_dir / "canonical-integration.manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    audit = json.loads(
+        (artifacts_dir / "canonical-integration.audit.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    warnings = json.loads(
+        (artifacts_dir / "canonical-integration.warnings.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert manifest["playlist_id"] == "canonical-integration"
+    assert manifest["resolved_count"] == 2
+    assert manifest["skipped_count"] == 0
+    assert [item["track_id"] for item in audit["resolved"]] == [
+        "canonical-a",
+        "canonical-b",
+    ]
+    assert audit["skipped"] == []
+    assert warnings == []

--- a/tests/test_canonical_composition_export_service.py
+++ b/tests/test_canonical_composition_export_service.py
@@ -1,0 +1,182 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from services.composition import (
+    CanonicalCompositionExecutionRequest,
+    CanonicalCompositionExecutionResult,
+    CanonicalCompositionExportService,
+    CompositionResult,
+    CompositionStatus,
+    CompositionSummary,
+    CompositionTrack,
+)
+
+
+def composition_result(
+    *,
+    status: CompositionStatus,
+    tracks: tuple[CompositionTrack, ...],
+) -> CompositionResult:
+    return CompositionResult(
+        status=status,
+        tracks=tracks,
+        decisions=(),
+        summary=CompositionSummary(
+            track_count=len(tracks),
+            total_duration_seconds=sum(track.duration_seconds for track in tracks),
+            average_bpm=(sum(track.bpm for track in tracks) / len(tracks)) if tracks else 0.0,
+            minimum_bpm=min((track.bpm for track in tracks), default=0.0),
+            maximum_bpm=max((track.bpm for track in tracks), default=0.0),
+            average_energy=(sum(track.energy for track in tracks) / len(tracks)) if tracks else 0.0,
+        ),
+    )
+
+
+def execution(
+    *,
+    status: CompositionStatus = CompositionStatus.SUCCESS,
+    tracks: tuple[CompositionTrack, ...] | None = None,
+) -> CanonicalCompositionExecutionResult:
+    resolved_tracks = tracks if tracks is not None else (
+        CompositionTrack(
+            track_id="canonical-1",
+            path="/music/canonical-1.mp3",
+            bpm=128.0,
+            camelot="8A",
+            energy=0.6,
+        ),
+    )
+    return CanonicalCompositionExecutionResult(
+        composition=composition_result(status=status, tracks=resolved_tracks),
+        candidate_count=len(resolved_tracks),
+        adapted_count=len(resolved_tracks),
+        rejected_count=0,
+        fallback_count=0,
+        adaptation_issues=(),
+    )
+
+
+class StaticRunner:
+    def __init__(self, value: CanonicalCompositionExecutionResult) -> None:
+        self.value = value
+        self.requests = []
+
+    def run(self, request) -> CanonicalCompositionExecutionResult:
+        self.requests.append(request)
+        return self.value
+
+
+class RecordingExporter:
+    def __init__(self, payload: dict | None = None) -> None:
+        self.payload = payload
+        self.calls = []
+
+    def export_m3u(self, *, playlist_id: str, tracks: list) -> dict:
+        self.calls.append({"playlist_id": playlist_id, "tracks": list(tracks)})
+        if self.payload is not None:
+            return dict(self.payload)
+        return {
+            "playlist_id": playlist_id,
+            "m3u_path": f"exports/{playlist_id}.m3u",
+            "manifest_path": f"artifacts/{playlist_id}.manifest.json",
+            "warnings_path": f"artifacts/{playlist_id}.warnings.json",
+            "audit_path": f"artifacts/{playlist_id}.audit.json",
+            "resolved_count": len(tracks),
+            "skipped_count": 0,
+        }
+
+
+def test_successful_execution_exports_with_generated_safe_id() -> None:
+    runner = StaticRunner(execution())
+    exporter = RecordingExporter()
+    service = CanonicalCompositionExportService(
+        runner=runner,
+        exporter=exporter,
+        run_id_factory=lambda: "canonical-test",
+    )
+
+    result = service.execute(CanonicalCompositionExecutionRequest(target_track_count=1))
+
+    assert result.exported is True
+    assert result.run_id == "canonical-test"
+    assert result.artifact is not None
+    assert result.artifact.playlist_id == "canonical-test"
+    assert result.artifact.resolved_count == 1
+    assert result.artifact.skipped_count == 0
+    assert exporter.calls[0]["playlist_id"] == "canonical-test"
+    assert [track.track_id for track in exporter.calls[0]["tracks"]] == ["canonical-1"]
+
+
+def test_failed_or_empty_execution_does_not_export() -> None:
+    exporter = RecordingExporter()
+    service = CanonicalCompositionExportService(
+        runner=StaticRunner(execution(status=CompositionStatus.FAILED, tracks=())),
+        exporter=exporter,
+        run_id_factory=lambda: "canonical-unused",
+    )
+
+    result = service.execute(CanonicalCompositionExecutionRequest(target_track_count=1))
+
+    assert result.exported is False
+    assert result.run_id is None
+    assert result.artifact is None
+    assert exporter.calls == []
+
+
+@pytest.mark.parametrize("run_id", ["canonical bad", "legacy-1", "canonical-", ".hidden"])
+def test_unsafe_generated_run_id_fails_before_export(run_id: str) -> None:
+    exporter = RecordingExporter()
+    service = CanonicalCompositionExportService(
+        runner=StaticRunner(execution()),
+        exporter=exporter,
+        run_id_factory=lambda: run_id,
+    )
+
+    with pytest.raises(RuntimeError, match="unsafe identifier"):
+        service.execute(CanonicalCompositionExecutionRequest(target_track_count=1))
+
+    assert exporter.calls == []
+
+
+def test_exporter_identity_and_counts_are_fail_closed() -> None:
+    bad_payloads = [
+        {
+            "playlist_id": "canonical-other",
+            "m3u_path": "x",
+            "manifest_path": "x",
+            "warnings_path": "x",
+            "audit_path": "x",
+            "resolved_count": 1,
+            "skipped_count": 0,
+        },
+        {
+            "playlist_id": "canonical-test",
+            "m3u_path": "x",
+            "manifest_path": "x",
+            "warnings_path": "x",
+            "audit_path": "x",
+            "resolved_count": 0,
+            "skipped_count": 1,
+        },
+    ]
+
+    for payload in bad_payloads:
+        service = CanonicalCompositionExportService(
+            runner=StaticRunner(execution()),
+            exporter=RecordingExporter(payload),
+            run_id_factory=lambda: "canonical-test",
+        )
+        with pytest.raises(RuntimeError):
+            service.execute(CanonicalCompositionExecutionRequest(target_track_count=1))
+
+
+def test_export_result_contract_is_immutable() -> None:
+    result = CanonicalCompositionExportService(
+        runner=StaticRunner(execution()),
+        exporter=RecordingExporter(),
+        run_id_factory=lambda: "canonical-test",
+    ).execute(CanonicalCompositionExecutionRequest(target_track_count=1))
+
+    with pytest.raises(FrozenInstanceError):
+        result.run_id = "canonical-other"


### PR DESCRIPTION
## Summary
- add an explicit canonical composition export service
- generate and validate internal canonical run IDs
- skip export for failed or empty canonical composition
- validate exporter identity, resolved count and skipped count postconditions
- return immutable execution and artifact evidence
- add unit and real filesystem integration tests

## Verification
- branch created directly from Bundle 35 squash commit `149a5cde26f55204ec5655130074f49e93021389`
- ahead-only diff limited to five composition, test and documentation files
- Python 3.11 and 3.12 CI required
- install, compile, critical Ruff and full pytest must pass
- no local test execution is claimed

## Isolation
- production pipeline remains legacy-authoritative
- canonical export requires explicit service invocation
- no API route, response, feature flag, receipt schema or database change

## Bundle Context
- Bundle: 36 — Canonical Composition Export Service
- Base branch: `feature/bundle-0-bootstrap`
- Base commit: `149a5cde26f55204ec5655130074f49e93021389`
- Related issue: #47
- Rollback: close this PR or revert the future squash commit; no data rollback required