### PR TITLE
Bundle 38: configured composition authority selector

### DIFF
--- a/config/examples/composition-authority.env.example
+++ b/config/examples/composition-authority.env.example
@@ -1,0 +1,6 @@
+# Legacy remains the production default.
+COMPOSITION_AUTHORITY=legacy
+
+# Controlled canonical rollout requires:
+# COMPOSITION_AUTHORITY=canonical
+# ENABLE_COMPOSITION_COMPARISON=false

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -1,0 +1,14 @@
+from core.config.composition_authority import (
+    CompositionAuthorityName,
+    CompositionAuthoritySettings,
+    resolve_composition_authority,
+)
+from core.config.settings import Settings, get_settings
+
+__all__ = [
+    "CompositionAuthorityName",
+    "CompositionAuthoritySettings",
+    "Settings",
+    "get_settings",
+    "resolve_composition_authority",
+]

--- a/core/config/composition_authority.py
+++ b/core/config/composition_authority.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import os
+from enum import Enum
+
+
+class CompositionAuthorityName(str, Enum):
+    LEGACY = "legacy"
+    CANONICAL = "canonical"
+
+
+def resolve_composition_authority(
+    value: CompositionAuthorityName | str | None = None,
+) -> CompositionAuthorityName:
+    raw = os.getenv("COMPOSITION_AUTHORITY", CompositionAuthorityName.LEGACY.value) if value is None else value
+    if isinstance(raw, CompositionAuthorityName):
+        return raw
+    if not isinstance(raw, str):
+        raise ValueError("COMPOSITION_AUTHORITY must be a string")
+    normalized = raw.strip().casefold()
+    try:
+        return CompositionAuthorityName(normalized)
+    except ValueError as exc:
+        allowed = ", ".join(item.value for item in CompositionAuthorityName)
+        raise ValueError(
+            f"Unsupported COMPOSITION_AUTHORITY: {raw!r}; allowed: {allowed}"
+        ) from exc

--- a/core/config/composition_authority.py
+++ b/core/config/composition_authority.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import os
 from enum import Enum
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class CompositionAuthorityName(str, Enum):
@@ -9,19 +10,31 @@ class CompositionAuthorityName(str, Enum):
     CANONICAL = "canonical"
 
 
+class CompositionAuthoritySettings(BaseSettings):
+    composition_authority: CompositionAuthorityName = CompositionAuthorityName.LEGACY
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+
 def resolve_composition_authority(
     value: CompositionAuthorityName | str | None = None,
 ) -> CompositionAuthorityName:
-    raw = os.getenv("COMPOSITION_AUTHORITY", CompositionAuthorityName.LEGACY.value) if value is None else value
-    if isinstance(raw, CompositionAuthorityName):
-        return raw
-    if not isinstance(raw, str):
+    if value is None:
+        return CompositionAuthoritySettings().composition_authority
+    if isinstance(value, CompositionAuthorityName):
+        return value
+    if not isinstance(value, str):
         raise ValueError("COMPOSITION_AUTHORITY must be a string")
-    normalized = raw.strip().casefold()
+    normalized = value.strip().casefold()
     try:
         return CompositionAuthorityName(normalized)
     except ValueError as exc:
         allowed = ", ".join(item.value for item in CompositionAuthorityName)
         raise ValueError(
-            f"Unsupported COMPOSITION_AUTHORITY: {raw!r}; allowed: {allowed}"
+            f"Unsupported COMPOSITION_AUTHORITY: {value!r}; allowed: {allowed}"
         ) from exc

