### PR TITLE
Bundle 37: pipeline composition authority seam

### DIFF
--- a/docs/bundles/BUNDLE_37_PIPELINE_COMPOSITION_AUTHORITY.md
+++ b/docs/bundles/BUNDLE_37_PIPELINE_COMPOSITION_AUTHORITY.md
@@ -1,0 +1,93 @@
+# Bundle 37 — Pipeline Composition Authority Seam
+
+## Status
+
+Implementation candidate. Legacy composition remains the only default authority.
+
+## Goal
+
+Separate pipeline orchestration from the implementation that composes and exports a playlist, while preserving the current API response and observability ordering.
+
+## Contracts
+
+`PipelineCompositionCommand` carries:
+
+- input path,
+- requested limit,
+- optional BPM range,
+- optional mode.
+
+`PipelineCompositionOutcome` carries:
+
+- the authoritative run ID,
+- ordered track objects,
+- the existing export dictionary.
+
+## Authorities
+
+### LegacyCompositionAuthority
+
+Encapsulates the exact existing flow:
+
+```text
+Composer.compose
+      │
+      ▼
+legacy pipeline run ID
+      │
+      ▼
+Exporter.export_m3u
+```
+
+The existing `composer`, `exporter` and `run_id_factory` constructor injection remains supported.
+
+### CanonicalCompositionAuthority
+
+Adapts `PipelineCompositionCommand` to the explicit Bundle 36 canonical export service.
+
+It is not selected by configuration or API. It can only be supplied explicitly through dependency injection.
+
+A canonical execution that does not produce a validated artifact fails closed.
+
+## Pipeline ordering
+
+```text
+composition authority
+        │
+        ▼
+successful export outcome
+        │
+        ▼
+optional comparison observability
+        │
+        ▼
+existing response payload
+```
+
+Authority failures prevent observability. Observability failures remain fail-open and cannot invalidate an already completed export.
+
+## Compatibility
+
+Without `composition_authority`, `OrchestratorPipeline` constructs `LegacyCompositionAuthority` and preserves:
+
+- composer and exporter behavior,
+- run-ID validation,
+- top-level response keys,
+- track ordering,
+- comparison hook timing.
+
+Supplying an authority together with legacy composer/exporter/run-ID dependencies is rejected as ambiguous configuration.
+
+## Isolation
+
+Bundle 37 does not:
+
+- add an authority feature flag,
+- change the default authority,
+- modify API routes or schemas,
+- change the database,
+- automatically execute canonical composition.
+
+## Rollback
+
+Revert the Bundle 37 squash commit. No data rollback is required.

--- a/services/orchestrator/__init__.py
+++ b/services/orchestrator/__init__.py
@@ -1,0 +1,17 @@
+from services.orchestrator.composition_authority import (
+    CanonicalCompositionAuthority,
+    LegacyCompositionAuthority,
+    PipelineCompositionAuthority,
+    PipelineCompositionCommand,
+    PipelineCompositionOutcome,
+)
+from services.orchestrator.pipeline import OrchestratorPipeline
+
+__all__ = [
+    "CanonicalCompositionAuthority",
+    "LegacyCompositionAuthority",
+    "OrchestratorPipeline",
+    "PipelineCompositionAuthority",
+    "PipelineCompositionCommand",
+    "PipelineCompositionOutcome",
+]

