### PR TITLE
Bundle 41: product baseline realignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,96 @@
 # APPLAYLIST
 
-APPLAYLIST je backend a vývojový základ pro DJ/audio intelligence: analýzu tracků, tvorbu playlistů, strukturu setů, export a budoucí API produkt.
-
-## Aktuální stav
-
-- Kanonický repozitář: `nulleimy/APPLAYLIST`
-- Aktuální checkpoint: Bundle 23
-- Podporovaný Python: `>=3.11,<3.13`
-- Produkční stav: **není ještě release-ready**
-- Legacy analyzér zůstává aktivní; provider vrstva a benchmark jsou zatím experimentální základ
-
-## Architektura
+APPLAYLIST is a local-first DJ preparation product that turns a selected local music library into an explainable, editable and interoperable DJ set.
 
 ```text
-API -> Services -> Repositories -> DB
-               -> Queue -> Workers
-
-Audio input -> Provider -> Normalize/Validate -> AnalysisRecord -> Repository
+select local library
+-> import and analyze tracks
+-> build a constrained set
+-> inspect and edit transitions
+-> export to an existing DJ workflow
 ```
 
-Hranice komponent:
+## Current status
 
-- `api/` — HTTP rozhraní, middleware a transportní validace
-- `core/` — doménové kontrakty, provider registry a čistá logika
-- `services/` — aplikační orchestrace
-- `data/` — modely, repository a persistence
-- `workers/` — asynchronní zpracování
-- `tests/` — unit, integrační a regresní testy
-- `docs/` — architektura, rollout a provozní dokumentace
+- Canonical repository: `nulleimy/APPLAYLIST`
+- Canonical branch: `feature/bundle-0-bootstrap`
+- Current runtime checkpoint: **Bundle 40 — Composition Startup Readiness Gate**
+- Product baseline: **Bundle 41 — Product Baseline Realignment**
+- Supported Python: `>=3.11,<3.13`
+- Release status: **not yet product-ready**
+- Default composition authority remains `legacy`
+- Canonical composition is available behind controlled configuration
+- `/ready` validates the selected composition runtime configuration
+- Legacy analysis remains active while the real baseline provider and benchmark are pending
 
-## Lokální vývoj
+The repository has strong provider, composition, export, readiness and security foundations. The next work is intentionally product-first: library import, real analysis evidence, benchmark validation, desktop workflow, manual editing and M3U8 release.
+
+## Product baseline
+
+- [Product Definition v1](docs/product/APPLAYLIST_PRODUCT_DEFINITION_V1.md)
+- [Target Architecture v1](docs/architecture/APPLAYLIST_TARGET_ARCHITECTURE_V1.md)
+- [MIR Benchmark Specification v1](docs/quality/APPLAYLIST_MIR_BENCHMARK_SPEC_V1.md)
+- [License Decision Register v1](docs/compliance/APPLAYLIST_LICENSE_DECISION_REGISTER_V1.md)
+- [Product Roadmap — Bundles 41–51](docs/roadmap/APPLAYLIST_PRODUCT_ROADMAP_41_51.md)
+
+## Product objective
+
+The first release must let a DJ:
+
+1. select one explicit local audio folder,
+2. import supported files with stable identity and metadata,
+3. analyze BPM, key/Camelot, energy and duration using a real provider,
+4. inspect confidence, warnings and failures,
+5. create a deterministic set under explicit musical constraints,
+6. manually reorder, lock, replace and regenerate tracks,
+7. export an approved playlist as path-valid M3U8.
+
+## Architecture
+
+```text
+Desktop UI / FastAPI
+        |
+Application services
+        |
++-------+--------------------+
+|                            |
+Provider boundary       Repository boundary
+metadata/audio          tracks/analyses/playlists/jobs
+        |                            |
+        +------> normalized domain <-+
+                         |
+                composition and export
+```
+
+Component boundaries:
+
+- `api/` — HTTP routes, middleware and transport validation
+- `core/` — domain contracts, configuration, provider registry and pure rules
+- `services/` — application orchestration, analysis, composition and export
+- `data/` — models, repositories and persistence
+- `workers/` — asynchronous processing foundation
+- `tests/` — unit, integration and regression tests
+- `docs/` — product, architecture, rollout, quality and operations
+
+## Non-negotiable engineering rules
+
+1. Do not run tests with global Python.
+2. Use `.venv/bin/python`.
+3. Do not use Python 3.14 for this project yet.
+4. Do not commit `.env`, `.venv`, databases, caches or macOS/iCloud duplicate files.
+5. Optional audio backends must not import on the mandatory API boot path.
+6. Providers never persist directly.
+7. Only normalized and validated analysis records may be stored.
+8. API routes must not contain heavy audio or product use-case logic.
+9. Repositories own persistence.
+10. Tests and product acceptance gates must pass before every checkpoint.
+11. New abstractions require a named product need.
+12. Default-provider or authority changes require benchmark and rollback evidence.
+
+## Local development
 
 ```bash
-cd /cesta/k/APPLAYLIST
+cd /path/to/APPLAYLIST
 python3.11 -m venv .venv
 .venv/bin/python -m pip install --upgrade pip
 .venv/bin/python -m pip install -e ".[dev]"
@@ -40,33 +98,37 @@ cp .env.example .env
 .venv/bin/python -m uvicorn api.main:app --reload --host 127.0.0.1 --port 8000
 ```
 
-## Ověření
+## Verification
 
 ```bash
-cd /cesta/k/APPLAYLIST
+cd /path/to/APPLAYLIST
 .venv/bin/python -m compileall -q api core services data workers
 .venv/bin/python -m ruff check .
 .venv/bin/python -m pytest -q
 ```
 
