### PR TITLE
Bundle 40: composition startup readiness gate

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -18,24 +18,39 @@ from api.routes.pipeline import create_pipeline_router
 from api.security.auth_gate import ApiKeyAuthMiddleware
 from api.security.bootstrap import apply_security_hardening
 from api.security.settings import SecuritySettings
+from core.config.composition_runtime import (
+    CompositionRuntimeReadiness,
+    evaluate_composition_runtime,
+)
 
 
-def create_app(security_settings: SecuritySettings | None = None) -> FastAPI:
+def create_app(
+    security_settings: SecuritySettings | None = None,
+    composition_readiness: CompositionRuntimeReadiness | None = None,
+) -> FastAPI:
     """Build an isolated APPLAYLIST application instance."""
     config = security_settings or SecuritySettings()
+    readiness = (
+        composition_readiness
+        if composition_readiness is not None
+        else evaluate_composition_runtime()
+    )
     configure_observability()
 
     application = FastAPI(
         title="APPLAYLIST API",
         version="0.13.1",
     )
+    application.state.composition_runtime_readiness = readiness
 
     apply_security_hardening(application, config)
     application.add_middleware(RequestContextMiddleware)
     application.add_middleware(ApiKeyAuthMiddleware, security_settings=config)
     application.middleware("http")(log_request_response)
 
-    application.include_router(create_health_router())
+    application.include_router(
+        create_health_router(readiness_provider=lambda: readiness)
+    )
     application.include_router(create_jobs_router())
     application.include_router(create_pipeline_router())
 

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,11 +1,22 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from fastapi import APIRouter
 
+from core.config.composition_runtime import (
+    CompositionRuntimeReadiness,
+    evaluate_composition_runtime,
+)
 from core.config.settings import get_settings
 
 
-def create_health_router() -> APIRouter:
+ReadinessProvider = Callable[[], CompositionRuntimeReadiness]
+
+
+def create_health_router(
+    readiness_provider: ReadinessProvider = evaluate_composition_runtime,
+) -> APIRouter:
     router = APIRouter(tags=["health"])
 
     @router.get("/health")
@@ -17,6 +28,10 @@ def create_health_router() -> APIRouter:
             "env": settings.app_env,
             "api_version": settings.api_version,
         }
+
+    @router.get("/ready")
+    def ready() -> dict:
+        return readiness_provider().as_dict()
 
     return router
 

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -3,12 +3,20 @@ from core.config.composition_authority import (
     CompositionAuthoritySettings,
     resolve_composition_authority,
 )
+from core.config.composition_runtime import (
+    CompositionRuntimeConfigurationError,
+    CompositionRuntimeReadiness,
+    evaluate_composition_runtime,
+)
 from core.config.settings import Settings, get_settings
 
 __all__ = [
     "CompositionAuthorityName",
     "CompositionAuthoritySettings",
+    "CompositionRuntimeConfigurationError",
+    "CompositionRuntimeReadiness",
     "Settings",
+    "evaluate_composition_runtime",
     "get_settings",
     "resolve_composition_authority",
 ]

--- a/core/config/composition_runtime.py
+++ b/core/config/composition_runtime.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from core.config.composition_authority import (
+    CompositionAuthorityName,
+    resolve_composition_authority,
+)
+from core.config.settings import get_settings
+
+
+class CompositionRuntimeConfigurationError(RuntimeError):
+    """Raised when composition runtime settings are internally inconsistent."""
+
+
+@dataclass(frozen=True, slots=True)
+class CompositionRuntimeReadiness:
+    status: str
+    authority: CompositionAuthorityName
+    comparison_enabled: bool
+    receipts_enabled: bool
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "status": self.status,
+            "composition_authority": self.authority.value,
+            "composition_comparison_enabled": self.comparison_enabled,
+            "composition_receipts_enabled": self.receipts_enabled,
+        }
+
+
+def evaluate_composition_runtime(
+    *,
+    authority: CompositionAuthorityName | str | None = None,
+    comparison_enabled: bool | None = None,
+    receipts_enabled: bool | None = None,
+) -> CompositionRuntimeReadiness:
+    resolved_authority = resolve_composition_authority(authority)
+
+    if comparison_enabled is None or receipts_enabled is None:
+        settings = get_settings()
+        if comparison_enabled is None:
+            comparison_enabled = settings.enable_composition_comparison
+        if receipts_enabled is None:
+            receipts_enabled = settings.enable_composition_receipts
+
+    if receipts_enabled and not comparison_enabled:
+        raise CompositionRuntimeConfigurationError(
+            "composition receipts require composition comparison"
+        )
+
+    if resolved_authority == CompositionAuthorityName.CANONICAL and comparison_enabled:
+        raise CompositionRuntimeConfigurationError(
+            "canonical composition authority cannot be combined with comparison observability"
+        )
+
+    return CompositionRuntimeReadiness(
+        status="ready",
+        authority=resolved_authority,
+        comparison_enabled=comparison_enabled,
+        receipts_enabled=receipts_enabled,
+    )

