### PR TITLE
Bundle 42: bounded library import boundary

### DIFF
--- a/core/library/__init__.py
+++ b/core/library/__init__.py
@@ -1,0 +1,15 @@
+from core.library.contracts import (
+    DEFAULT_AUDIO_EXTENSIONS,
+    LibraryScanIssue,
+    LibraryScanPolicy,
+    LibraryScanResult,
+    SymlinkPolicy,
+)
+
+__all__ = [
+    "DEFAULT_AUDIO_EXTENSIONS",
+    "LibraryScanIssue",
+    "LibraryScanPolicy",
+    "LibraryScanResult",
+    "SymlinkPolicy",
+]

--- a/core/library/contracts.py
+++ b/core/library/contracts.py
@@ -48,10 +48,14 @@ class LibraryScanPolicy:
             raise TypeError("recursive must be boolean")
         if not isinstance(self.include_hidden, bool):
             raise TypeError("include_hidden must be boolean")
-        if isinstance(self.max_entries, bool) or self.max_entries <= 0:
-            raise ValueError("max_entries must be a positive integer")
-        if isinstance(self.max_files, bool) or self.max_files <= 0:
-            raise ValueError("max_files must be a positive integer")
+        if not isinstance(self.max_entries, int) or isinstance(self.max_entries, bool):
+            raise TypeError("max_entries must be an integer")
+        if self.max_entries <= 0:
+            raise ValueError("max_entries must be positive")
+        if not isinstance(self.max_files, int) or isinstance(self.max_files, bool):
+            raise TypeError("max_files must be an integer")
+        if self.max_files <= 0:
+            raise ValueError("max_files must be positive")
 
         policy = self.symlink_policy
         if not isinstance(policy, SymlinkPolicy):
@@ -98,13 +102,19 @@ class LibraryScanResult:
         root = Path(self.root)
         if not root.is_absolute():
             raise ValueError("scan result root must be absolute")
-        if isinstance(self.discovered_entries, bool) or self.discovered_entries < 0:
-            raise ValueError("discovered_entries must be a non-negative integer")
+        if not isinstance(self.discovered_entries, int) or isinstance(
+            self.discovered_entries,
+            bool,
+        ):
+            raise TypeError("discovered_entries must be an integer")
+        if self.discovered_entries < 0:
+            raise ValueError("discovered_entries must be non-negative")
         if any(not Path(path).is_absolute() for path in self.accepted_paths):
             raise ValueError("accepted paths must be absolute")
         if len(set(self.accepted_paths)) != len(self.accepted_paths):
             raise ValueError("accepted paths must be unique")