-Nepoužívej globální Python ani Python 3.14. Do repozitáře nepatří `.env`, `.venv`, databáze, cache, lokální zálohy ani iCloud duplikáty typu `* 2.py`.
+Release gates:
 
-## Release brány
+- CI passes on Python 3.11 and 3.12,
+- mandatory boot does not require an optional audio backend,
+- provider output is normalized and validated before storage,
+- no fake success or hidden provider fallback,
+- API contract changes have an explicit migration plan,
+- exported playlist paths exist,
+- product-facing slices demonstrate their user-visible acceptance result.
 
-Release je povolen pouze při splnění všech podmínek:
+## Product-first implementation order
 
-1. CI projde na Pythonu 3.11 a 3.12.
-2. Import API nevyžaduje nepovinný audio backend.
-3. Provider výstup je normalizovaný a validovaný před uložením.
-4. Neexistuje falešný úspěch ani skrytý fallback.
-5. API kontrakty zůstávají zpětně kompatibilní nebo mají migrační plán.
-6. Rollback provider režimu je ověřený feature flagem.
+1. Bundle 41 — Product Baseline Realignment
+2. Bundle 42 — Library Import Boundary
+3. Bundle 43 — Metadata and Stable Track Identity
+4. Bundle 44 — Analysis Job Contract
+5. Bundle 45 — Real Baseline Audio Provider
+6. Bundle 46 — MIR Benchmark Harness
+7. Bundle 47 — Desktop Library Shell
+8. Bundle 48 — Analysis Inspector
+9. Bundle 49 — Set Builder
+10. Bundle 50 — Manual Playlist Editor
+11. Bundle 51 — M3U8 End-to-End Release Slice
 
-## Další implementační pořadí
-
-1. Production baseline a CI gate.
-2. Provider hardening bez importu optional závislostí při bootu.
-3. Routed analysis service za fail-closed feature flagem.
-4. Integrace do jobs, observability a persistence compatibility testy.
-5. API metadata/availability bez změny stávající response shape.
-6. Staging porovnání výstupů a teprve poté rozhodnutí o default provideru.
+Until Bundle 51, do not prioritize cloud accounts, streaming integration, live mixing, stems, mobile clients, proprietary database reverse engineering or additional generalized composition infrastructure.