--- a/core/config/composition_runtime.py
+++ b/core/config/composition_runtime.py
@@ -20,6 +20,10 @@ class CompositionRuntimeReadiness:
     comparison_enabled: bool
     receipts_enabled: bool
 
+    def __post_init__(self) -> None:
+        if self.status != "ready":
+            raise ValueError("composition readiness status must be 'ready'")
+
     def as_dict(self) -> dict[str, object]:
         return {
             "status": self.status,
@@ -35,7 +39,12 @@ def evaluate_composition_runtime(
     comparison_enabled: bool | None = None,
     receipts_enabled: bool | None = None,
 ) -> CompositionRuntimeReadiness:
-    resolved_authority = resolve_composition_authority(authority)
+    try:
+        resolved_authority = resolve_composition_authority(authority)
+    except ValueError as exc:
+        raise CompositionRuntimeConfigurationError(
+            "invalid composition authority configuration"
+        ) from exc
 
     if comparison_enabled is None or receipts_enabled is None:
         settings = get_settings()
@@ -43,6 +52,11 @@ def evaluate_composition_runtime(
             comparison_enabled = settings.enable_composition_comparison
         if receipts_enabled is None:
             receipts_enabled = settings.enable_composition_receipts
+
+    if not isinstance(comparison_enabled, bool) or not isinstance(receipts_enabled, bool):
+        raise CompositionRuntimeConfigurationError(
+            "composition observability settings must be boolean"
+        )
 
     if receipts_enabled and not comparison_enabled:
         raise CompositionRuntimeConfigurationError(

--- a/docs/bundles/BUNDLE_40_COMPOSITION_STARTUP_READINESS.md
+++ b/docs/bundles/BUNDLE_40_COMPOSITION_STARTUP_READINESS.md
@@ -1,0 +1,95 @@
+# Bundle 40 — Composition Startup Readiness Gate
+
+## Status
+
+Implemented on `feature/bundle-40-composition-startup-readiness`. Merge requires the full Python 3.11/3.12 release gate.
+
+## Problem
+
+Composition authority selection was validated only when a pipeline object was first constructed. An application configured with an invalid authority or incompatible canonical observability settings could start and return `status=ok` from `/health`, then fail on its first pipeline request.
+
+## Runtime contract
+
+`evaluate_composition_runtime()` produces an immutable readiness snapshot containing only:
+
+- readiness status;
+- selected composition authority;
+- comparison enabled state;
+- receipt enabled state.
+
+It rejects:
+
+- an unsupported composition authority;
+- composition receipts without composition comparison;
+- canonical authority combined with comparison observability;
+- non-boolean explicit observability values.
+
+No secrets, paths, database records, candidate counts, or filesystem information are included.
+
+## Application startup
+
+`create_app()` evaluates composition readiness before constructing and serving the FastAPI application. Invalid runtime configuration therefore fails application construction instead of waiting for the first `/pipeline/run` request.
+
+The immutable snapshot is stored at:
+
+```text
+app.state.composition_runtime_readiness
+```
+
+Tests and controlled embedding environments may inject an already validated snapshot through `create_app(composition_readiness=...)`.
+
+## Endpoints
+
+### `/health`
+
+Existing liveness response remains unchanged:
+
+```json
+{
+  "status": "ok",
+  "app": "APPLAYLIST",
+  "env": "development",
+  "api_version": "0.1.0"
+}
+```
+
+### `/ready`
+
+The new readiness endpoint returns the immutable configuration snapshot:
+
+```json
+{
+  "status": "ready",
+  "composition_authority": "legacy",
+  "composition_comparison_enabled": false,
+  "composition_receipts_enabled": false
+}
+```
+
+`/ready` is a safe read-only endpoint. It does not scan files, query candidate data, create schemas, run composition, or write artifacts.
+
+## Isolation
+
+- Legacy remains the default authority.
+- No pipeline response or request schema changes.
+- No database migration.
+- No candidate availability assertion.
+- No filesystem or exporter side effect.
+- No automatic canonical fallback.
+
+## Verification
+
+Required gates:
+
+- startup rejection tests for every invalid combination;
+- valid legacy and canonical readiness tests;
+- exact `/health` backward-compatibility assertion;
+- `/ready` payload assertion;
+- application-state immutability assertion;
+- route wiring guard;
+- Python 3.11 and 3.12 install, compile, critical Ruff and full pytest;
+- PR Guard, review-thread and mergeability checks.
+
+## Rollback
+
+Operational rollback is `COMPOSITION_AUTHORITY=legacy`, with comparison and receipts disabled if necessary. Code rollback is a revert of the future Bundle 40 squash commit. No data rollback is required.

--- a/tests/test_composition_runtime_readiness.py
+++ b/tests/test_composition_runtime_readiness.py
@@ -1,0 +1,148 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import create_app
+from core.config.composition_authority import CompositionAuthorityName
+from core.config.composition_runtime import (
+    CompositionRuntimeConfigurationError,
+    CompositionRuntimeReadiness,
+    evaluate_composition_runtime,
+)
+from core.config.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def clear_settings_cache():
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def test_default_runtime_is_ready_with_legacy_authority(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("COMPOSITION_AUTHORITY", raising=False)
+    monkeypatch.delenv("ENABLE_COMPOSITION_COMPARISON", raising=False)
+    monkeypatch.delenv("ENABLE_COMPOSITION_RECEIPTS", raising=False)
+
+    readiness = evaluate_composition_runtime()
+
+    assert readiness == CompositionRuntimeReadiness(
+        status="ready",
+        authority=CompositionAuthorityName.LEGACY,
+        comparison_enabled=False,
+        receipts_enabled=False,
+    )
+
+
+def test_invalid_authority_fails_application_construction(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("COMPOSITION_AUTHORITY", "unsupported")
+
+    with pytest.raises(
+        CompositionRuntimeConfigurationError,
+        match="invalid composition authority",
+    ):
+        create_app()
+
+
+def test_canonical_with_comparison_fails_application_construction(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("COMPOSITION_AUTHORITY", "canonical")
+    monkeypatch.setenv("ENABLE_COMPOSITION_COMPARISON", "true")
+    monkeypatch.setenv("ENABLE_COMPOSITION_RECEIPTS", "false")
+
+    with pytest.raises(
+        CompositionRuntimeConfigurationError,
+        match="cannot be combined",
+    ):
+        create_app()
+
+
+def test_receipts_without_comparison_fail_application_construction(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("COMPOSITION_AUTHORITY", "legacy")
+    monkeypatch.setenv("ENABLE_COMPOSITION_COMPARISON", "false")
+    monkeypatch.setenv("ENABLE_COMPOSITION_RECEIPTS", "true")
+
+    with pytest.raises(
+        CompositionRuntimeConfigurationError,
+        match="require composition comparison",
+    ):
+        create_app()
+
+
+def test_valid_canonical_configuration_reports_ready(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("COMPOSITION_AUTHORITY", "canonical")
+    monkeypatch.setenv("ENABLE_COMPOSITION_COMPARISON", "false")
+    monkeypatch.setenv("ENABLE_COMPOSITION_RECEIPTS", "false")
+
+    application = create_app()
+    client = TestClient(application)
+
+    response = client.get("/ready")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ready",
+        "composition_authority": "canonical",
+        "composition_comparison_enabled": False,
+        "composition_receipts_enabled": False,
+    }
+    assert application.state.composition_runtime_readiness.authority == (
+        CompositionAuthorityName.CANONICAL
+    )
+
+
+def test_health_payload_remains_backward_compatible() -> None:
+    readiness = CompositionRuntimeReadiness(
+        status="ready",
+        authority=CompositionAuthorityName.LEGACY,
+        comparison_enabled=False,
+        receipts_enabled=False,
+    )
+    client = TestClient(create_app(composition_readiness=readiness))
+
+    payload = client.get("/health").json()
+
+    assert payload == {
+        "status": "ok",
+        "app": "APPLAYLIST",
+        "env": "development",
+        "api_version": "0.1.0",
+    }
+
+
+def test_explicit_readiness_injection_bypasses_environment_resolution(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("COMPOSITION_AUTHORITY", "unsupported")
+    readiness = CompositionRuntimeReadiness(
+        status="ready",
+        authority=CompositionAuthorityName.LEGACY,
+        comparison_enabled=False,
+        receipts_enabled=False,
+    )
+
+    application = create_app(composition_readiness=readiness)
+
+    assert application.state.composition_runtime_readiness is readiness
+
+
+def test_readiness_snapshot_is_immutable() -> None:
+    readiness = evaluate_composition_runtime(
+        authority="legacy",
+        comparison_enabled=False,
+        receipts_enabled=False,
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        readiness.status = "not-ready"

--- a/tests/test_route_wiring_guard.py
+++ b/tests/test_route_wiring_guard.py
@@ -7,6 +7,7 @@ def test_required_routes_present() -> None:
     paths = set(app.openapi().get("paths", {}))
     required = {
         "/health",
+        "/ready",
         "/jobs/{job_type}",
         "/jobs/{job_id}",
         "/pipeline/run",


### PR DESCRIPTION
## Summary
- add an immutable composition runtime readiness contract
- validate composition authority and observability during application construction
- reject receipts without comparison and canonical with comparison
- add a safe `/ready` endpoint while preserving `/health`
- store the validated snapshot on application state
- add startup, route, immutability and compatibility tests

## Verification
- branch created directly from Bundle 39 squash commit `dd749e8161f0a08acbec74577f19cf476f6fa268`
- ahead-only diff limited to seven startup, config, route, test and documentation files
- Python 3.11 and 3.12 CI required
- install, compile, critical Ruff and full pytest must pass
- no local test execution is claimed

## Isolation
- legacy remains the default authority
- no pipeline request or response change
- no database or candidate readiness query
- no filesystem scan, composition run or artifact write
- no database migration

## Bundle Context
- Bundle: 40 — Composition Startup Readiness Gate
- Base branch: `feature/bundle-0-bootstrap`
- Base commit: `dd749e8161f0a08acbec74577f19cf476f6fa268`
- Related issue: #55
- Rollback: restore valid legacy configuration or revert the future squash commit; no data rollback required