### PR TITLE
Bundle 39: canonical source-path scope

### DIFF
--- a/docs/bundles/BUNDLE_39_CANONICAL_SOURCE_PATH_SCOPE.md
+++ b/docs/bundles/BUNDLE_39_CANONICAL_SOURCE_PATH_SCOPE.md
@@ -1,0 +1,54 @@
+# Bundle 39 — Canonical Source-Path Scope
+
+## Status
+
+Implemented on `feature/bundle-39-canonical-source-path-scope`. Production rollout requires a green pull-request gate and squash merge.
+
+## Problem
+
+The pipeline request already contains a `path`, but canonical composition previously ignored it and loaded every joined playlist candidate from the indexed library. In canonical authority mode, a request for one folder could therefore export tracks from unrelated folders.
+
+## Contract
+
+`CanonicalCompositionExecutionRequest` now accepts an optional `source_path`.
+
+When `source_path` is set:
+
+- it must be a non-empty absolute path;
+- normalization occurs before repository access;
+- only a candidate whose path exactly equals the scope or is a lexical descendant is retained;
+- filtering occurs before candidate adaptation;
+- out-of-scope malformed candidates do not contribute rejection or fallback evidence;
+- an empty scoped candidate set produces a failed composition and no export.
+
+When `source_path` is omitted, existing whole-library runner behavior remains unchanged for comparison and internal callers.
+
+## Pipeline behavior
+
+`CanonicalCompositionAuthority` passes `PipelineCompositionCommand.path` to the canonical execution request.
+
+Legacy authority behavior is unchanged. There is no filesystem scan, ingestion, database migration, API field, response field, or fallback to whole-library canonical selection.
+
+## Security and correctness properties
+
+- Relative and empty source paths are rejected before repository access.
+- Candidate matching is path-component aware, so `/music/set-two` is not considered a descendant of `/music/set`.
+- No filesystem resolution or unbounded traversal is performed.
+- Canonical export remains fail-closed when the selected scope has no exportable tracks.
+- Export postconditions from Bundle 36 remain mandatory.
+
+## Verification
+
+Required gates:
+
+- Python 3.11 install, compile, critical Ruff, and full pytest;
+- Python 3.12 install, compile, critical Ruff, and full pytest;
+- real SQLite repository JOIN integration;
+- real exporter integration proving out-of-scope paths are absent from M3U output;
+- PR Guard success;
+- no unresolved review threads;
+- mergeability against `feature/bundle-0-bootstrap`.
+
+## Rollback
+
+Set `COMPOSITION_AUTHORITY=legacy` for immediate operational rollback. Code rollback is a revert of the future Bundle 39 squash commit. No data rollback is required.

--- a/services/composition/runner.py
+++ b/services/composition/runner.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Protocol
 
 from data.models.playlist_candidate import PlaylistCandidate
@@ -19,6 +21,29 @@ class PlaylistCandidateRepository(Protocol):
     def list_playlist_candidates(self) -> list[PlaylistCandidate]: ...
 
 
+def normalize_source_path(value: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("source_path must be a non-empty absolute path")
+    candidate = Path(os.path.normpath(value.strip()))
+    if not candidate.is_absolute():
+        raise ValueError("source_path must be an absolute path")
+    return str(candidate)
+
+
+def candidate_is_within_source_path(
+    candidate: PlaylistCandidate,
+    source_path: str,
+) -> bool:
+    raw_path = candidate.path
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        return False
+    candidate_path = Path(os.path.normpath(raw_path.strip()))
+    if not candidate_path.is_absolute():
+        return False
+    scope = Path(source_path)
+    return candidate_path == scope or scope in candidate_path.parents
+
+
 @dataclass(frozen=True, slots=True)
 class CanonicalCompositionExecutionRequest:
     target_track_count: int
@@ -28,6 +53,7 @@ class CanonicalCompositionExecutionRequest:
     genre: str | None = None
     start_key: str | None = None
     duration_fallback_seconds: int = 300
+    source_path: str | None = None
 
     def __post_init__(self) -> None:
         if self.target_track_count <= 0:
@@ -38,6 +64,12 @@ class CanonicalCompositionExecutionRequest:
             raise ValueError("bpm_min must be less than or equal to bpm_max")
         if self.duration_fallback_seconds <= 0:
             raise ValueError("duration_fallback_seconds must be greater than zero")
+        if self.source_path is not None:
+            object.__setattr__(
+                self,
+                "source_path",
+                normalize_source_path(self.source_path),
+            )
 
 
 @dataclass(frozen=True, slots=True)
@@ -76,6 +108,12 @@ class CanonicalCompositionRunner:
     ) -> CanonicalCompositionExecutionResult:
         mode = parse_composition_mode(request.mode)
         candidates = self._repository.list_playlist_candidates()