--- a/docs/architecture/APPLAYLIST_TARGET_ARCHITECTURE_V1.md
+++ b/docs/architecture/APPLAYLIST_TARGET_ARCHITECTURE_V1.md
@@ -1,0 +1,319 @@
+# APPLAYLIST Target Architecture v1
+
+## Status
+
+Accepted target architecture for the product-first roadmap. This document does not activate new runtime behavior.
+
+## Architectural goal
+
+APPLAYLIST must support one complete local DJ workflow without coupling UI, audio backends, persistence and export logic.
+
+```text
+Desktop UI
+  -> application services
+      -> domain contracts
+      -> repositories
+      -> provider boundary
+      -> export adapters
+```
+
+## Product topology
+
+```text
++------------------------------------------------------+
+| Desktop application                                  |
+| Library | Analysis | Set Builder | Playlist | Export |
++-------------------------+----------------------------+
+                          |
++-------------------------v----------------------------+
+| Application services                                 |
+| LibraryImportService                                 |
+| AnalysisJobService                                   |
+| CanonicalCompositionRunner                           |
+| PlaylistEditingService                               |
+| PlaylistExportService                                |
++------------+------------------+----------------------+
+             |                  |
++------------v------+  +--------v----------------------+
+| Provider boundary  |  | Repository boundary          |
+| metadata reader    |  | libraries/import sessions    |
+| baseline audio     |  | tracks/analyses/playlists    |
+| advanced optional  |  | playlist revisions/jobs      |
++--------------------+  +-------------------------------+
+```
+
+## Runtime shape
+
+### Local-first application
+
+The first product release is a local desktop application backed by the existing Python domain and service layers.
+
+Recommended desktop candidate: PySide6 using Qt Widgets or QML. This is a decision candidate, not a dependency approval. The license register must be resolved before packaging.
+
+### Headless API
+
+FastAPI remains supported for:
+
+- automated tests,
+- local automation,
+- integrations,
+- future remote or service mode.
+
+The desktop UI should call application services directly where practical. Core product behavior must not exist only inside HTTP routes.
+
+## Layer responsibilities
+
+### UI layer
+
+Owns:
+
+- folder selection,
+- progress presentation,
+- table and editor state,
+- user commands,
+- validation feedback.
+
+Must not own:
+
+- filesystem traversal,
+- audio DSP,
+- SQL,
+- provider selection,
+- export serialization.
+
+### Application services
+
+Own use-case orchestration and transaction boundaries.
+
+Required services:
+
+- `LibraryImportService`
+- `AnalysisJobService`
+- `CanonicalCompositionRunner`
+- `PlaylistEditingService`
+- `PlaylistExportService`
+
+### Domain layer
+
+Owns immutable contracts and pure rules:
+
+- track identity,
+- analysis evidence,
+- composition constraints,
+- transition scoring,
+- playlist revisions,
+- export preconditions.
+
+Domain code must not import FastAPI, SQLite, desktop UI, Librosa or Essentia.
+
+### Provider layer
+
+Owns optional external or heavy capabilities:
+
+- metadata extraction,
+- baseline audio analysis,
+- advanced audio analysis,
+- future fingerprinting.
+
+Provider rules:
+
+- lazy optional imports,
+- raw output never persisted directly,
+- explicit availability and version,
+- controlled errors,
+- no repository writes.
+
+### Repository layer
+
+Owns persistence and query/read models.
+
+Required aggregate boundaries:
+
+- library,
+- import session,
+- track,
+- analysis,
+- playlist,
+- playlist revision,
+- job.
+
+Repositories must support batch operations required by import and analysis jobs.
+
+### Export adapters
+
+Each format is isolated behind a stable export contract.
+
+Initial order:
+
+1. M3U8
+2. JSON/manifest evidence
+3. rekordbox XML
+4. Traktor NML
+
+Adapters must never mutate the approved playlist.
+
+## Library import boundary
+
+A bounded scanner receives an explicit absolute root and policy:
+
+- allowed extensions,
+- recursion setting,
+- maximum file count,
+- symlink policy,
+- cancellation token.
+
+It returns evidence:
+
+- discovered paths,
+- accepted files,
+- skipped files with reason,
+- errors with controlled code.
+
+The scanner must not search outside the selected root.
+
+## Track identity
+
+Path alone is not a durable identity because files can move.
+
+MVP identity should combine:
+
+- normalized source path,
+- file size,
+- modified timestamp,
+- lightweight content fingerprint or deterministic hash strategy.
+
+The exact fingerprint algorithm is a Bundle 43 decision. It must be benchmarked for performance on large files and must not require network access.
+
+## Analysis flow
+
+```text
+TrackRecord
+-> AnalysisJob
+-> selected provider
+-> raw provider result
+-> normalize
+-> validate
+-> AnalysisRecord
+-> repository transaction
+```
+
+Required evidence:
+
+- provider name/version,
+- extractor and feature schema version,
+- BPM/key/energy/duration,
+- confidence values when available,
+- warnings,
+- source file identity,
+- completed timestamp.
+
+## Composition flow
+
+```text
+source-scoped analyzed candidates
+-> fail-closed candidate adapter
+-> canonical deterministic engine
+-> composition result and decision trace
+-> editable playlist revision
+```
+
+Composition must not query external services while scoring candidates.
+
+## Playlist editing model
+
+Manual editing requires a persisted revision model rather than mutating a generated result in place.
+
+Each revision should capture:
+
+- playlist ID,
+- ordered track IDs,
+- locked positions,
+- origin (`generated` or `manual`),
+- parent revision,
+- created timestamp,
+- warnings and unresolved transition issues.
+
+Undo/redo can operate over revisions or commands in the desktop state while saving explicit checkpoints.
+
+## Export flow
+
+```text
+approved playlist revision
+-> path integrity validation
+-> format adapter
+-> temporary output
+-> atomic publish
+-> export manifest
+```
+
+Export preconditions:
+
+- non-empty approved playlist,
+- all paths are absolute and exist,
+- no duplicate output identity,
+- no unresolved rejected track,
+- output remains below the configured export destination.
+
+## Background processing
+
+Long-running import and analysis work must use typed job payloads.
+
+A job payload must include:
+
+- job ID and type,
+- library/import session ID,
+- track IDs or source scope,
+- provider and options,
+- idempotency key,
+- cancellation state.
+
+A job must expose pending/running/done/failed/cancelled state and progress counts, not only a floating percentage.
+
+## Security boundaries
+
+- explicit local roots only,
+- no arbitrary server-side path supplied by an untrusted remote caller,
+- bounded recursion and file count,
+- symlink escape prevention,
+- safe output roots and atomic writes,
+- no secrets in repository or generated receipts,
+- optional providers cannot execute during mandatory boot.
+
+## Observability
+
+Product-relevant structured events:
+
+- import session summary,
+- analysis job summary,
+- provider selection and controlled failure,
+- composition request/result summary,
+- export path-integrity result.
+
+Existing comparison receipts remain diagnostic. They are not a user-facing product dependency.
+
+## Deployment stages
+
+### Development
+
+Python virtual environment, local SQLite, FastAPI and service tests.
+
+### Desktop MVP
+
+Signed macOS application is the first packaging target, followed by Windows. Packaging technology and Qt licensing require explicit approval before implementation.
+
+### Future service mode
+
+Remote API, accounts and cloud sync are deferred until local product value is proven.
+
+## Architecture invariants
+
+1. UI never performs DSP or SQL.
+2. Providers never persist.
+3. Routes never own core use-case logic.
+4. Optional audio imports never occur on mandatory boot.
+5. Only normalized validated analysis is stored.
+6. Composition is deterministic for a fixed snapshot and version.
+7. Manual edits produce explicit playlist state.
+8. Export validates every path before publishing.
+9. New abstraction work requires a named product use case.
+10. Default runtime changes require benchmark and rollback evidence.