--- a/docs/bundles/BUNDLE_38_CONFIGURED_COMPOSITION_AUTHORITY.md
+++ b/docs/bundles/BUNDLE_38_CONFIGURED_COMPOSITION_AUTHORITY.md
@@ -1,0 +1,82 @@
+# Bundle 38 — Configured Composition Authority Selector
+
+## Status
+
+Implementation candidate. The default remains `legacy`.
+
+## Goal
+
+Allow a controlled operator rollout of canonical composition without adding a per-request API switch or silently changing existing installations.
+
+## Configuration
+
+```env
+COMPOSITION_AUTHORITY=legacy
+```
+
+Allowed values are:
+
+- `legacy`,
+- `canonical`.
+
+The selector is loaded through a dedicated typed settings model that reads process environment variables and the project `.env` file. Unknown values fail validation.
+
+A safe standalone example is stored at:
+
+```text
+config/examples/composition-authority.env.example
+```
+
+The main `.env.example` was not rewritten in this bundle because it contains historical secret fields and the repository write safety gate rejected a full-file replacement.
+
+## Selection precedence
+
+1. Explicit `composition_authority` dependency injection.
+2. Explicit legacy `composer`, `exporter` or `run_id_factory` dependencies.
+3. Configured `COMPOSITION_AUTHORITY`.
+4. Default `legacy`.
+
+Configuration therefore cannot override explicit test or embedding dependencies.
+
+## Canonical mode
+
+With:
+
+```env
+COMPOSITION_AUTHORITY=canonical
+ENABLE_COMPOSITION_COMPARISON=false
+```
+
+default `OrchestratorPipeline` construction selects `CanonicalCompositionAuthority`, which delegates through the validated canonical runner and export service.
+
+There is no fallback to legacy when canonical execution fails.
+
+## Comparison restriction
+
+Comparison observability treats the authoritative playlist as a legacy baseline. Running it while canonical is authoritative would create semantically invalid evidence. The combination is therefore rejected fail-closed:
+
+```env
+COMPOSITION_AUTHORITY=canonical
+ENABLE_COMPOSITION_COMPARISON=true
+```
+
+## Compatibility
+
+The following remain unchanged:
+
+- API route and request schema,
+- top-level pipeline response shape,
+- default legacy behavior,
+- explicit composer/exporter/run-ID injection,
+- database schema,
+- exporter artifact format.
+
+## Rollback
+
+Set:
+
+```env
+COMPOSITION_AUTHORITY=legacy
+```
+
+and restart the process. Code rollback is available by reverting the Bundle 38 squash commit. No data rollback is required.

--- a/services/orchestrator/composition_authority.py
+++ b/services/orchestrator/composition_authority.py
@@ -29,6 +29,8 @@ class PipelineCompositionOutcome:
 
 
 class PipelineCompositionAuthority(Protocol):