+        if request.source_path is not None:
+            candidates = [
+                candidate
+                for candidate in candidates
+                if candidate_is_within_source_path(candidate, request.source_path)
+            ]
         adaptation = adapt_playlist_candidates(
             candidates,
             duration_fallback_seconds=request.duration_fallback_seconds,

--- a/services/orchestrator/composition_authority.py
+++ b/services/orchestrator/composition_authority.py
@@ -113,6 +113,7 @@ class CanonicalCompositionAuthority:
                 bpm_min=command.bpm_min if command.bpm_min is not None else 1.0,
                 bpm_max=command.bpm_max if command.bpm_max is not None else 300.0,
                 mode=command.mode if command.mode is not None else "club",
+                source_path=command.path,
             )
         )
         if not result.exported or result.run_id is None or result.artifact is None:

--- a/tests/test_canonical_composition_authority.py
+++ b/tests/test_canonical_composition_authority.py
@@ -77,7 +77,7 @@ def test_canonical_authority_maps_command_to_export_service() -> None:
 
     outcome = authority.execute(
         PipelineCompositionCommand(
-            path="/ignored-by-canonical-runner",
+            path="/music/selected",
             limit=5,
             bpm_min=124.0,
             bpm_max=132.0,
@@ -90,6 +90,7 @@ def test_canonical_authority_maps_command_to_export_service() -> None:
     assert request.bpm_min == 124.0
     assert request.bpm_max == 132.0
     assert request.mode == "afterhours"
+    assert request.source_path == "/music/selected"
     assert outcome.run_id == "canonical-authority"
     assert [track.track_id for track in outcome.tracks] == ["canonical-1"]
     assert outcome.export["playlist_id"] == "canonical-authority"
@@ -107,6 +108,7 @@ def test_canonical_authority_uses_explicit_control_defaults() -> None:
     assert request.bpm_min == 1.0
     assert request.bpm_max == 300.0
     assert request.mode == "club"
+    assert request.source_path == "/music"
 
 
 def test_non_exportable_canonical_result_is_fail_closed() -> None:

--- a/tests/test_canonical_source_path_scope.py
+++ b/tests/test_canonical_source_path_scope.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import pytest
+
+from data.models.playlist_candidate import PlaylistCandidate
+from services.composition.export_service import CanonicalCompositionExportService
+from services.composition.runner import (
+    CanonicalCompositionExecutionRequest,
+    CanonicalCompositionRunner,
+)
+from services.orchestrator.composition_authority import (
+    CanonicalCompositionAuthority,
+    PipelineCompositionCommand,
+)
+
+
+class FakeRepository:
+    def __init__(self, candidates: list[PlaylistCandidate]) -> None:
+        self.candidates = candidates
+        self.calls = 0
+
+    def list_playlist_candidates(self) -> list[PlaylistCandidate]:
+        self.calls += 1
+        return list(self.candidates)
+
+
+class RecordingExporter:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def export_m3u(self, *, playlist_id: str, tracks: list) -> dict:
+        self.calls += 1
+        return {
+            "playlist_id": playlist_id,
+            "m3u_path": f"exports/{playlist_id}.m3u",
+            "manifest_path": f"artifacts/{playlist_id}.manifest.json",
+            "warnings_path": f"artifacts/{playlist_id}.warnings.json",
+            "audit_path": f"artifacts/{playlist_id}.audit.json",
+            "resolved_count": len(tracks),
+            "skipped_count": 0,
+        }
+
+
+def candidate(
+    track_id: str,
+    path: str,
+    *,
+    bpm: float | None = 128.0,
+) -> PlaylistCandidate:
+    return PlaylistCandidate(
+        track_id=track_id,
+        path=path,
+        title=track_id,
+        artist=f"artist-{track_id}",
+        genre="tech house",
+        source="scope-test",
+        duration_seconds=300.0,
+        bpm=bpm,
+        camelot="8A",
+        energy=0.6,
+    )
+
+
+def test_directory_scope_keeps_only_descendants() -> None:
+    repository = FakeRepository(
+        [
+            candidate("inside-a", "/music/set/inside-a.mp3"),
+            candidate("inside-b", "/music/set/deeper/inside-b.mp3"),
+            candidate("outside", "/music/other/outside.mp3"),
+        ]
+    )
+
+    result = CanonicalCompositionRunner(repository=repository).run(
+        CanonicalCompositionExecutionRequest(
+            target_track_count=2,
+            source_path="/music/set",
+        )
+    )
+
+    assert repository.calls == 1
+    assert result.candidate_count == 2
+    assert {track.track_id for track in result.tracks} == {"inside-a", "inside-b"}
+
+
+def test_exact_file_scope_keeps_only_exact_path() -> None:
+    repository = FakeRepository(
+        [
+            candidate("exact", "/music/set/exact.mp3"),
+            candidate("sibling", "/music/set/sibling.mp3"),
+        ]
+    )
+
+    result = CanonicalCompositionRunner(repository=repository).run(
+        CanonicalCompositionExecutionRequest(
+            target_track_count=1,
+            source_path="/music/set/exact.mp3",
+        )
+    )
+
+    assert result.candidate_count == 1
+    assert [track.track_id for track in result.tracks] == ["exact"]
+
+
+def test_relative_scope_is_rejected_before_repository_access() -> None:
+    repository = FakeRepository([])
+
+    with pytest.raises(ValueError, match="absolute path"):
+        CanonicalCompositionExecutionRequest(
+            target_track_count=1,
+            source_path="music/set",
+        )
+
+    assert repository.calls == 0
+
+
+def test_out_of_scope_invalid_candidate_does_not_pollute_evidence() -> None:
+    repository = FakeRepository(
+        [
+            candidate("inside", "/music/set/inside.mp3"),
+            candidate("outside-invalid", "/music/other/bad.mp3", bpm=None),
+        ]
+    )
+
+    result = CanonicalCompositionRunner(repository=repository).run(
+        CanonicalCompositionExecutionRequest(
+            target_track_count=1,
+            source_path="/music/set",
+        )
+    )
+
+    assert result.candidate_count == 1
+    assert result.rejected_count == 0
+    assert result.adaptation_issues == ()
+    assert [track.track_id for track in result.tracks] == ["inside"]
+
+
+def test_empty_scope_performs_no_export_and_authority_fails_closed() -> None:
+    repository = FakeRepository(
+        [candidate("outside", "/music/other/outside.mp3")]
+    )
+    exporter = RecordingExporter()
+    service = CanonicalCompositionExportService(
+        runner=CanonicalCompositionRunner(repository=repository),
+        exporter=exporter,
+        run_id_factory=lambda: "canonical-scope-test",
+    )
+    authority = CanonicalCompositionAuthority(service=service)
+
+    with pytest.raises(RuntimeError, match="did not produce"):
+        authority.execute(
+            PipelineCompositionCommand(
+                path="/music/set",
+                limit=1,
+            )
+        )
+
+    assert repository.calls == 1
+    assert exporter.calls == 0

--- a/tests/test_canonical_source_path_scope_integration.py
+++ b/tests/test_canonical_source_path_scope_integration.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+
+from core.config.settings import get_settings
+from data.models.analysis_record import AnalysisRecord
+from data.models.track_record import TrackRecord
+from data.repositories.analysis_repository import AnalysisRepository
+from data.repositories.track_repository import TrackRepository
+from services.composition.export_service import CanonicalCompositionExportService
+from services.composition.runner import (
+    CanonicalCompositionExecutionRequest,
+    CanonicalCompositionRunner,
+)
+from services.export.exporter import Exporter
+
+
+def seed_candidate(track_id: str, path: str, bpm: float, energy: float) -> None:
+    TrackRepository().upsert(
+        TrackRecord(
+            track_id=track_id,
+            path=path,
+            title=track_id,
+            artist=f"artist-{track_id}",
+            genre="tech house",
+            source="scope-integration",
+            duration_seconds=300.0,
+        )
+    )
+    AnalysisRepository().upsert(
+        AnalysisRecord(
+            track_id=track_id,
+            analysis_version="1",
+            features_version="1",
+            extractor_backend="test",
+            extractor_name="bundle-39",
+            bpm=bpm,
+            camelot="8A",
+            energy=energy,
+            duration_seconds=300.0,
+        )
+    )
+
+
+def test_real_repository_and_exporter_never_emit_out_of_scope_track(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path / 'scope.db'}")
+    get_settings.cache_clear()
+
+    try:
+        seed_candidate("inside-a", "/music/selected/inside-a.mp3", 126.0, 0.4)
+        seed_candidate("inside-b", "/music/selected/deeper/inside-b.mp3", 127.0, 0.6)
+        seed_candidate("outside", "/music/other/outside.mp3", 128.0, 0.8)
+
+        exports_dir = tmp_path / "exports"
+        service = CanonicalCompositionExportService(
+            runner=CanonicalCompositionRunner(repository=AnalysisRepository()),
+            exporter=Exporter(
+                exports_dir=exports_dir,
+                artifacts_dir=tmp_path / "artifacts",
+            ),
+            run_id_factory=lambda: "canonical-scope-integration",
+        )
+
+        result = service.execute(
+            CanonicalCompositionExecutionRequest(
+                target_track_count=2,
+                source_path="/music/selected",
+            )
+        )
+
+        assert result.exported is True
+        assert result.artifact is not None
+        assert result.artifact.resolved_count == 2
+        assert {track.track_id for track in result.execution.tracks} == {
+            "inside-a",
+            "inside-b",
+        }
+
+        m3u = (exports_dir / "canonical-scope-integration.m3u").read_text(
+            encoding="utf-8"
+        )
+        assert "/music/selected/inside-a.mp3" in m3u
+        assert "/music/selected/deeper/inside-b.mp3" in m3u
+        assert "/music/other/outside.mp3" not in m3u
+    finally:
+        get_settings.cache_clear()


### PR DESCRIPTION
## Summary
- make canonical composition honor the pipeline source path
- validate non-empty absolute scopes before repository access
- filter exact-path and descendant candidates before adaptation
- exclude out-of-scope malformed candidates from quality evidence
- preserve unscoped runner behavior for comparison callers
- add unit and real SQLite/exporter integration tests

## Verification
- branch created directly from Bundle 38 squash commit `3a24cd05ddbfaca255b016d5a029bfe9230101a1`
- ahead-only diff limited to six composition, authority, test and documentation files
- Python 3.11 and 3.12 CI required
- install, compile, critical Ruff and full pytest must pass
- no local test execution is claimed

## Isolation
- legacy authority behavior is unchanged
- no filesystem scan or ingestion
- no API route or response schema change
- no database migration
- no fallback to whole-library canonical selection

## Bundle Context
- Bundle: 39 — Canonical Source-Path Scope
- Base branch: `feature/bundle-0-bootstrap`
- Base commit: `3a24cd05ddbfaca255b016d5a029bfe9230101a1`
- Related issue: #53
- Rollback: set `COMPOSITION_AUTHORITY=legacy` or revert the future squash commit; no data rollback required