--- a/docs/compliance/APPLAYLIST_LICENSE_DECISION_REGISTER_V1.md
+++ b/docs/compliance/APPLAYLIST_LICENSE_DECISION_REGISTER_V1.md
@@ -1,0 +1,121 @@
+# APPLAYLIST License Decision Register v1
+
+## Status
+
+Initial compliance register. Entries marked `review_required` are not approved for product distribution.
+
+This document is an engineering control, not legal advice. Final commercial distribution decisions require legal review appropriate to the business model and target jurisdictions.
+
+## Decision states
+
+- `approved_dev` — permitted for development and CI under current understanding.
+- `approved_distribution` — cleared for intended packaged distribution with documented obligations.
+- `experiment_only` — may be used for isolated evaluation but not shipped.
+- `review_required` — unresolved; do not add to product dependencies or installers.
+- `rejected` — must not be used for the stated product mode.
+
+## Current runtime stack
+
+| Component | Intended role | Current state | Required action |
+|---|---|---|---|
+| Python | runtime | approved_dev | verify redistribution notices for packaged app |
+| FastAPI | local/headless API | approved_dev | include dependency license manifest |
+| Pydantic | contracts/configuration | approved_dev | include dependency license manifest |
+| NumPy | numerical baseline | approved_dev | verify binary-wheel notices in packaged app |
+| SciPy | signal-processing baseline | approved_dev | verify binary-wheel notices in packaged app |
+| SoundFile | audio decode boundary | approved_dev | audit bundled native `libsndfile` obligations |
+| Librosa | baseline MIR candidate | approved_dev | benchmark; move behind lazy provider boundary |
+
+`approved_dev` does not automatically mean approved for a signed commercial installer.
+
+## Candidate metadata dependencies
+
+| Component | Candidate use | State | Decision notes |
+|---|---|---|---|
+| TinyTag | read-only audio metadata | review_required | verify exact version, license, supported formats and packaging before adding |
+| Mutagen | metadata read/write | review_required | broader functionality than MVP needs; legal and distribution review required before use |
+
+Product preference is the smallest read-only metadata dependency that satisfies supported formats and can be safely packaged.
+
+## Candidate MIR dependencies
+
+| Component | Candidate use | State | Decision notes |
+|---|---|---|---|
+| Essentia | advanced BPM/key/energy benchmark | experiment_only | commercial distribution requires explicit licensing decision; model licenses must be evaluated individually |
+| Essentia pretrained models | optional ML descriptors | review_required | no model may be downloaded or shipped without per-model license record |
+| madmom | beat/downbeat research | review_required | release age, compatibility and model-data restrictions require review; not an MVP dependency |
+| remote audio-analysis API | analysis provider | rejected for MVP | conflicts with local-first privacy and reproducibility goals unless separately approved |
+
+## Desktop candidates
+
+| Component | Candidate use | State | Decision notes |
+|---|---|---|---|
+| PySide6 / Qt for Python | desktop shell | review_required | available under community LGPLv3/GPLv3 or commercial Qt terms; packaging approach and compliance plan required |
+| Qt commercial distribution | desktop shell | review_required | evaluate cost and licensing against business model before dependency approval |
+| pyside6-deploy / Nuitka path | packaging | review_required | run reproducible macOS and Windows packaging proof; audit transitive licenses and generated notices |
+
+No desktop dependency may be added to the main runtime dependency set in Bundle 41.
+
+## Export formats and interoperability
+
+| Format/integration | State | Notes |
+|---|---|---|
+| M3U8 | approved_dev | first MVP export; path-integrity and encoding tests required |
+| JSON manifest | approved_dev | internal evidence format; schema version required |
+| rekordbox XML | review_required | implement from documented import format; avoid proprietary database manipulation |
+| Traktor NML | review_required | format and compatibility tests required before product claim |
+| OneLibrary | monitor | evaluate only through published compatible interfaces or partnership path |
+| proprietary database reverse engineering | rejected | outside MVP and unacceptable without explicit legal/product approval |
+
+## Datasets
+
+Every benchmark dataset requires a manifest containing:
+
+- dataset name/version,
+- source and retrieval date,
+- license text or stable reference,
+- allowed research/commercial use,
+- redistribution permission,
+- checksums,
+- storage location.
+
+Rules:
+
+- dataset audio is never committed to the repository,
+- non-redistributable annotations stay outside source control,
+- public reports contain only permitted aggregate or derived data,
+- private DJ collections require documented ownership or permission.
+
+## Installer compliance requirements
+
+Before any external release:
+
+1. generate a complete SBOM from the resolved packaged environment,
+2. collect dependency and native-library license notices,
+3. document source-offer or relinking obligations where applicable,
+4. verify that no `experiment_only` or `review_required` component is packaged,
+5. verify code signing and notarization inputs contain no secrets,
+6. archive the exact dependency lock and build provenance,
+7. run the packaged application on a clean target machine.
+
+## Approval template
+
+A dependency may move to `approved_distribution` only with a decision record containing:
+
+- exact package and version,
+- role and alternatives considered,
+- upstream license and copyright notices,
+- transitive/native dependencies,
+- dynamic/static linking and packaging method,
+- distribution obligations,
+- security maintenance status,
+- approving reviewer and date.
+
+## Immediate decisions
+
+- keep the current backend dependency set unchanged in Bundle 41,
+- use Librosa only as a baseline benchmark candidate until quality gates pass,
+- keep Essentia out of production dependencies,
+- do not start the PySide6 implementation before a desktop licensing and packaging decision,
+- implement M3U8 before proprietary ecosystem adapters,
+- prohibit unreviewed pretrained-model downloads in runtime or CI.