-        if tuple(sorted(self.accepted_paths, key=str.casefold)) != self.accepted_paths:
+        sort_key = lambda value: (value.casefold(), value)
+        if tuple(sorted(self.accepted_paths, key=sort_key)) != self.accepted_paths:
             raise ValueError("accepted paths must be deterministically sorted")
         for value, name in (
             (self.cancelled, "cancelled"),

--- a/core/library/contracts.py
+++ b/core/library/contracts.py
@@ -18,6 +18,10 @@ DEFAULT_AUDIO_EXTENSIONS = (
 )
 
 
+def _text_sort_key(value: str) -> tuple[str, str]:
+    return value.casefold(), value
+
+
 class SymlinkPolicy(str, Enum):
     SKIP = "skip"
     ALLOW_WITHIN_ROOT = "allow_within_root"
@@ -113,8 +117,7 @@ class LibraryScanResult:
             raise ValueError("accepted paths must be absolute")
         if len(set(self.accepted_paths)) != len(self.accepted_paths):
             raise ValueError("accepted paths must be unique")
-        sort_key = lambda value: (value.casefold(), value)
-        if tuple(sorted(self.accepted_paths, key=sort_key)) != self.accepted_paths:
+        if tuple(sorted(self.accepted_paths, key=_text_sort_key)) != self.accepted_paths:
             raise ValueError("accepted paths must be deterministically sorted")
         for value, name in (
             (self.cancelled, "cancelled"),

--- a/core/library/contracts.py
+++ b/core/library/contracts.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+
+DEFAULT_AUDIO_EXTENSIONS = (
+    ".aac",
+    ".aif",
+    ".aiff",
+    ".flac",
+    ".m4a",
+    ".mp3",
+    ".ogg",
+    ".opus",
+    ".wav",
+)
+
+
+class SymlinkPolicy(str, Enum):
+    SKIP = "skip"
+    ALLOW_WITHIN_ROOT = "allow_within_root"
+
+
+@dataclass(frozen=True, slots=True)
+class LibraryScanPolicy:
+    allowed_extensions: tuple[str, ...] = DEFAULT_AUDIO_EXTENSIONS
+    recursive: bool = True
+    include_hidden: bool = False
+    symlink_policy: SymlinkPolicy = SymlinkPolicy.SKIP
+    max_entries: int = 100_000
+    max_files: int = 10_000
+
+    def __post_init__(self) -> None:
+        normalized_extensions: set[str] = set()
+        for extension in self.allowed_extensions:
+            if not isinstance(extension, str) or not extension.strip():
+                raise ValueError("allowed extensions must be non-empty strings")
+            normalized = extension.strip().lower()
+            if not normalized.startswith("."):
+                normalized = f".{normalized}"
+            normalized_extensions.add(normalized)
+
+        if not normalized_extensions:
+            raise ValueError("at least one allowed extension is required")
+        if not isinstance(self.recursive, bool):
+            raise TypeError("recursive must be boolean")
+        if not isinstance(self.include_hidden, bool):
+            raise TypeError("include_hidden must be boolean")
+        if isinstance(self.max_entries, bool) or self.max_entries <= 0:
+            raise ValueError("max_entries must be a positive integer")
+        if isinstance(self.max_files, bool) or self.max_files <= 0:
+            raise ValueError("max_files must be a positive integer")
+
+        policy = self.symlink_policy
+        if not isinstance(policy, SymlinkPolicy):
+            try:
+                policy = SymlinkPolicy(policy)
+            except (TypeError, ValueError) as exc:
+                raise ValueError("unsupported symlink policy") from exc
+
+        object.__setattr__(
+            self,
+            "allowed_extensions",
+            tuple(sorted(normalized_extensions)),
+        )
+        object.__setattr__(self, "symlink_policy", policy)
+
+
+@dataclass(frozen=True, slots=True)
+class LibraryScanIssue:
+    path: str
+    code: str
+    detail: str
+
+    def __post_init__(self) -> None:
+        if not self.path:
+            raise ValueError("scan issue path is required")
+        if not self.code:
+            raise ValueError("scan issue code is required")
+        if not self.detail:
+            raise ValueError("scan issue detail is required")
+
+
+@dataclass(frozen=True, slots=True)
+class LibraryScanResult:
+    root: str
+    accepted_paths: tuple[str, ...]
+    skipped: tuple[LibraryScanIssue, ...]
+    errors: tuple[LibraryScanIssue, ...]
+    discovered_entries: int
+    cancelled: bool = False
+    entry_limit_reached: bool = False
+    file_limit_reached: bool = False
+
+    def __post_init__(self) -> None:
+        root = Path(self.root)
+        if not root.is_absolute():
+            raise ValueError("scan result root must be absolute")
+        if isinstance(self.discovered_entries, bool) or self.discovered_entries < 0:
+            raise ValueError("discovered_entries must be a non-negative integer")
+        if any(not Path(path).is_absolute() for path in self.accepted_paths):
+            raise ValueError("accepted paths must be absolute")
+        if len(set(self.accepted_paths)) != len(self.accepted_paths):
+            raise ValueError("accepted paths must be unique")
+        if tuple(sorted(self.accepted_paths, key=str.casefold)) != self.accepted_paths:
+            raise ValueError("accepted paths must be deterministically sorted")
+        for value, name in (
+            (self.cancelled, "cancelled"),
+            (self.entry_limit_reached, "entry_limit_reached"),
+            (self.file_limit_reached, "file_limit_reached"),
+        ):
+            if not isinstance(value, bool):
+                raise TypeError(f"{name} must be boolean")
+
+    @property
+    def accepted_count(self) -> int:
+        return len(self.accepted_paths)
+
+    @property
+    def complete(self) -> bool:
+        return not (
+            self.cancelled
+            or self.entry_limit_reached
+            or self.file_limit_reached
+            or self.errors
+        )

--- a/docs/bundles/BUNDLE_42_BOUNDED_LIBRARY_IMPORT.md
+++ b/docs/bundles/BUNDLE_42_BOUNDED_LIBRARY_IMPORT.md
@@ -1,0 +1,116 @@
+# Bundle 42 — Bounded Library Import Boundary
+
+## Status
+
+Implemented on `feature/bundle-42-bounded-library-import`. Merge requires the full release gate.
+
+## User value
+
+A DJ can select one explicit local directory and receive deterministic evidence of supported audio candidates, skipped entries and controlled filesystem errors.
+
+This bundle creates the discovery boundary only. It does not import metadata, analyze audio or persist records.
+
+## Contracts
+
+### `LibraryScanPolicy`
+
+Immutable policy containing:
+
+- normalized allowed extensions,
+- recursive or non-recursive mode,
+- hidden-entry behavior,
+- symlink policy,
+- maximum discovered entries,
+- maximum accepted files.
+
+Default candidate extensions:
+
+```text
+.aac .aif .aiff .flac .m4a .mp3 .ogg .opus .wav
+```
+
+An extension in this list means only that the file is a candidate for later metadata/provider validation. It is not yet a compatibility guarantee.
+
+### `LibraryScanResult`
+
+Immutable result containing:
+
+- resolved absolute root,
+- deterministic unique accepted paths,
+- skipped evidence,
+- controlled errors,
+- discovered-entry count,
+- cancellation state,
+- entry-limit state,
+- file-limit state.
+
+### `LibraryScanIssue`
+
+Every skipped or failed entry has a stable code, path and controlled detail.
+
+## Scanner behavior
+
+`LibraryScanner` uses bounded deterministic `os.scandir` traversal.
+
+Security properties:
+
+- relative roots are rejected before filesystem traversal,
+- the root is resolved to an absolute path,
+- accepted files must resolve within the selected root,
+- hidden entries can be excluded,
+- recursion is explicit,
+- total entries and accepted files have separate limits,
+- symlinks are skipped by default,
+- optional allowed symlinks must resolve within the root,
+- directory device/inode identity prevents loops and alias rescans,
+- accepted targets are deduplicated,
+- cancellation produces an explicit partial result.
+
+## Symlink modes
+
+### `skip`
+
+All symlinks are evidenced and ignored.
+
+### `allow_within_root`
+
+A symlink may be followed only when its resolved target remains under the selected resolved root. External targets are skipped. Revisited directory identities are not traversed again.
+
+## Isolation
+
+This bundle does not:
+
+- read audio tags,
+- decode audio,
+- import Librosa or Essentia,
+- write SQLite records,
+- create analysis jobs,
+- expose a new API route,
+- add a desktop UI,
+- add a dependency.
+
+## Verification
+
+Required tests cover:
+
+- policy normalization and immutable validation,
+- relative/missing/non-directory roots,
+- recursive and non-recursive scans,
+- deterministic accepted order,
+- hidden and unsupported entries,
+- maximum entry and file limits,
+- cancellation,
+- default symlink rejection,
+- allowed internal file symlink deduplication,
+- external symlink rejection,
+- directory-symlink loop prevention.
+
+The full existing suite must pass on Python 3.11 and 3.12.
+
+## Rollback
+
+Revert the future Bundle 42 squash commit. No runtime configuration, database or generated artifact rollback is required.
+
+## Next
+
+Bundle 43 — Metadata and Stable Track Identity. The scanner result will become input to a separate import application service; the scanner itself must remain persistence-free.

--- a/services/library/__init__.py
+++ b/services/library/__init__.py
@@ -1,0 +1,3 @@
+from services.library.scanner import LibraryScanner
+
+__all__ = ["LibraryScanner"]

--- a/services/library/scanner.py
+++ b/services/library/scanner.py
@@ -1,0 +1,464 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from pathlib import Path
+
+from core.library.contracts import (
+    LibraryScanIssue,
+    LibraryScanPolicy,
+    LibraryScanResult,
+    SymlinkPolicy,
+)
+
+
+CancelRequested = Callable[[], bool]
+DirectoryIdentity = tuple[int, int]
+
+
+class LibraryScanner:
+    def __init__(
+        self,
+        *,
+        policy: LibraryScanPolicy | None = None,
+        cancel_requested: CancelRequested | None = None,
+    ) -> None:
+        self.policy = policy or LibraryScanPolicy()
+        self._cancel_requested = cancel_requested or (lambda: False)
+
+    def scan(self, root: str | Path) -> LibraryScanResult:
+        requested_root = Path(root).expanduser()
+        if not requested_root.is_absolute():
+            raise ValueError("library root must be absolute")
+
+        resolved_root = requested_root.resolve(strict=False)
+        root_text = str(resolved_root)
+        errors: list[LibraryScanIssue] = []
+        skipped: list[LibraryScanIssue] = []
+
+        try:
+            root_exists = resolved_root.exists()
+        except OSError:
+            root_exists = False
+        if not root_exists:
+            errors.append(
+                self._issue(
+                    resolved_root,
+                    "root_not_found",
+                    "library root does not exist",
+                )
+            )
+            return self._result(root_text, errors=errors)
+
+        try:
+            root_is_directory = resolved_root.is_dir()
+        except OSError:
+            root_is_directory = False
+        if not root_is_directory:
+            errors.append(
+                self._issue(
+                    resolved_root,
+                    "root_not_directory",
+                    "library root is not a directory",
+                )
+            )
+            return self._result(root_text, errors=errors)
+
+        accepted: set[str] = set()
+        discovered_entries = 0
+        cancelled = False
+        entry_limit_reached = False
+        file_limit_reached = False
+        stop = False
+
+        root_identity = self._directory_identity(resolved_root)
+        if root_identity is None:
+            errors.append(
+                self._issue(
+                    resolved_root,
+                    "root_unreadable",
+                    "library root cannot be inspected",
+                )
+            )
+            return self._result(root_text, errors=errors)
+
+        visited_directories: set[DirectoryIdentity] = {root_identity}
+        pending_directories: list[Path] = [resolved_root]
+
+        while pending_directories and not stop:
+            if self._cancel_requested():
+                cancelled = True
+                break
+
+            current_directory = pending_directories.pop()
+            try:
+                entries = sorted(
+                    os.scandir(current_directory),
+                    key=lambda entry: (entry.name.casefold(), entry.name),
+                )
+            except OSError:
+                errors.append(
+                    self._issue(
+                        current_directory,
+                        "directory_unreadable",
+                        "directory cannot be read",
+                    )
+                )
+                continue
+
+            child_directories: list[Path] = []
+            for entry in entries:
+                if self._cancel_requested():
+                    cancelled = True
+                    stop = True
+                    break
+
+                entry_path = Path(entry.path)
+                if discovered_entries >= self.policy.max_entries:
+                    entry_limit_reached = True
+                    skipped.append(
+                        self._issue(
+                            entry_path,
+                            "entry_limit_reached",
+                            "maximum scanned entry count reached",
+                        )
+                    )
+                    stop = True
+                    break
+                discovered_entries += 1
+
+                if not self.policy.include_hidden and entry.name.startswith("."):
+                    skipped.append(
+                        self._issue(
+                            entry_path,
+                            "hidden_entry_skipped",
+                            "hidden entry excluded by scan policy",
+                        )
+                    )
+                    continue
+
+                try:
+                    is_symlink = entry.is_symlink()
+                except OSError:
+                    errors.append(
+                        self._issue(
+                            entry_path,
+                            "entry_unreadable",
+                            "entry type cannot be inspected",
+                        )
+                    )
+                    continue
+
+                if is_symlink:
+                    stop = self._handle_symlink(
+                        entry_path=entry_path,
+                        root=resolved_root,
+                        accepted=accepted,
+                        skipped=skipped,
+                        errors=errors,
+                        child_directories=child_directories,
+                        visited_directories=visited_directories,
+                    )
+                    if stop:
+                        file_limit_reached = True
+                        break
+                    continue
+
+                try:
+                    is_directory = entry.is_dir(follow_symlinks=False)
+                    is_file = entry.is_file(follow_symlinks=False)
+                except OSError:
+                    errors.append(
+                        self._issue(
+                            entry_path,
+                            "entry_unreadable",
+                            "entry type cannot be inspected",
+                        )
+                    )
+                    continue
+
+                if is_directory:
+                    if not self.policy.recursive:
+                        skipped.append(
+                            self._issue(
+                                entry_path,
+                                "directory_skipped_non_recursive",
+                                "directory excluded by non-recursive policy",
+                            )
+                        )
+                        continue
+                    resolved_directory = self._resolve_within_root(
+                        entry_path,
+                        resolved_root,
+                    )
+                    if resolved_directory is None:
+                        errors.append(
+                            self._issue(
+                                entry_path,
+                                "directory_unreadable",
+                                "directory cannot be resolved within root",
+                            )
+                        )
+                        continue
+                    self._queue_directory(
+                        directory=resolved_directory,
+                        source_path=entry_path,
+                        child_directories=child_directories,
+                        visited_directories=visited_directories,
+                        skipped=skipped,
+                        errors=errors,
+                    )
+                    continue
+
+                if is_file:
+                    resolved_file = self._resolve_within_root(entry_path, resolved_root)
+                    if resolved_file is None:
+                        errors.append(
+                            self._issue(
+                                entry_path,
+                                "file_unreadable",
+                                "file cannot be resolved within root",
+                            )
+                        )
+                        continue
+                    if self._accept_file(
+                        resolved_file,
+                        accepted=accepted,
+                        skipped=skipped,
+                    ):
+                        file_limit_reached = True
+                        stop = True
+                        break
+                    continue
+
+                skipped.append(
+                    self._issue(
+                        entry_path,
+                        "unsupported_entry_type",
+                        "entry is neither a regular file nor a directory",
+                    )
+                )
+
+            if not stop:
+                child_directories.sort(key=self._path_sort_key, reverse=True)
+                pending_directories.extend(child_directories)
+
+        accepted_paths = tuple(sorted(accepted, key=self._text_sort_key))
+        return LibraryScanResult(
+            root=root_text,
+            accepted_paths=accepted_paths,
+            skipped=tuple(skipped),
+            errors=tuple(errors),
+            discovered_entries=discovered_entries,
+            cancelled=cancelled,
+            entry_limit_reached=entry_limit_reached,
+            file_limit_reached=file_limit_reached,
+        )
+
+    def _handle_symlink(
+        self,
+        *,
+        entry_path: Path,
+        root: Path,
+        accepted: set[str],
+        skipped: list[LibraryScanIssue],
+        errors: list[LibraryScanIssue],
+        child_directories: list[Path],
+        visited_directories: set[DirectoryIdentity],
+    ) -> bool:
+        if self.policy.symlink_policy == SymlinkPolicy.SKIP:
+            skipped.append(
+                self._issue(
+                    entry_path,
+                    "symlink_skipped",
+                    "symlink excluded by scan policy",
+                )
+            )
+            return False
+
+        try:
+            target = entry_path.resolve(strict=True)
+        except OSError:
+            errors.append(
+                self._issue(
+                    entry_path,
+                    "symlink_unreadable",
+                    "symlink target cannot be resolved",
+                )
+            )
+            return False
+
+        if not target.is_relative_to(root):
+            skipped.append(
+                self._issue(
+                    entry_path,
+                    "symlink_outside_root",
+                    "symlink target escapes the selected root",
+                )
+            )
+            return False
+
+        try:
+            if target.is_dir():
+                if not self.policy.recursive:
+                    skipped.append(
+                        self._issue(
+                            entry_path,
+                            "directory_skipped_non_recursive",
+                            "symlinked directory excluded by non-recursive policy",
+                        )
+                    )
+                    return False
+                self._queue_directory(
+                    directory=target,
+                    source_path=entry_path,
+                    child_directories=child_directories,
+                    visited_directories=visited_directories,
+                    skipped=skipped,
+                    errors=errors,
+                )
+                return False
+            if target.is_file():
+                return self._accept_file(
+                    target,
+                    accepted=accepted,
+                    skipped=skipped,
+                    issue_path=entry_path,
+                )
+        except OSError:
+            errors.append(
+                self._issue(
+                    entry_path,
+                    "symlink_unreadable",
+                    "symlink target cannot be inspected",
+                )
+            )
+            return False
+
+        skipped.append(
+            self._issue(
+                entry_path,
+                "unsupported_entry_type",
+                "symlink target is not a regular file or directory",
+            )
+        )
+        return False
+
+    def _accept_file(
+        self,
+        file_path: Path,
+        *,
+        accepted: set[str],
+        skipped: list[LibraryScanIssue],
+        issue_path: Path | None = None,
+    ) -> bool:
+        evidence_path = issue_path or file_path
+        if file_path.suffix.lower() not in self.policy.allowed_extensions:
+            skipped.append(
+                self._issue(
+                    evidence_path,
+                    "unsupported_extension",
+                    "file extension excluded by scan policy",
+                )
+            )
+            return False
+
+        normalized = str(file_path)
+        if normalized in accepted:
+            skipped.append(
+                self._issue(
+                    evidence_path,
+                    "duplicate_target",
+                    "resolved file was already accepted",
+                )
+            )
+            return False
+
+        if len(accepted) >= self.policy.max_files:
+            skipped.append(
+                self._issue(
+                    evidence_path,
+                    "file_limit_reached",
+                    "maximum accepted file count reached",
+                )
+            )
+            return True
+
+        accepted.add(normalized)
+        return False
+
+    def _queue_directory(
+        self,
+        *,
+        directory: Path,
+        source_path: Path,
+        child_directories: list[Path],
+        visited_directories: set[DirectoryIdentity],
+        skipped: list[LibraryScanIssue],
+        errors: list[LibraryScanIssue],
+    ) -> None:
+        identity = self._directory_identity(directory)
+        if identity is None:
+            errors.append(
+                self._issue(
+                    source_path,
+                    "directory_unreadable",
+                    "directory identity cannot be inspected",
+                )
+            )
+            return
+        if identity in visited_directories:
+            skipped.append(
+                self._issue(
+                    source_path,
+                    "duplicate_directory",
+                    "directory target was already scheduled or scanned",
+                )
+            )
+            return
+        visited_directories.add(identity)
+        child_directories.append(directory)
+
+    @staticmethod
+    def _directory_identity(path: Path) -> DirectoryIdentity | None:
+        try:
+            stat_result = path.stat()
+        except OSError:
+            return None
+        return stat_result.st_dev, stat_result.st_ino
+
+    @staticmethod
+    def _resolve_within_root(path: Path, root: Path) -> Path | None:
+        try:
+            resolved = path.resolve(strict=True)
+        except OSError:
+            return None
+        if not resolved.is_relative_to(root):
+            return None
+        return resolved
+
+    @staticmethod
+    def _issue(path: Path, code: str, detail: str) -> LibraryScanIssue:
+        return LibraryScanIssue(path=str(path.absolute()), code=code, detail=detail)
+
+    @staticmethod
+    def _text_sort_key(value: str) -> tuple[str, str]:
+        return value.casefold(), value
+
+    @classmethod
+    def _path_sort_key(cls, value: Path) -> tuple[str, str]:
+        return cls._text_sort_key(str(value))
+
+    @staticmethod
+    def _result(
+        root: str,
+        *,
+        errors: list[LibraryScanIssue],
+    ) -> LibraryScanResult:
+        return LibraryScanResult(
+            root=root,
+            accepted_paths=(),
+            skipped=(),
+            errors=tuple(errors),
+            discovered_entries=0,
+        )

--- a/tests/test_library_scanner.py
+++ b/tests/test_library_scanner.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+from core.library import LibraryScanPolicy, SymlinkPolicy
+from services.library import LibraryScanner
+
+
+def _touch(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"audio-candidate")
+    return path.resolve()
+
+
+def _symlink(target: Path, link: Path, *, directory: bool = False) -> None:
+    try:
+        link.symlink_to(target, target_is_directory=directory)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+
+def _codes(result) -> set[str]:
+    return {issue.code for issue in (*result.skipped, *result.errors)}
+
+
+def test_policy_normalizes_extensions_and_is_immutable() -> None:
+    policy = LibraryScanPolicy(allowed_extensions=("MP3", ".Wav", "mp3"))
+
+    assert policy.allowed_extensions == (".mp3", ".wav")
+    with pytest.raises(FrozenInstanceError):
+        policy.max_files = 1
+
+
+@pytest.mark.parametrize("value", [True, 1.5, "10"])
+def test_policy_rejects_non_integral_limits(value) -> None:
+    with pytest.raises(TypeError):
+        LibraryScanPolicy(max_files=value)
+
+
+@pytest.mark.parametrize("value", [0, -1])
+def test_policy_rejects_non_positive_limits(value: int) -> None:
+    with pytest.raises(ValueError):
+        LibraryScanPolicy(max_entries=value)
+
+
+def test_scanner_rejects_relative_root() -> None:
+    with pytest.raises(ValueError, match="absolute"):
+        LibraryScanner().scan("relative/music")
+
+
+def test_missing_and_file_roots_return_controlled_errors(tmp_path: Path) -> None:
+    missing = LibraryScanner().scan(tmp_path / "missing")
+    file_root = _touch(tmp_path / "single.mp3")
+    not_directory = LibraryScanner().scan(file_root)
+
+    assert missing.accepted_paths == ()
+    assert [issue.code for issue in missing.errors] == ["root_not_found"]
+    assert not_directory.accepted_paths == ()
+    assert [issue.code for issue in not_directory.errors] == [
+        "root_not_directory"
+    ]
+
+
+def test_recursive_scan_is_deterministic_and_evidenced(tmp_path: Path) -> None:
+    root = tmp_path.resolve()
+    track_a = _touch(root / "a.wav")
+    track_b = _touch(root / "B.MP3")
+    nested_track = _touch(root / "nested" / "c.flac")
+    _touch(root / "notes.txt")
+    _touch(root / ".hidden.mp3")
+
+    result = LibraryScanner().scan(root)
+
+    assert result.accepted_paths == tuple(
+        sorted(
+            (str(track_a), str(track_b), str(nested_track)),
+            key=lambda value: (value.casefold(), value),
+        )
+    )
+    assert result.accepted_count == 3
+    assert result.discovered_entries == 6
+    assert result.complete is True
+    assert {issue.code for issue in result.skipped} == {
+        "hidden_entry_skipped",
+        "unsupported_extension",
+    }
+
+
+def test_non_recursive_scan_does_not_descend(tmp_path: Path) -> None:
+    root = tmp_path.resolve()
+    top_track = _touch(root / "top.mp3")
+    _touch(root / "nested" / "deep.mp3")
+
+    result = LibraryScanner(
+        policy=LibraryScanPolicy(recursive=False)
+    ).scan(root)
+
+    assert result.accepted_paths == (str(top_track),)
+    assert "directory_skipped_non_recursive" in _codes(result)
+
+
+def test_entry_limit_stops_before_unbounded_traversal(tmp_path: Path) -> None:
+    root = tmp_path.resolve()
+    first = _touch(root / "a.mp3")
+    second = _touch(root / "b.mp3")
+    _touch(root / "c.mp3")
+
+    result = LibraryScanner(
+        policy=LibraryScanPolicy(max_entries=2, max_files=10)
+    ).scan(root)
+
+    assert result.accepted_paths == (str(first), str(second))
+    assert result.discovered_entries == 2
+    assert result.entry_limit_reached is True
+    assert result.file_limit_reached is False
+    assert "entry_limit_reached" in _codes(result)
+
+
+def test_file_limit_stops_on_next_supported_candidate(tmp_path: Path) -> None:
+    root = tmp_path.resolve()
+    first = _touch(root / "a.mp3")
+    _touch(root / "b.mp3")
+
+    result = LibraryScanner(
+        policy=LibraryScanPolicy(max_files=1)
+    ).scan(root)
+
+    assert result.accepted_paths == (str(first),)
+    assert result.file_limit_reached is True
+    assert result.entry_limit_reached is False
+    assert "file_limit_reached" in _codes(result)
+
+
+def test_cancellation_returns_explicit_partial_state(tmp_path: Path) -> None:
+    root = tmp_path.resolve()
+    _touch(root / "a.mp3")
+    calls = 0
+
+    def cancel_requested() -> bool:
+        nonlocal calls
+        calls += 1
+        return calls >= 2
+
+    result = LibraryScanner(cancel_requested=cancel_requested).scan(root)
+
+    assert result.cancelled is True
+    assert result.complete is False
+    assert result.discovered_entries == 0
+    assert result.accepted_paths == ()
+
+
+def test_default_policy_skips_symlinks(tmp_path: Path) -> None:
+    root = tmp_path.resolve()
+    target = _touch(root / "target.mp3")
+    _symlink(target, root / "alias.mp3")
+
+    result = LibraryScanner().scan(root)
+
+    assert result.accepted_paths == (str(target),)
+    assert "symlink_skipped" in _codes(result)
+
+
+def test_allowed_symlink_inside_root_is_deduplicated(tmp_path: Path) -> None:
+    root = tmp_path.resolve()
+    target = _touch(root / "target.mp3")
+    _symlink(target, root / "alias.mp3")
+
+    result = LibraryScanner(
+        policy=LibraryScanPolicy(
+            symlink_policy=SymlinkPolicy.ALLOW_WITHIN_ROOT
+        )
+    ).scan(root)
+
+    assert result.accepted_paths == (str(target),)
+    assert "duplicate_target" in _codes(result)
+
+
+def test_allowed_symlink_cannot_escape_root(tmp_path: Path) -> None:
+    root = (tmp_path / "library").resolve()
+    root.mkdir()
+    outside = _touch(tmp_path / "outside.mp3")
+    _symlink(outside, root / "outside-link.mp3")
+
+    result = LibraryScanner(
+        policy=LibraryScanPolicy(
+            symlink_policy=SymlinkPolicy.ALLOW_WITHIN_ROOT
+        )
+    ).scan(root)
+
+    assert result.accepted_paths == ()
+    assert "symlink_outside_root" in _codes(result)
+
+
+def test_allowed_directory_symlink_cannot_create_loop(tmp_path: Path) -> None:
+    root = tmp_path.resolve()
+    nested = root / "nested"
+    track = _touch(nested / "track.mp3")
+    _symlink(root, nested / "back", directory=True)
+
+    result = LibraryScanner(
+        policy=LibraryScanPolicy(
+            symlink_policy=SymlinkPolicy.ALLOW_WITHIN_ROOT
+        )
+    ).scan(root)
+
+    assert result.accepted_paths == (str(track),)
+    assert result.entry_limit_reached is False
+    assert "duplicate_directory" in _codes(result)


### PR DESCRIPTION
## Summary
- add immutable library scan policy, issue and result contracts
- add a bounded deterministic directory scanner
- normalize the candidate audio-extension policy
- support recursive/non-recursive and hidden-entry policies
- enforce separate discovered-entry and accepted-file limits
- skip symlinks by default and optionally allow only targets within the selected root
- prevent directory alias loops using device/inode identity
- add explicit cancellation and partial-result evidence
- add temporary-filesystem security and regression tests

## Verification
- branch created directly from Bundle 41 squash commit `3e40a23b0e0891f4f5f32fe8bbbcfba26ba6cd1a`
- ahead-only diff limited to six new library contract, scanner, test and documentation files
- Python 3.11 and 3.12 install, compile, critical Ruff and full pytest are required
- no local test execution is claimed

## Isolation
- no metadata extraction
- no audio decode or analysis
- no repository/database writes
- no API or desktop integration
- no dependency or environment change
- no traversal outside the selected resolved root

## Bundle Context
- Bundle: 42 — Bounded Library Import Boundary
- Base branch: `feature/bundle-0-bootstrap`
- Base commit: `3e40a23b0e0891f4f5f32fe8bbbcfba26ba6cd1a`
- Related issue: #62
- Next: Bundle 43 — Metadata and Stable Track Identity
- Rollback: revert the future isolated squash commit; no data rollback required