+    authority_name: str
+
     def execute(
         self,
         command: PipelineCompositionCommand,
@@ -53,6 +55,8 @@ def new_pipeline_run_id() -> str:
 
 class LegacyCompositionAuthority:
     """Preserve the existing composer, run-ID and exporter behavior."""
+
+    authority_name = "legacy"
 
     def __init__(
         self,
@@ -87,6 +91,8 @@ class LegacyCompositionAuthority:
 
 class CanonicalCompositionAuthority:
     """Explicit canonical authority backed by the isolated export service."""
+
+    authority_name = "canonical"
 
     def __init__(
         self,

--- a/services/orchestrator/pipeline.py
+++ b/services/orchestrator/pipeline.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 
+from core.config.composition_authority import (
+    CompositionAuthorityName,
+    resolve_composition_authority,
+)
 from core.config.settings import get_settings
 from services.composer.composer import Composer
 from services.composition.hook import (
@@ -15,6 +19,7 @@ from services.composition.receipt_sink import (
 )
 from services.export.exporter import Exporter
 from services.orchestrator.composition_authority import (
+    CanonicalCompositionAuthority,
     LegacyCompositionAuthority,
     PipelineCompositionAuthority,
     PipelineCompositionCommand,
@@ -39,26 +44,43 @@ class OrchestratorPipeline:
         comparison_hook: object | None = None,
         comparison_enabled: bool | None = None,
     ) -> None:
-        if composition_authority is not None and any(
+        legacy_dependencies_supplied = any(
             value is not None for value in (composer, exporter, run_id_factory)
-        ):
+        )
+        if composition_authority is not None and legacy_dependencies_supplied:
             raise ValueError(
                 "composition_authority cannot be combined with legacy dependencies"
             )
 
         if composition_authority is None:
-            legacy_authority = LegacyCompositionAuthority(
-                composer=composer,
-                exporter=exporter,
-                run_id_factory=run_id_factory,
+            authority_name = (
+                CompositionAuthorityName.LEGACY
+                if legacy_dependencies_supplied
+                else resolve_composition_authority()
             )
-            self._composition_authority = legacy_authority
-            self.composer = legacy_authority.composer
-            self.exporter = legacy_authority.exporter
+            if authority_name == CompositionAuthorityName.CANONICAL:
+                self._composition_authority = CanonicalCompositionAuthority()
+                self.composer = None
+                self.exporter = None
+            else:
+                legacy_authority = LegacyCompositionAuthority(
+                    composer=composer,
+                    exporter=exporter,
+                    run_id_factory=run_id_factory,
+                )
+                self._composition_authority = legacy_authority
+                self.composer = legacy_authority.composer
+                self.exporter = legacy_authority.exporter
         else:
             self._composition_authority = composition_authority
             self.composer = None
             self.exporter = None
+
+        selected_authority_name = getattr(
+            self._composition_authority,
+            "authority_name",
+            "custom",
+        )
 
         settings = None
         if comparison_enabled is None or (
@@ -68,6 +90,11 @@ class OrchestratorPipeline:
         if comparison_enabled is None:
             assert settings is not None
             comparison_enabled = settings.enable_composition_comparison
+
+        if selected_authority_name == "canonical" and comparison_enabled:
+            raise ValueError(
+                "canonical composition authority cannot be combined with comparison observability"
+            )
 
         self._comparison_enabled = comparison_enabled
         self._comparison_hook = comparison_hook

--- a/tests/test_configured_composition_authority.py
+++ b/tests/test_configured_composition_authority.py
@@ -51,6 +51,17 @@ def test_resolver_defaults_to_legacy_without_environment(monkeypatch, tmp_path) 
     assert resolve_composition_authority() == CompositionAuthorityName.LEGACY
 
 
+def test_resolver_reads_canonical_from_dotenv(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("COMPOSITION_AUTHORITY", raising=False)
+    (tmp_path / ".env").write_text(
+        "COMPOSITION_AUTHORITY=canonical\nUNRELATED_VALUE=ignored\n",
+        encoding="utf-8",
+    )
+
+    assert resolve_composition_authority() == CompositionAuthorityName.CANONICAL
+
+
 def test_default_pipeline_uses_legacy_authority(monkeypatch, tmp_path) -> None:
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("COMPOSITION_AUTHORITY", raising=False)

--- a/tests/test_configured_composition_authority.py
+++ b/tests/test_configured_composition_authority.py
@@ -1,0 +1,124 @@
+from types import MappingProxyType
+
+import pytest
+
+from core.config.composition_authority import (
+    CompositionAuthorityName,
+    resolve_composition_authority,
+)
+from data.models.playlist_candidate import PlaylistCandidate
+from services.orchestrator.composition_authority import (
+    CanonicalCompositionAuthority,
+    LegacyCompositionAuthority,
+    PipelineCompositionCommand,
+    PipelineCompositionOutcome,
+)
+from services.orchestrator.pipeline import OrchestratorPipeline
+
+
+class FakeComposer:
+    def compose(self, limit: int) -> list[PlaylistCandidate]:
+        return []
+
+
+class FakeExporter:
+    def export_m3u(self, *, playlist_id: str, tracks: list) -> dict:
+        return {"playlist_id": playlist_id}
+
+
+class ExplicitAuthority:
+    authority_name = "custom"
+
+    def execute(self, command: PipelineCompositionCommand) -> PipelineCompositionOutcome:
+        track = PlaylistCandidate(
+            track_id="explicit-1",
+            path="/music/explicit-1.mp3",
+            bpm=128.0,
+            camelot="8A",
+            energy=0.7,
+        )
+        return PipelineCompositionOutcome(
+            run_id="explicit-run",
+            tracks=(track,),
+            export=MappingProxyType({"playlist_id": "explicit-run"}),
+        )
+
+
+def test_resolver_defaults_to_legacy_without_environment(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("COMPOSITION_AUTHORITY", raising=False)
+
+    assert resolve_composition_authority() == CompositionAuthorityName.LEGACY
+
+
+def test_default_pipeline_uses_legacy_authority(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("COMPOSITION_AUTHORITY", raising=False)
+
+    pipeline = OrchestratorPipeline(comparison_enabled=False)
+
+    assert isinstance(pipeline._composition_authority, LegacyCompositionAuthority)
+    assert pipeline.composer is not None
+    assert pipeline.exporter is not None
+
+
+def test_canonical_environment_selects_canonical_authority(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("COMPOSITION_AUTHORITY", "canonical")
+
+    pipeline = OrchestratorPipeline(comparison_enabled=False)
+
+    assert isinstance(pipeline._composition_authority, CanonicalCompositionAuthority)
+    assert pipeline.composer is None
+    assert pipeline.exporter is None
+
+
+def test_invalid_environment_value_fails_configuration(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("COMPOSITION_AUTHORITY", "unsupported")
+
+    with pytest.raises(ValueError):
+        OrchestratorPipeline(comparison_enabled=False)
+
+
+def test_explicit_legacy_dependencies_override_configured_canonical(monkeypatch) -> None:
+    monkeypatch.setenv("COMPOSITION_AUTHORITY", "canonical")
+    composer = FakeComposer()
+    exporter = FakeExporter()
+
+    pipeline = OrchestratorPipeline(
+        composer=composer,
+        exporter=exporter,
+        run_id_factory=lambda: "pipeline-explicit",
+        comparison_enabled=False,
+    )
+
+    assert isinstance(pipeline._composition_authority, LegacyCompositionAuthority)
+    assert pipeline.composer is composer
+    assert pipeline.exporter is exporter
+
+
+def test_explicit_authority_is_not_overridden_by_configuration(monkeypatch) -> None:
+    monkeypatch.setenv("COMPOSITION_AUTHORITY", "canonical")
+    authority = ExplicitAuthority()
+
+    pipeline = OrchestratorPipeline(
+        composition_authority=authority,
+        comparison_enabled=False,
+    )
+
+    assert pipeline._composition_authority is authority
+    result = pipeline.run(path="/music", limit=1)
+    assert result["tracks"] == ["explicit-1"]
+    assert result["export"] == {"playlist_id": "explicit-run"}
+
+
+def test_canonical_authority_rejects_comparison_observability(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("COMPOSITION_AUTHORITY", "canonical")
+
+    with pytest.raises(ValueError, match="cannot be combined"):
+        OrchestratorPipeline(
+            comparison_enabled=True,
+            comparison_hook=object(),
+        )


### PR DESCRIPTION
## Summary
- add a typed legacy/canonical composition authority selector
- load selection from process environment or project dotenv
- preserve explicit dependency injection precedence
- keep legacy as the default authority
- reject canonical authority combined with comparison observability
- add safe configuration example, rollout documentation and regression tests

## Verification
- branch created directly from Bundle 37 squash commit `1d84ce119b295bceecf70352db90310b45cc8cc7`
- ahead-only diff limited to seven configuration, orchestrator, test and documentation files
- Python 3.11 and 3.12 CI required
- install, compile, critical Ruff and full pytest must pass
- no local test execution is claimed

## Isolation
- no per-request authority selector
- no route or response schema change
- no database migration
- default remains `legacy`
- canonical failures do not silently fall back to legacy

## Bundle Context
- Bundle: 38 — Configured Composition Authority Selector
- Base branch: `feature/bundle-0-bootstrap`
- Base commit: `1d84ce119b295bceecf70352db90310b45cc8cc7`
- Related issue: #51
- Rollback: set `COMPOSITION_AUTHORITY=legacy` or revert the future squash commit; no data rollback required