--- a/docs/product/APPLAYLIST_PRODUCT_DEFINITION_V1.md
+++ b/docs/product/APPLAYLIST_PRODUCT_DEFINITION_V1.md
@@ -1,0 +1,184 @@
+# APPLAYLIST Product Definition v1
+
+## Status
+
+Accepted target for the product-first roadmap. Bundle 41 does not change runtime behavior.
+
+## Product statement
+
+APPLAYLIST is a local-first DJ preparation application that turns a selected local music library into an explainable, editable and interoperable DJ set.
+
+The product must help a DJ move from audio files to a playable set:
+
+```text
+select local library
+-> import track metadata
+-> analyze musical evidence
+-> build a constrained set
+-> inspect and edit transitions
+-> export to an existing DJ workflow
+```
+
+## Primary user
+
+The first release targets a working DJ who:
+
+- owns or controls local audio files,
+- prepares sets before a performance,
+- understands BPM and harmonic mixing,
+- wants automation without surrendering final control,
+- already uses software such as rekordbox, Traktor, Serato or Mixxx,
+- needs a reliable playlist rather than an automatic live-mixing system.
+
+## Core problem
+
+Existing DJ platforms are strong at library management, performance and hardware integration. APPLAYLIST must not reproduce those products.
+
+Its focused problem is:
+
+> Produce a musically defensible starting set from real local tracks, explain why each transition was selected, let the DJ correct it quickly, and export the approved order safely.
+
+## Product promise
+
+For a selected folder of supported audio files, APPLAYLIST will:
+
+1. import each supported file with stable identity and metadata,
+2. analyze BPM, key/Camelot, energy and duration with quality evidence,
+3. reject or visibly flag incomplete and invalid analysis,
+4. compose a deterministic set under explicit constraints,
+5. display transition reasons and warnings,
+6. preserve manual edits,
+7. export only tracks with valid existing paths.
+
+## Product principles
+
+### Human authority
+
+The DJ is the final authority. Automatic composition produces a proposal, never an irreversible result.
+
+### Evidence before confidence
+
+BPM, key and energy values must include provider/version provenance, confidence where available, and warnings when uncertain.
+
+### Local-first
+
+The first release operates on local audio files and a local database. Cloud accounts and remote synchronization are outside the MVP.
+
+### Interoperability
+
+APPLAYLIST exports into existing DJ ecosystems. It does not require the DJ to abandon their current performance software.
+
+### Determinism
+
+The same library snapshot, constraints and engine version must produce the same initial result.
+
+### Fail closed for data quality
+
+Invalid paths, NaN/inf values, malformed keys and fake provider success must never silently enter an exported playlist.
+
+## MVP user journey
+
+### 1. Import
+
+The user selects one explicit folder. APPLAYLIST performs a bounded scan and displays imported, skipped and failed files.
+
+### 2. Analyze
+
+The user starts analysis for new or changed tracks. Progress and controlled errors are visible.
+
+### 3. Inspect
+
+The library shows at minimum:
+
+- title and artist,
+- source path,
+- duration,
+- BPM and confidence,
+- key and Camelot,
+- energy,
+- provider and analysis version,
+- warning/error state.
+
+### 4. Build set
+
+The user chooses:
+
+- target track count or target duration,
+- BPM range,
+- composition mode/energy curve,
+- optional genres,
+- optional start key,
+- maximum transition constraints.
+
+### 5. Edit
+
+The user can reorder, remove, lock and replace tracks and regenerate a selected section.
+
+### 6. Export
+
+The approved result is exported as M3U8 with a machine-readable manifest and path-integrity evidence.
+
+## MVP Definition of Done
+
+The MVP is complete only when a clean installation can demonstrate this end-to-end flow with real local files:
+
+- an explicit folder is imported,
+- supported files receive stable track records,
+- BPM, key/Camelot, energy and duration are produced by a real provider,
+- no provider returns `stub` or fake success,
+- analysis is normalized and persisted outside the provider,
+- canonical composition respects source scope and user constraints,
+- transition reasons are visible,
+- the playlist can be manually edited,
+- every exported path exists,
+- the M3U8 opens successfully in at least one supported DJ application,
+- the complete flow has a documented smoke test,
+- Python 3.11 and 3.12 CI remains green.
+
+## Explicit non-goals before MVP
+
+- live DJ performance or audio playback,
+- automatic live mixing,
+- stems generation,
+- waveform or beatgrid editing,
+- streaming-catalog integration,
+- cloud sync and multi-user accounts,
+- mobile applications,
+- generative chat as the primary UI,
+- reverse engineering proprietary DJ databases,
+- additional authority, receipt or governance abstractions without a product requirement.
+
+## Success metrics
+
+### Technical
+
+- 100% exported-path integrity,
+- deterministic composition for an unchanged snapshot,
+- zero invalid numeric values persisted,
+- controlled failures instead of optional-provider startup crashes.
+
+### Product
+
+- first set created from a local folder without manual database work,
+- a DJ can identify why each transition was selected,
+- a DJ can correct a weak transition without rebuilding the full set,
+- exported order is usable in an existing DJ workflow.
+
+## Release sequence
+
+The product-first sequence is:
+
+```text
+product baseline
+-> bounded library import
+-> metadata and identity
+-> analysis jobs
+-> real baseline provider
+-> MIR benchmark decision
+-> desktop library UI
+-> analysis inspector
+-> set builder/editor
+-> M3U8 vertical-slice release
+```
+
+Any new proposal must state which step it advances and how its completion will be verified by a user-visible outcome.