--- a/services/orchestrator/composition_authority.py
+++ b/services/orchestrator/composition_authority.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Protocol
+from uuid import uuid4
+
+from services.composer.composer import Composer
+from services.composition.export_service import CanonicalCompositionExportService
+from services.composition.runner import CanonicalCompositionExecutionRequest
+from services.export.exporter import Exporter
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineCompositionCommand:
+    path: str
+    limit: int
+    bpm_min: float | None = None
+    bpm_max: float | None = None
+    mode: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineCompositionOutcome:
+    run_id: str
+    tracks: tuple[object, ...]
+    export: Mapping[str, object]
+
+
+class PipelineCompositionAuthority(Protocol):
+    def execute(
+        self,
+        command: PipelineCompositionCommand,
+    ) -> PipelineCompositionOutcome: ...
+
+
+class LegacyComposer(Protocol):
+    def compose(self, limit: int) -> list: ...
+
+
+class PlaylistExporter(Protocol):
+    def export_m3u(self, *, playlist_id: str, tracks: list) -> dict: ...
+
+
+class CanonicalExportExecutor(Protocol):
+    def execute(self, request: CanonicalCompositionExecutionRequest): ...
+
+
+def new_pipeline_run_id() -> str:
+    return f"pipeline-{uuid4().hex}"
+
+
+class LegacyCompositionAuthority:
+    """Preserve the existing composer, run-ID and exporter behavior."""
+
+    def __init__(
+        self,
+        *,
+        composer: LegacyComposer | None = None,
+        exporter: PlaylistExporter | None = None,
+        run_id_factory: Callable[[], str] | None = None,
+    ) -> None:
+        self.composer = composer if composer is not None else Composer()
+        self.exporter = exporter if exporter is not None else Exporter()
+        self._run_id_factory = run_id_factory or new_pipeline_run_id
+
+    def execute(
+        self,
+        command: PipelineCompositionCommand,
+    ) -> PipelineCompositionOutcome:
+        playlist = list(self.composer.compose(limit=command.limit))
+        run_id = self._run_id_factory()
+        if not isinstance(run_id, str) or not run_id.strip():
+            raise RuntimeError("Pipeline run ID factory returned an invalid identifier")
+        normalized_run_id = run_id.strip()
+        export = self.exporter.export_m3u(
+            playlist_id=normalized_run_id,
+            tracks=playlist,
+        )
+        return PipelineCompositionOutcome(
+            run_id=normalized_run_id,
+            tracks=tuple(playlist),
+            export=MappingProxyType(dict(export)),
+        )
+
+
+class CanonicalCompositionAuthority:
+    """Explicit canonical authority backed by the isolated export service."""
+
+    def __init__(
+        self,
+        *,
+        service: CanonicalExportExecutor | None = None,
+    ) -> None:
+        self._service = (
+            service if service is not None else CanonicalCompositionExportService()
+        )
+
+    def execute(
+        self,
+        command: PipelineCompositionCommand,
+    ) -> PipelineCompositionOutcome:
+        result = self._service.execute(
+            CanonicalCompositionExecutionRequest(
+                target_track_count=command.limit,
+                bpm_min=command.bpm_min if command.bpm_min is not None else 1.0,
+                bpm_max=command.bpm_max if command.bpm_max is not None else 300.0,
+                mode=command.mode if command.mode is not None else "club",
+            )
+        )
+        if not result.exported or result.run_id is None or result.artifact is None:
+            raise RuntimeError("Canonical composition did not produce an exportable playlist")
+
+        artifact = result.artifact
+        export = {
+            "playlist_id": artifact.playlist_id,
+            "m3u_path": artifact.m3u_path,
+            "manifest_path": artifact.manifest_path,
+            "warnings_path": artifact.warnings_path,
+            "audit_path": artifact.audit_path,
+            "resolved_count": artifact.resolved_count,
+            "skipped_count": artifact.skipped_count,
+        }
+        return PipelineCompositionOutcome(
+            run_id=result.run_id,
+            tracks=tuple(result.execution.tracks),
+            export=MappingProxyType(export),
+        )

--- a/services/orchestrator/pipeline.py
+++ b/services/orchestrator/pipeline.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from typing import Protocol
-from uuid import uuid4
 
 from core.config.settings import get_settings
 from services.composer.composer import Composer
@@ -16,40 +14,51 @@ from services.composition.receipt_sink import (
     JsonCompositionReceiptSink,
 )
 from services.export.exporter import Exporter
+from services.orchestrator.composition_authority import (
+    LegacyCompositionAuthority,
+    PipelineCompositionAuthority,
+    PipelineCompositionCommand,
+    new_pipeline_run_id,
+)
 
 
 logger = logging.getLogger(__name__)
 
 
-class PipelineComparisonObserver(Protocol):
-    def observe(
-        self,
-        *,
-        legacy_track_ids: tuple[str, ...],
-        target_track_count: int,
-        bpm_min: float | None,
-        bpm_max: float | None,
-        mode: str | None,
-    ) -> object: ...
-
-
-def _new_pipeline_run_id() -> str:
-    return f"pipeline-{uuid4().hex}"
+_new_pipeline_run_id = new_pipeline_run_id
 
 
 class OrchestratorPipeline:
     def __init__(
         self,
         *,
+        composition_authority: PipelineCompositionAuthority | None = None,
         composer: Composer | None = None,
         exporter: Exporter | None = None,
         run_id_factory: Callable[[], str] | None = None,
         comparison_hook: object | None = None,
         comparison_enabled: bool | None = None,
     ) -> None:
-        self.composer = composer if composer is not None else Composer()
-        self.exporter = exporter if exporter is not None else Exporter()
-        self._run_id_factory = run_id_factory or _new_pipeline_run_id
+        if composition_authority is not None and any(
+            value is not None for value in (composer, exporter, run_id_factory)
+        ):
+            raise ValueError(
+                "composition_authority cannot be combined with legacy dependencies"
+            )
+
+        if composition_authority is None:
+            legacy_authority = LegacyCompositionAuthority(
+                composer=composer,
+                exporter=exporter,
+                run_id_factory=run_id_factory,
+            )
+            self._composition_authority = legacy_authority
+            self.composer = legacy_authority.composer
+            self.exporter = legacy_authority.exporter
+        else:
+            self._composition_authority = composition_authority
+            self.composer = None
+            self.exporter = None
 
         settings = None
         if comparison_enabled is None or (
@@ -84,20 +93,20 @@ class OrchestratorPipeline:
         bpm_max: float | None = None,
         mode: str | None = None,
     ) -> dict:
-        playlist = self.composer.compose(limit=limit)
-        playlist_id = self._run_id_factory()
-
-        if not isinstance(playlist_id, str) or not playlist_id.strip():
-            raise RuntimeError("Pipeline run ID factory returned an invalid identifier")
-        normalized_playlist_id = playlist_id.strip()
-
-        export = self.exporter.export_m3u(
-            playlist_id=normalized_playlist_id,
-            tracks=playlist,
+        outcome = self._composition_authority.execute(
+            PipelineCompositionCommand(
+                path=path,
+                limit=limit,
+                bpm_min=bpm_min,
+                bpm_max=bpm_max,
+                mode=mode,
+            )
         )
+        playlist = list(outcome.tracks)
+        export = dict(outcome.export)
 
         self._observe_composition(
-            run_id=normalized_playlist_id,
+            run_id=outcome.run_id,
             playlist=playlist,
             limit=limit,
             bpm_min=bpm_min,

--- a/tests/test_canonical_composition_authority.py
+++ b/tests/test_canonical_composition_authority.py
@@ -1,0 +1,123 @@
+import pytest
+
+from services.composition import (
+    CanonicalCompositionExecutionResult,
+    CanonicalCompositionExportArtifact,
+    CanonicalCompositionExportResult,
+    CompositionResult,
+    CompositionStatus,
+    CompositionSummary,
+    CompositionTrack,
+)
+from services.orchestrator.composition_authority import (
+    CanonicalCompositionAuthority,
+    PipelineCompositionCommand,
+)
+
+
+def execution() -> CanonicalCompositionExecutionResult:
+    track = CompositionTrack(
+        track_id="canonical-1",
+        path="/music/canonical-1.mp3",
+        bpm=128.0,
+        camelot="8A",
+        energy=0.7,
+    )
+    return CanonicalCompositionExecutionResult(
+        composition=CompositionResult(
+            status=CompositionStatus.SUCCESS,
+            tracks=(track,),
+            decisions=(),
+            summary=CompositionSummary(
+                track_count=1,
+                total_duration_seconds=300,
+                average_bpm=128.0,
+                minimum_bpm=128.0,
+                maximum_bpm=128.0,
+                average_energy=0.7,
+            ),
+        ),
+        candidate_count=1,
+        adapted_count=1,
+        rejected_count=0,
+        fallback_count=0,
+        adaptation_issues=(),
+    )
+
+
+class StaticCanonicalService:
+    def __init__(self, result: CanonicalCompositionExportResult) -> None:
+        self.result = result
+        self.requests = []
+
+    def execute(self, request) -> CanonicalCompositionExportResult:
+        self.requests.append(request)
+        return self.result
+
+
+def exported_result() -> CanonicalCompositionExportResult:
+    return CanonicalCompositionExportResult(
+        execution=execution(),
+        run_id="canonical-authority",
+        artifact=CanonicalCompositionExportArtifact(
+            playlist_id="canonical-authority",
+            m3u_path="exports/canonical-authority.m3u",
+            manifest_path="artifacts/canonical-authority.manifest.json",
+            warnings_path="artifacts/canonical-authority.warnings.json",
+            audit_path="artifacts/canonical-authority.audit.json",
+            resolved_count=1,
+            skipped_count=0,
+        ),
+    )
+
+
+def test_canonical_authority_maps_command_to_export_service() -> None:
+    service = StaticCanonicalService(exported_result())
+    authority = CanonicalCompositionAuthority(service=service)
+
+    outcome = authority.execute(
+        PipelineCompositionCommand(
+            path="/ignored-by-canonical-runner",
+            limit=5,
+            bpm_min=124.0,
+            bpm_max=132.0,
+            mode="afterhours",
+        )
+    )
+
+    request = service.requests[0]
+    assert request.target_track_count == 5
+    assert request.bpm_min == 124.0
+    assert request.bpm_max == 132.0
+    assert request.mode == "afterhours"
+    assert outcome.run_id == "canonical-authority"
+    assert [track.track_id for track in outcome.tracks] == ["canonical-1"]
+    assert outcome.export["playlist_id"] == "canonical-authority"
+    assert outcome.export["resolved_count"] == 1
+    assert outcome.export["skipped_count"] == 0
+
+
+def test_canonical_authority_uses_explicit_control_defaults() -> None:
+    service = StaticCanonicalService(exported_result())
+    authority = CanonicalCompositionAuthority(service=service)
+
+    authority.execute(PipelineCompositionCommand(path="/music", limit=1))
+
+    request = service.requests[0]
+    assert request.bpm_min == 1.0
+    assert request.bpm_max == 300.0
+    assert request.mode == "club"
+
+
+def test_non_exportable_canonical_result_is_fail_closed() -> None:
+    service = StaticCanonicalService(
+        CanonicalCompositionExportResult(
+            execution=execution(),
+            run_id=None,
+            artifact=None,
+        )
+    )
+    authority = CanonicalCompositionAuthority(service=service)
+
+    with pytest.raises(RuntimeError, match="did not produce"):
+        authority.execute(PipelineCompositionCommand(path="/music", limit=1))

--- a/tests/test_pipeline_composition_authority.py
+++ b/tests/test_pipeline_composition_authority.py
@@ -1,0 +1,178 @@
+from types import MappingProxyType
+
+import pytest
+
+from data.models.playlist_candidate import PlaylistCandidate
+from services.orchestrator.composition_authority import (
+    PipelineCompositionCommand,
+    PipelineCompositionOutcome,
+)
+from services.orchestrator.pipeline import OrchestratorPipeline
+
+
+class FakeComposer:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    def compose(self, limit: int) -> list[PlaylistCandidate]:
+        self.events.append("compose")
+        return [
+            PlaylistCandidate(
+                track_id="legacy-1",
+                path="/music/legacy-1.mp3",
+                bpm=128.0,
+                camelot="8A",
+                energy=0.7,
+            )
+        ][:limit]
+
+
+class FakeExporter:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    def export_m3u(self, *, playlist_id: str, tracks: list) -> dict:
+        self.events.append("export")
+        return {
+            "playlist_id": playlist_id,
+            "m3u_path": f"exports/{playlist_id}.m3u",
+            "resolved_count": len(tracks),
+            "skipped_count": 0,
+        }
+
+
+class RecordingAuthority:
+    def __init__(self, events: list[str], *, fail: bool = False) -> None:
+        self.events = events
+        self.fail = fail
+        self.commands = []
+
+    def execute(self, command: PipelineCompositionCommand) -> PipelineCompositionOutcome:
+        self.events.append("authority")
+        self.commands.append(command)
+        if self.fail:
+            raise RuntimeError("authority failed")
+        track = PlaylistCandidate(
+            track_id="authority-1",
+            path="/music/authority-1.mp3",
+            bpm=127.0,
+            camelot="9A",
+            energy=0.6,
+        )
+        return PipelineCompositionOutcome(
+            run_id="authority-run",
+            tracks=(track,),
+            export=MappingProxyType(
+                {
+                    "playlist_id": "authority-run",
+                    "m3u_path": "exports/authority-run.m3u",
+                    "resolved_count": 1,
+                    "skipped_count": 0,
+                }
+            ),
+        )
+
+
+class RecordingHook:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+        self.calls = []
+
+    def observe_run(self, **kwargs) -> None:
+        self.events.append("observe")
+        self.calls.append(kwargs)
+
+
+def test_default_legacy_dependencies_preserve_exact_response_and_order() -> None:
+    events: list[str] = []
+    pipeline = OrchestratorPipeline(
+        composer=FakeComposer(events),
+        exporter=FakeExporter(events),
+        run_id_factory=lambda: "pipeline-test",
+        comparison_enabled=False,
+    )
+
+    result = pipeline.run(
+        path="/music",
+        limit=1,
+        bpm_min=126.0,
+        bpm_max=132.0,
+        mode="club",
+    )
+
+    assert events == ["compose", "export"]
+    assert result == {
+        "input": {
+            "path": "/music",
+            "limit": 1,
+            "bpm_min": 126.0,
+            "bpm_max": 132.0,
+            "mode": "club",
+        },
+        "tracks": ["legacy-1"],
+        "count": 1,
+        "export": {
+            "playlist_id": "pipeline-test",
+            "m3u_path": "exports/pipeline-test.m3u",
+            "resolved_count": 1,
+            "skipped_count": 0,
+        },
+    }
+
+
+def test_injected_authority_receives_controls_and_preserves_response_shape() -> None:
+    events: list[str] = []
+    authority = RecordingAuthority(events)
+    hook = RecordingHook(events)
+    pipeline = OrchestratorPipeline(
+        composition_authority=authority,
+        comparison_hook=hook,
+        comparison_enabled=True,
+    )
+
+    result = pipeline.run(
+        path="/library",
+        limit=7,
+        bpm_min=124.0,
+        bpm_max=130.0,
+        mode="afterhours",
+    )
+
+    assert events == ["authority", "observe"]
+    assert authority.commands == [
+        PipelineCompositionCommand(
+            path="/library",
+            limit=7,
+            bpm_min=124.0,
+            bpm_max=130.0,
+            mode="afterhours",
+        )
+    ]
+    assert result["tracks"] == ["authority-1"]
+    assert result["count"] == 1
+    assert result["export"]["playlist_id"] == "authority-run"
+    assert hook.calls[0]["run_id"] == "authority-run"
+    assert hook.calls[0]["legacy_track_ids"] == ("authority-1",)
+
+
+def test_authority_failure_prevents_observability() -> None:
+    events: list[str] = []
+    pipeline = OrchestratorPipeline(
+        composition_authority=RecordingAuthority(events, fail=True),
+        comparison_hook=RecordingHook(events),
+        comparison_enabled=True,
+    )
+
+    with pytest.raises(RuntimeError, match="authority failed"):
+        pipeline.run(path="/music", limit=1)
+
+    assert events == ["authority"]
+
+
+def test_authority_cannot_be_combined_with_legacy_dependencies() -> None:
+    with pytest.raises(ValueError, match="cannot be combined"):
+        OrchestratorPipeline(
+            composition_authority=RecordingAuthority([]),
+            composer=FakeComposer([]),
+            comparison_enabled=False,
+        )


### PR DESCRIPTION
## Summary
- add immutable pipeline composition command and outcome contracts
- encapsulate current behavior in a legacy composition authority
- add an explicit canonical composition authority backed by Bundle 36
- refactor the pipeline to delegate composition and export through the authority
- preserve legacy constructor injection and exact response shape
- reject ambiguous authority plus legacy dependencies
- add compatibility, ordering and fail-closed canonical tests

## Verification
- branch created directly from Bundle 36 squash commit `fab103ce7695230ecef5a51656d98552e3068a69`
- ahead-only diff limited to six orchestrator, test and documentation files
- Python 3.11 and 3.12 CI required
- install, compile, critical Ruff and full pytest must pass
- no local test execution is claimed

## Isolation
- legacy remains the only default authority
- canonical authority requires explicit dependency injection
- no env or API authority selector
- no route, response schema or database change

## Bundle Context
- Bundle: 37 — Pipeline Composition Authority Seam
- Base branch: `feature/bundle-0-bootstrap`
- Base commit: `fab103ce7695230ecef5a51656d98552e3068a69`
- Related issue: #49
- Rollback: close this PR or revert the future squash commit; no data rollback required