--- a/docs/quality/APPLAYLIST_MIR_BENCHMARK_SPEC_V1.md
+++ b/docs/quality/APPLAYLIST_MIR_BENCHMARK_SPEC_V1.md
@@ -1,0 +1,242 @@
+# APPLAYLIST MIR Benchmark Specification v1
+
+## Status
+
+Accepted benchmark design. No provider is approved as the production default by this document.
+
+## Purpose
+
+APPLAYLIST must choose audio providers using measured DJ-relevant quality, performance, licensing and packaging evidence.
+
+A green unit-test suite proves software behavior. It does not prove BPM, key or energy accuracy.
+
+## Benchmark questions
+
+1. Can the provider decode the supported local library reliably?
+2. Is BPM accurate after accounting for half/double-tempo ambiguity?
+3. Is key useful for Camelot-oriented DJ transitions?
+4. Does the energy value preserve a useful ranking for set construction?
+5. Is analysis fast enough for a local desktop workflow?
+6. Does the provider package and license fit the intended commercial distribution?
+
+## Providers under evaluation
+
+### Baseline candidate
+
+Librosa with NumPy/SciPy/SoundFile behind a lazy provider boundary.
+
+Required remediation before benchmarking:
+
+- no module-level optional import on mandatory boot,
+- no repository write inside provider code,
+- normalized raw result contract,
+- provider and algorithm version evidence,
+- confidence/warning fields,
+- controlled decode/runtime/output failures.
+
+### Advanced candidate
+
+Essentia may be evaluated as an optional benchmark provider. It is not approved for commercial distribution until licensing is resolved.
+
+### Excluded from initial decision
+
+- providers returning stub or empty musical descriptors,
+- remote services requiring upload of user audio,
+- models with unresolved non-commercial restrictions,
+- algorithms that cannot report version/provenance.
+
+## Datasets
+
+The benchmark must include both public reference data and a private legal DJ evaluation collection.
+
+### Public reference categories
+
+- electronic-dance tempo annotations,
+- electronic-dance key annotations,
+- beat/downbeat data where licensing permits local evaluation.
+
+Dataset manifests must record:
+
+- name and version,
+- source URL,
+- license,
+- checksum,
+- permitted use,
+- local storage location outside the repository.
+
+Audio files and restricted datasets must not be committed.
+
+### Private DJ evaluation set
+
+Minimum initial target: 200 legally controlled tracks, stratified across:
+
+- house,
+- tech house,
+- groove techno,
+- hypnotic techno,
+- tracks with beatless intros/outros,
+- live or unstable percussion,
+- half/double-tempo ambiguity,
+- major/minor and modal ambiguity,
+- long breakdowns and dynamic energy changes.
+
+Each reference item should contain manual evidence for BPM and key and a DJ energy score. Annotation provenance must identify the human and method.
+
+## Ground-truth representation
+
+### BPM
+
+Store:
+
+- reference BPM,
+- accepted alternate half/double value where musically equivalent,
+- confidence/annotation notes.
+
+### Key
+
+Store tonic and mode plus normalized Camelot value where applicable.
+
+Evaluation categories:
+
+- exact tonic/mode,
+- relative major/minor,
+- adjacent Camelot position,
+- compatible but non-exact,
+- incompatible.
+
+### Energy
+
+Energy is not treated as a universal physical truth. Store a DJ-oriented ordinal score and optional pairwise ranking annotations.
+
+## Metrics
+
+### Decode reliability
+
+- supported files attempted,
+- successful analyses,
+- controlled failures,
+- uncontrolled exceptions,
+- median and p95 duration.
+
+### BPM
+
+- exact within +/- 1%,
+- correct after half/double normalization,
+- absolute percentage error,
+- catastrophic outlier count.
+
+### Key
+
+- exact accuracy,
+- relative accuracy,
+- Camelot-compatible accuracy,
+- incompatible error rate.
+
+### Energy
+
+- Spearman rank correlation,
+- pairwise ordering agreement,
+- distribution collapse detection,
+- genre-stratified performance.
+
+### Runtime
+
+Measure on the supported development Mac and at least one representative target machine:
+
+- real-time factor,
+- median and p95 seconds per track,
+- peak memory,
+- cold-start cost,
+- concurrency behavior.
+
+### Data integrity
+
+- NaN/inf count,
+- missing required descriptor count,
+- invalid Camelot/key count,
+- persistence validation failures.
+
+## Proposed acceptance gates
+
+These are APPLAYLIST product gates, not universal industry standards.
+
+| Metric | Initial gate |
+|---|---:|
+| Supported-file decode success | >= 99.5% |
+| Controlled rather than uncontrolled failure | 100% |
+| Duration availability | >= 99.9% |
+| BPM correct after half/double normalization | >= 95% within +/- 1% |
+| Exact key accuracy | >= 75% |
+| Camelot-compatible key accuracy | >= 90% |
+| Invalid numeric values persisted | 0 |
+| Exported paths existing | 100% |
+| Determinism for fixed input/version | 100% |
+| Energy rank correlation on private set | >= 0.75 |
+| DJ-rated playable transitions | >= 85% |
+
+A threshold may be changed only with a documented rationale and versioned benchmark report.
+
+## Human transition evaluation
+
+Automatic descriptor metrics are necessary but insufficient.
+
+A blind evaluation should sample generated adjacent pairs and ask DJs to classify:
+
+- playable,
+- playable with manual correction,
+- not playable.
+
+Record reasons:
+
+- BPM jump,
+- harmonic clash,
+- energy mismatch,
+- phrasing/structure issue,
+- artist/label repetition,
+- subjective preference.
+
+The benchmark report must separate objective rule violations from subjective rejection.
+
+## Reproducibility
+
+Each run produces a machine-readable report containing:
+
+- benchmark schema version,
+- dataset manifest checksums,
+- provider and dependency versions,
+- source commit,
+- hardware/OS/Python information,
+- configuration,
+- per-track outputs and errors,
+- aggregate metrics.
+
+Generated reports belong under ignored artifacts storage unless a redacted aggregate report is intentionally committed.
+
+## Decision matrix
+
+Provider selection weighs:
+
+| Dimension | Weight |
+|---|---:|
+| BPM/key quality | 35% |
+| Decode reliability | 20% |
+| Energy usefulness | 15% |
+| Runtime/packaging | 15% |
+| License/commercial suitability | 15% |
+
+A provider that fails licensing or controlled-failure requirements cannot win through accuracy alone.
+
+## Decision gate
+
+The production default cannot change until:
+
+- the baseline provider is benchmarked,
+- the advanced candidate is benchmarked if legally available,
+- results are reviewed by a human DJ,
+- persistence compatibility is proven,
+- rollback to the prior provider is verified,
+- the license register marks the selected stack as approved.
+
+## Required implementation bundle
+
+The benchmark harness is scheduled after real baseline-provider hardening and before desktop UI composition becomes release-authoritative.

--- a/docs/roadmap/APPLAYLIST_PRODUCT_ROADMAP_41_51.md
+++ b/docs/roadmap/APPLAYLIST_PRODUCT_ROADMAP_41_51.md
@@ -1,0 +1,291 @@
+# APPLAYLIST Product Roadmap — Bundles 41–51
+
+## Status
+
+Accepted product-first implementation order following Bundle 40 composition startup readiness.
+
+## Governing rule
+
+Every bundle after Bundle 41 must deliver a named product capability, a measurable acceptance result, or a release-critical dependency for the next vertical slice.
+
+Additional authority, receipt, governance or generalized orchestration work is frozen unless a roadmap bundle demonstrates that it is necessary.
+
+## Bundle 41 — Product Baseline Realignment
+
+### Goal
+
+Replace infrastructure-first sequencing with a product-first baseline.
+
+### Deliverables
+
+- Product Definition v1
+- Target Architecture v1
+- MIR Benchmark Specification v1
+- License Decision Register v1
+- this roadmap
+- updated README and implementation order
+
+### Scope
+
+Documentation only.
+
+## Bundle 42 — Library Import Boundary
+
+### User value
+
+A DJ can select one local folder and see which audio files APPLAYLIST accepts, skips or cannot read.
+
+### Deliverables
+
+- immutable library and import-session contracts,
+- bounded directory scanner,
+- explicit supported-extension policy,
+- recursion, symlink and maximum-file limits,
+- cancellation boundary,
+- accepted/skipped/error evidence,
+- no analysis or metadata dependency yet.
+
+### Acceptance
+
+- scanner never escapes the selected root,
+- deterministic ordering,
+- duplicate paths are not returned twice,
+- controlled results for unreadable files and loops,
+- unit and temporary-filesystem integration tests.
+
+## Bundle 43 — Metadata and Stable Track Identity
+
+### User value
+
+Imported files become useful library rows and remain identifiable after safe rescans.
+
+### Deliverables
+
+- read-only metadata provider contract,
+- selected provider after license review,
+- normalized title/artist/album/genre/duration/sample-rate/bitrate,
+- stable identity strategy,
+- batch track upsert/query operations,
+- changed/moved/missing file evidence,
+- import-session persistence.
+
+### Acceptance
+
+- supported formats produce normalized records,
+- malformed tags cannot break an import batch,
+- a rescan is idempotent,
+- identity collisions and moves are tested.
+
+## Bundle 44 — Analysis Job Contract
+
+### User value
+
+A DJ can start, observe and cancel analysis for imported tracks.
+
+### Deliverables
+
+- typed job payload,
+- track/library/provider/options fields,
+- idempotency key,
+- pending/running/done/failed/cancelled states,
+- count-based progress,
+- controlled error taxonomy,
+- repository-backed job state.
+
+### Acceptance
+
+- retry does not create duplicate analysis for the same version,
+- cancellation is visible and controlled,
+- job payload contains no arbitrary unvalidated path authority.
+
+## Bundle 45 — Real Baseline Audio Provider
+
+### User value
+
+APPLAYLIST produces real BPM, key/Camelot, energy and duration evidence for local tracks.
+
+### Deliverables
+
+- lazy Librosa/NumPy/SciPy provider boundary,
+- no repository writes inside provider code,
+- normalized raw result,
+- algorithm/provider version evidence,
+- confidence and warnings where possible,
+- controlled decode/dependency/runtime/output failures,
+- analysis application service persistence transaction.
+
+### Acceptance
+
+- no optional import on API mandatory boot,
+- no `stub` result,
+- no NaN/inf persistence,
+- real audio fixtures produce validated records,
+- failure of one file does not corrupt the batch.
+
+## Bundle 46 — MIR Benchmark Harness
+
+### User value
+
+Provider choice is justified by measured quality rather than implementation convenience.
+
+### Deliverables
+
+- dataset manifest schema,
+- benchmark runner,
+- BPM/key/energy/runtime metrics,
+- machine-readable report,
+- baseline Librosa report,
+- optional Essentia experiment when licensing permits,
+- human DJ transition-evaluation protocol.
+
+### Decision Gate A
+
+The production provider default cannot change until the benchmark and license review pass.
+
+## Bundle 47 — Desktop Library Shell
+
+### User value
+
+The DJ can perform import and inspect library state without terminal or direct API use.
+
+### Preconditions
+
+- desktop framework and packaging license approved,
+- Bundles 42–46 complete.
+
+### Deliverables
+
+- desktop application entry point,
+- folder picker,
+- library table,
+- import and analysis progress,
+- error/warning presentation,
+- service-layer integration without duplicated domain logic.
+
+### Acceptance
+
+A clean local user can import and analyze a folder through the UI.
+
+## Bundle 48 — Analysis Inspector
+
+### User value
+
+The DJ can review uncertain or invalid analysis before using tracks in a set.
+
+### Deliverables
+
+- BPM/key/Camelot/energy/confidence display,
+- provider/version evidence,
+- warning filters,
+- manual correction command and audit trail,
+- re-analysis command.
+
+### Acceptance
+
+Manual corrections survive refresh and are distinguishable from provider output.
+
+## Bundle 49 — Set Builder
+
+### User value
+
+The DJ can generate an explainable set under explicit musical constraints.
+
+### Deliverables
+
+- target count and target-duration request,
+- BPM range,
+- energy curve/mode,
+- genre and optional start-key controls,
+- canonical composition execution,
+- transition score/reason panel,
+- summary warnings and constraint failures.
+
+### Acceptance
+
+The UI result reflects the exact source scope and constraints and is deterministic for a fixed snapshot.
+
+## Bundle 50 — Manual Playlist Editor
+
+### User value
+
+The DJ can turn an automatic proposal into an approved performance plan.
+
+### Deliverables
+
+- persisted playlist/revision model,
+- reorder/remove/lock/replace,
+- regenerate selected section,
+- undo/redo or revision checkpoints,
+- transition-warning recalculation,
+- explicit approved state.
+
+### Acceptance
+
+Manual edits do not disappear after restart and export uses the approved revision.
+
+## Bundle 51 — M3U8 End-to-End Release Slice
+
+### User value
+
+A DJ can complete the full workflow and open the exported playlist in supported DJ software.
+
+### Deliverables
+
+- approved-revision export,
+- UTF-8 M3U8 adapter,
+- atomic write and manifest,
+- path-integrity validation,
+- desktop export action,
+- clean-install instructions,
+- end-to-end smoke script,
+- supported-DJ-software compatibility record.
+
+### Definition of Done
+
+- select folder,
+- import tracks,
+- analyze real audio,
+- inspect evidence,
+- generate set,
+- edit order,
+- export M3U8,
+- open the playlist successfully in at least one declared supported application.
+
+## Post-MVP candidates
+
+Only after Bundle 51:
+
+- rekordbox XML adapter,
+- Traktor NML adapter,
+- advanced provider rollout,
+- packaging for additional platforms,
+- library change monitoring,
+- cue/phrase research,
+- OneLibrary-compatible integration when technically and legally available.
+
+## Stop list until Bundle 51
+
+- cloud accounts and synchronization,
+- streaming services,
+- mobile clients,
+- live performance engine,
+- stems,
+- waveform/beatgrid editor,
+- AI chat as the main product surface,
+- automatic live transitions,
+- proprietary database reverse engineering,
+- further composition authority abstractions without an accepted product need.
+
+## Release governance
+
+Each bundle requires:
+
+1. issue with user value and scope,
+2. branch from exact canonical head,
+3. smallest isolated diff,
+4. Python 3.11 and 3.12 CI,
+5. product acceptance tests appropriate to the slice,
+6. rollback statement,
+7. documentation update when contracts change.
+
+A green test count alone is not sufficient. Product-facing bundles must demonstrate their user-visible acceptance outcome.

--- a/docs/status/BUNDLE_41_PRODUCT_BASELINE_REALIGNMENT.md
+++ b/docs/status/BUNDLE_41_PRODUCT_BASELINE_REALIGNMENT.md
@@ -1,0 +1,73 @@
+# Bundle 41 — Product Baseline Realignment
+
+## Status
+
+Documentation implementation complete. Runtime verification and merge gate pending.
+
+## Base
+
+- canonical branch: `feature/bundle-0-bootstrap`
+- base commit: `d7b0155829ac880af3a3278adcafe1ff405b17e2`
+- predecessor: Bundle 40 — Composition Startup Readiness Gate
+- related issue: #60
+
+## Decision
+
+APPLAYLIST development is realigned from infrastructure-first work to one local-first DJ product journey:
+
+```text
+library import
+-> metadata and stable identity
+-> real audio analysis
+-> benchmark decision
+-> desktop library
+-> explainable set builder
+-> manual editor
+-> interoperable M3U8 release
+```
+
+## Added baseline documents
+
+- `docs/product/APPLAYLIST_PRODUCT_DEFINITION_V1.md`
+- `docs/architecture/APPLAYLIST_TARGET_ARCHITECTURE_V1.md`
+- `docs/quality/APPLAYLIST_MIR_BENCHMARK_SPEC_V1.md`
+- `docs/compliance/APPLAYLIST_LICENSE_DECISION_REGISTER_V1.md`
+- `docs/roadmap/APPLAYLIST_PRODUCT_ROADMAP_41_51.md`
+
+## Runtime impact
+
+None.
+
+This bundle does not change:
+
+- Python dependencies,
+- provider behavior,
+- composition authority or startup readiness,
+- API routes or schemas,
+- persistence,
+- export behavior,
+- feature flags.
+
+The Bundle 40 readiness endpoint and runtime validation remain unchanged.
+
+## Governance effect
+
+Until Bundle 51, new work must map to the accepted product roadmap. Additional authority, receipt, cloud or generalized orchestration work requires a documented blocking product need.
+
+## Verification requirements
+
+- documentation-only diff,
+- README updated to current runtime checkpoint,
+- all referenced files exist,
+- no code/dependency/config runtime change,
+- PR Guard green,
+- Python 3.11 and 3.12 CI remains green,
+- full test suite remains green.
+
+## Rollback
+
+Revert the future Bundle 41 documentation squash commit. No runtime, database or artifact rollback is required.
+
+## Next
+
+Bundle 42 — bounded Library Import Boundary.


### PR DESCRIPTION
## Summary
- define APPLAYLIST as a local-first explainable DJ set preparation product
- add Product Definition v1 and MVP Definition of Done
- add the target desktop/service/provider/repository architecture
- define the MIR benchmark and provider decision gates
- add a dependency and distribution license decision register
- replace infrastructure-first sequencing with the Bundle 41–51 product roadmap
- update the README from the stale Bundle 23 checkpoint to the current Bundle 40 readiness/product-first baseline

## Verification
- branch created directly from Bundle 40 squash commit `d7b0155829ac880af3a3278adcafe1ff405b17e2`
- ahead-only diff contains one README update and six new documentation files
- no Python, API, database, dependency, environment or runtime configuration file is changed
- PR Guard and full Python 3.11/3.12 CI are required
- no local test execution is claimed

## Isolation
- documentation-only bundle
- Bundle 40 composition startup-readiness behavior remains unchanged
- legacy/canonical authority defaults remain unchanged
- no provider rollout or desktop dependency is activated
- no database migration or generated artifact
- future generalized infrastructure work is frozen unless tied to an accepted product slice

## Bundle Context
- Bundle: 41 — Product Baseline Realignment
- Base branch: `feature/bundle-0-bootstrap`
- Base commit: `d7b0155829ac880af3a3278adcafe1ff405b17e2`
- Related issue: #60
- Next: Bundle 42 — bounded Library Import Boundary
- Rollback: revert the future documentation-only squash commit; no runtime or data rollback required