### PR TITLE
Bundle 43: metadata and stable track identity

### DIFF
--- a/core/library/__init__.py
+++ b/core/library/__init__.py
@@ -5,11 +5,25 @@ from core.library.contracts import (
     LibraryScanResult,
     SymlinkPolicy,
 )
+from core.library.track_metadata import (
+    MetadataOrigin,
+    TrackIdentity,
+    TrackImportBatchResult,
+    TrackImportCandidate,
+    TrackImportIssue,
+    TrackMetadata,
+)
 
 __all__ = [
     "DEFAULT_AUDIO_EXTENSIONS",
     "LibraryScanIssue",
     "LibraryScanPolicy",
     "LibraryScanResult",
+    "MetadataOrigin",
     "SymlinkPolicy",
+    "TrackIdentity",
+    "TrackImportBatchResult",
+    "TrackImportCandidate",
+    "TrackImportIssue",
+    "TrackMetadata",
 ]

--- a/core/library/track_metadata.py
+++ b/core/library/track_metadata.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import math
+import re
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-import math
-import re
 
 
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
@@ -62,10 +62,17 @@ class TrackMetadata:
     def __post_init__(self) -> None:
         if not Path(self.source_path).is_absolute():
             raise ValueError("metadata source path must be absolute")
+        if not isinstance(self.provider, str):
+            raise TypeError("metadata provider must be a string")
         if not self.provider.strip():
             raise ValueError("metadata provider is required")
+        if not isinstance(self.provider_version, str):
+            raise TypeError("metadata provider version must be a string")
         if not self.provider_version.strip():
             raise ValueError("metadata provider version is required")
+
+        object.__setattr__(self, "provider", self.provider.strip())
+        object.__setattr__(self, "provider_version", self.provider_version.strip())
 
         origin = self.origin
         if not isinstance(origin, MetadataOrigin):
@@ -78,6 +85,8 @@ class TrackMetadata:
         for field_name in ("title", "artist", "album", "genre"):
             value = getattr(self, field_name)
             if value is not None:
+                if not isinstance(value, str):
+                    raise TypeError(f"{field_name} must be a string")
                 normalized = " ".join(value.split())
                 object.__setattr__(self, field_name, normalized or None)
 
@@ -100,9 +109,16 @@ class TrackMetadata:
                 if value <= 0:
                     raise ValueError(f"{field_name} must be positive")
 
+        normalized_warning_values: set[str] = set()
+        for value in self.warnings:
+            if not isinstance(value, str):
+                raise TypeError("metadata warnings must be strings")
+            normalized = " ".join(value.split())
+            if normalized:
+                normalized_warning_values.add(normalized)
         normalized_warnings = tuple(
             sorted(
-                {" ".join(value.split()) for value in self.warnings if value.strip()},
+                normalized_warning_values,
                 key=lambda value: (value.casefold(), value),
             )
         )

--- a/core/library/track_metadata.py
+++ b/core/library/track_metadata.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+import math
+import re
+
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class MetadataOrigin(str, Enum):
+    TAGS = "tags"
+    FILENAME_FALLBACK = "filename_fallback"
+
+
+@dataclass(frozen=True, slots=True)
+class TrackIdentity:
+    track_id: str
+    digest_algorithm: str
+    digest_hex: str
+    source_path: str
+    size_bytes: int
+    mtime_ns: int
+
+    def __post_init__(self) -> None:
+        if self.digest_algorithm != "sha256":
+            raise ValueError("track identity digest algorithm must be sha256")
+        if not _SHA256_RE.fullmatch(self.digest_hex):
+            raise ValueError("track identity digest must be lowercase sha256 hex")
+        expected_track_id = f"aptrack:v1:sha256:{self.digest_hex}"
+        if self.track_id != expected_track_id:
+            raise ValueError("track id does not match the content digest")
+        if not Path(self.source_path).is_absolute():
+            raise ValueError("track identity source path must be absolute")
+        if not isinstance(self.size_bytes, int) or isinstance(self.size_bytes, bool):
+            raise TypeError("track identity size must be an integer")
+        if self.size_bytes < 0:
+            raise ValueError("track identity size must be non-negative")
+        if not isinstance(self.mtime_ns, int) or isinstance(self.mtime_ns, bool):
+            raise TypeError("track identity mtime must be an integer")
+        if self.mtime_ns < 0:
+            raise ValueError("track identity mtime must be non-negative")
+
+
+@dataclass(frozen=True, slots=True)
+class TrackMetadata:
+    source_path: str
+    provider: str
+    provider_version: str
+    origin: MetadataOrigin
+    title: str | None = None
+    artist: str | None = None
+    album: str | None = None
+    genre: str | None = None
+    duration_seconds: float | None = None
+    sample_rate_hz: int | None = None
+    bitrate_kbps: int | None = None
+    warnings: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not Path(self.source_path).is_absolute():
+            raise ValueError("metadata source path must be absolute")
+        if not self.provider.strip():
+            raise ValueError("metadata provider is required")
+        if not self.provider_version.strip():
+            raise ValueError("metadata provider version is required")
+
+        origin = self.origin
+        if not isinstance(origin, MetadataOrigin):
+            try:
+                origin = MetadataOrigin(origin)
+            except (TypeError, ValueError) as exc:
+                raise ValueError("unsupported metadata origin") from exc
+            object.__setattr__(self, "origin", origin)
+
+        for field_name in ("title", "artist", "album", "genre"):
+            value = getattr(self, field_name)
+            if value is not None:
+                normalized = " ".join(value.split())
+                object.__setattr__(self, field_name, normalized or None)
+
+        if self.duration_seconds is not None:
+            if isinstance(self.duration_seconds, bool) or not isinstance(
+                self.duration_seconds,
+                (int, float),
+            ):
+                raise TypeError("duration must be numeric")
+            duration = float(self.duration_seconds)
+            if not math.isfinite(duration) or duration <= 0:
+                raise ValueError("duration must be finite and positive")
+            object.__setattr__(self, "duration_seconds", duration)
+
+        for field_name in ("sample_rate_hz", "bitrate_kbps"):
+            value = getattr(self, field_name)
+            if value is not None:
+                if not isinstance(value, int) or isinstance(value, bool):
+                    raise TypeError(f"{field_name} must be an integer")
+                if value <= 0:
+                    raise ValueError(f"{field_name} must be positive")
+
+        normalized_warnings = tuple(
+            sorted(
+                {" ".join(value.split()) for value in self.warnings if value.strip()},
+                key=lambda value: (value.casefold(), value),
+            )
+        )
+        object.__setattr__(self, "warnings", normalized_warnings)
+
+
+@dataclass(frozen=True, slots=True)
+class TrackImportCandidate:
+    identity: TrackIdentity
+    metadata: TrackMetadata
+
+    def __post_init__(self) -> None:
+        if self.identity.source_path != self.metadata.source_path:
+            raise ValueError("identity and metadata source paths must match")
+
+
+@dataclass(frozen=True, slots=True)
+class TrackImportIssue:
+    path: str
+    code: str
+    detail: str
+
+    def __post_init__(self) -> None:
+        if not self.path:
+            raise ValueError("import issue path is required")
+        if not self.code:
+            raise ValueError("import issue code is required")
+        if not self.detail:
+            raise ValueError("import issue detail is required")
+
+
+@dataclass(frozen=True, slots=True)
+class TrackImportBatchResult:
+    candidates: tuple[TrackImportCandidate, ...]
+    issues: tuple[TrackImportIssue, ...]
+    source_scan_complete: bool
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.source_scan_complete, bool):
+            raise TypeError("source_scan_complete must be boolean")
+        track_ids = tuple(candidate.identity.track_id for candidate in self.candidates)
+        if len(set(track_ids)) != len(track_ids):
+            raise ValueError("import candidates must have unique track ids")
+        paths = tuple(candidate.identity.source_path for candidate in self.candidates)
+        expected = tuple(sorted(paths, key=lambda value: (value.casefold(), value)))
+        if paths != expected:
+            raise ValueError("import candidates must be deterministically sorted")

--- a/docs/status/BUNDLE_43_METADATA_STABLE_TRACK_IDENTITY.md
+++ b/docs/status/BUNDLE_43_METADATA_STABLE_TRACK_IDENTITY.md
@@ -1,0 +1,114 @@
+# Bundle 43 — Metadata and Stable Track Identity
+
+## Status
+
+Implemented on an isolated feature branch. Not yet merged.
+
+## Selected Enterprise Scope
+
+This bundle deliberately keeps only the highest-value elements from the historical plans and donor repositories:
+
+- immutable contracts,
+- stable content identity,
+- deterministic processing,
+- controlled failure taxonomy,
+- explicit provider/version evidence,
+- bounded-memory file processing,
+- tests before rollout,
+- no optional heavy dependency on the boot path.
+
+Deferred or rejected here:
+
+- Spotify, Last.fm and market popularity signals,
+- embeddings and generative AI,
+- BPM, key, energy or cue extraction,
+- database writes,
+- API and desktop integration,
+- direct reuse of historic bundle code,
+- path-derived track identity,
+- guessed artist parsing from filenames.
+
+## Schema Tree
+
+```text
+APPLAYLIST
+└── Library ingestion
+    ├── Bundle 42: LibraryScanner
+    │   └── LibraryScanResult
+    │       ├── accepted_paths[]
+    │       ├── skipped[]
+    │       ├── errors[]
+    │       └── completion evidence
+    │
+    └── Bundle 43: Identity and metadata
+        ├── ContentTrackIdentityService
+        │   ├── opened-file-descriptor SHA-256
+        │   ├── inode/device verification
+        │   ├── size + mtime evidence
+        │   └── TrackIdentity
+        │       └── aptrack:v1:sha256:<digest>
+        │
+        ├── TrackMetadataReader boundary
+        │   ├── provider name/version
+        │   ├── explicit metadata origin
+        │   ├── normalized values
+        │   └── warnings
+        │
+        └── LibraryCandidateImporter
+            ├── deterministic ordering
+            ├── duplicate-content rejection
+            ├── controlled issue taxonomy
+            └── TrackImportBatchResult
+```
+
+## Runtime Flow
+
+```text
+selected directory
+  → bounded scan
+  → accepted audio path
+  → stable content fingerprint
+  → read-only metadata provider
+  → validated import candidate
+  → later repository persistence
+  → later BPM/key/energy analysis
+```
+
+## Security Boundaries
+
+- Input paths must be absolute and resolve to regular files.
+- Hashing is streaming and bounded in memory.
+- Identity is bound to the opened file descriptor.
+- Device/inode, size and mtime must remain stable during hashing.
+- Metadata provider output is validated before acceptance.
+- Duplicate bytes are represented once, with explicit duplicate evidence.
+- No tag mutation, network access or database side effect occurs.
+
+## Recognition Roadmap
+
+Bundle 43 does not claim music recognition. It creates the stable evidence layer required for it.
+
+The next product slices are:
+
+```text
+Bundle 44: tagged metadata provider + repository persistence
+Bundle 45: real baseline MIR provider
+           ├── tempo + beat confidence
+           ├── key + scale + Camelot
+           ├── tonal strength/confidence
+           ├── energy features
+           └── duration and warnings
+Bundle 46: benchmark harness and acceptance report
+Bundle 47+: desktop library and analysis inspector
+```
+
+## Definition of Done
+
+- same bytes at different paths produce the same track ID,
+- changed bytes produce a different track ID,
+- identity processing remains bounded in memory,
+- a file changed or replaced during hashing is rejected,
+- malformed metadata output becomes a controlled issue,
+- filename fallback does not invent artist certainty,
+- duplicate content is deterministic and visible,
+- Python 3.11 and 3.12 CI pass.

--- a/services/library/__init__.py
+++ b/services/library/__init__.py
@@ -1,3 +1,18 @@
+from services.library.identity import ContentTrackIdentityService, TrackIdentityError
+from services.library.importer import LibraryCandidateImporter
+from services.library.metadata import (
+    FilenameFallbackMetadataReader,
+    MetadataReadError,
+    TrackMetadataReader,
+)
 from services.library.scanner import LibraryScanner
 
-__all__ = ["LibraryScanner"]
+__all__ = [
+    "ContentTrackIdentityService",
+    "FilenameFallbackMetadataReader",
+    "LibraryCandidateImporter",
+    "LibraryScanner",
+    "MetadataReadError",
+    "TrackIdentityError",
+    "TrackMetadataReader",
+]

--- a/services/library/identity.py
+++ b/services/library/identity.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+from core.library.track_metadata import TrackIdentity
+
+
+@dataclass(frozen=True, slots=True)
+class TrackIdentityError(Exception):
+    path: str
+    code: str
+    detail: str
+
+    def __str__(self) -> str:
+        return self.detail
+
+
+class ContentTrackIdentityService:
+    def __init__(self, *, chunk_size: int = 1024 * 1024) -> None:
+        if not isinstance(chunk_size, int) or isinstance(chunk_size, bool):
+            raise TypeError("chunk_size must be an integer")
+        if chunk_size <= 0:
+            raise ValueError("chunk_size must be positive")
+        self._chunk_size = chunk_size
+
+    def identify(self, path: str | Path) -> TrackIdentity:
+        source = Path(path)
+        if not source.is_absolute():
+            raise TrackIdentityError(
+                path=str(source),
+                code="identity_path_not_absolute",
+                detail="track identity requires an absolute path",
+            )
+
+        try:
+            resolved = source.resolve(strict=True)
+        except FileNotFoundError as exc:
+            raise TrackIdentityError(
+                path=str(source),
+                code="identity_file_missing",
+                detail="track identity source file does not exist",
+            ) from exc
+        except OSError as exc:
+            raise TrackIdentityError(
+                path=str(source),
+                code="identity_path_unreadable",
+                detail="track identity source path cannot be resolved",
+            ) from exc
+
+        if not resolved.is_file():
+            raise TrackIdentityError(
+                path=str(resolved),
+                code="identity_not_regular_file",
+                detail="track identity source must be a regular file",
+            )
+
+        try:
+            before = resolved.stat()
+            digest = hashlib.sha256()
+            with resolved.open("rb") as handle:
+                while True:
+                    chunk = handle.read(self._chunk_size)
+                    if not chunk:
+                        break
+                    digest.update(chunk)
+            after = resolved.stat()
+        except OSError as exc:
+            raise TrackIdentityError(
+                path=str(resolved),
+                code="identity_read_failed",
+                detail="track identity source could not be read",
+            ) from exc
+
+        if (before.st_size, before.st_mtime_ns) != (after.st_size, after.st_mtime_ns):
+            raise TrackIdentityError(
+                path=str(resolved),
+                code="identity_file_changed",
+                detail="track identity source changed while it was being read",
+            )
+
+        digest_hex = digest.hexdigest()
+        return TrackIdentity(
+            track_id=f"aptrack:v1:sha256:{digest_hex}",
+            digest_algorithm="sha256",
+            digest_hex=digest_hex,
+            source_path=str(resolved),
+            size_bytes=after.st_size,
+            mtime_ns=after.st_mtime_ns,
+        )

--- a/services/library/identity.py
+++ b/services/library/identity.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -57,15 +58,17 @@ class ContentTrackIdentityService:
             )
 
         try:
-            before = resolved.stat()
+            path_before = resolved.stat()
             digest = hashlib.sha256()
             with resolved.open("rb") as handle:
+                fd_before = os.fstat(handle.fileno())
                 while True:
                     chunk = handle.read(self._chunk_size)
                     if not chunk:
                         break
                     digest.update(chunk)
-            after = resolved.stat()
+                fd_after = os.fstat(handle.fileno())
+            path_after = resolved.stat()
         except OSError as exc:
             raise TrackIdentityError(
                 path=str(resolved),
@@ -73,7 +76,19 @@ class ContentTrackIdentityService:
                 detail="track identity source could not be read",
             ) from exc
 
-        if (before.st_size, before.st_mtime_ns) != (after.st_size, after.st_mtime_ns):
+        identities = {
+            (path_before.st_dev, path_before.st_ino),
+            (fd_before.st_dev, fd_before.st_ino),
+            (fd_after.st_dev, fd_after.st_ino),
+            (path_after.st_dev, path_after.st_ino),
+        }
+        snapshots = {
+            (path_before.st_size, path_before.st_mtime_ns),
+            (fd_before.st_size, fd_before.st_mtime_ns),
+            (fd_after.st_size, fd_after.st_mtime_ns),
+            (path_after.st_size, path_after.st_mtime_ns),
+        }
+        if len(identities) != 1 or len(snapshots) != 1:
             raise TrackIdentityError(
                 path=str(resolved),
                 code="identity_file_changed",
@@ -86,6 +101,6 @@ class ContentTrackIdentityService:
             digest_algorithm="sha256",
             digest_hex=digest_hex,
             source_path=str(resolved),
-            size_bytes=after.st_size,
-            mtime_ns=after.st_mtime_ns,
+            size_bytes=fd_after.st_size,
+            mtime_ns=fd_after.st_mtime_ns,
         )

--- a/services/library/importer.py
+++ b/services/library/importer.py
@@ -38,31 +38,12 @@ class LibraryCandidateImporter:
         for path in sorted(scan_result.accepted_paths, key=_text_sort_key):
             try:
                 identity = self._identity_service.identify(path)
-                metadata = self._metadata_reader.read(identity.source_path)
             except TrackIdentityError as exc:
                 issues.append(
                     TrackImportIssue(
                         path=exc.path,
                         code=exc.code,
                         detail=exc.detail,
-                    )
-                )
-                continue
-            except MetadataReadError as exc:
-                issues.append(
-                    TrackImportIssue(
-                        path=exc.path,
-                        code=exc.code,
-                        detail=exc.detail,
-                    )
-                )
-                continue
-            except (TypeError, ValueError) as exc:
-                issues.append(
-                    TrackImportIssue(
-                        path=path,
-                        code="metadata_output_invalid",
-                        detail=str(exc) or "metadata reader returned invalid output",
                     )
                 )
                 continue
@@ -78,7 +59,28 @@ class LibraryCandidateImporter:
                 )
                 continue
 
-            candidate = TrackImportCandidate(identity=identity, metadata=metadata)
+            try:
+                metadata = self._metadata_reader.read(identity.source_path)
+                candidate = TrackImportCandidate(identity=identity, metadata=metadata)
+            except MetadataReadError as exc:
+                issues.append(
+                    TrackImportIssue(
+                        path=exc.path,
+                        code=exc.code,
+                        detail=exc.detail,
+                    )
+                )
+                continue
+            except (AttributeError, TypeError, ValueError) as exc:
+                issues.append(
+                    TrackImportIssue(
+                        path=identity.source_path,
+                        code="metadata_output_invalid",
+                        detail=str(exc) or "metadata reader returned invalid output",
+                    )
+                )
+                continue
+
             candidates.append(candidate)
             seen_track_ids[identity.track_id] = identity.source_path
 

--- a/services/library/importer.py
+++ b/services/library/importer.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from core.library.contracts import LibraryScanResult
+from core.library.track_metadata import (
+    TrackImportBatchResult,
+    TrackImportCandidate,
+    TrackImportIssue,
+)
+from services.library.identity import ContentTrackIdentityService, TrackIdentityError
+from services.library.metadata import (
+    FilenameFallbackMetadataReader,
+    MetadataReadError,
+    TrackMetadataReader,
+)
+
+
+def _text_sort_key(value: str) -> tuple[str, str]:
+    return value.casefold(), value
+
+
+class LibraryCandidateImporter:
+    def __init__(
+        self,
+        *,
+        identity_service: ContentTrackIdentityService | None = None,
+        metadata_reader: TrackMetadataReader | None = None,
+    ) -> None:
+        self._identity_service = identity_service or ContentTrackIdentityService()
+        self._metadata_reader = metadata_reader or FilenameFallbackMetadataReader()
+
+    def import_scan(self, scan_result: LibraryScanResult) -> TrackImportBatchResult:
+        candidates: list[TrackImportCandidate] = []
+        issues: list[TrackImportIssue] = []
+        seen_track_ids: dict[str, str] = {}
+
+        for path in sorted(scan_result.accepted_paths, key=_text_sort_key):
+            try:
+                identity = self._identity_service.identify(path)
+                metadata = self._metadata_reader.read(identity.source_path)
+            except TrackIdentityError as exc:
+                issues.append(
+                    TrackImportIssue(
+                        path=exc.path,
+                        code=exc.code,
+                        detail=exc.detail,
+                    )
+                )
+                continue
+            except MetadataReadError as exc:
+                issues.append(
+                    TrackImportIssue(
+                        path=exc.path,
+                        code=exc.code,
+                        detail=exc.detail,
+                    )
+                )
+                continue
+            except (TypeError, ValueError) as exc:
+                issues.append(
+                    TrackImportIssue(
+                        path=path,
+                        code="metadata_output_invalid",
+                        detail=str(exc) or "metadata reader returned invalid output",
+                    )
+                )
+                continue
+
+            first_path = seen_track_ids.get(identity.track_id)
+            if first_path is not None:
+                issues.append(
+                    TrackImportIssue(
+                        path=identity.source_path,
+                        code="duplicate_content",
+                        detail=f"same content already accepted from {first_path}",
+                    )
+                )
+                continue
+
+            candidate = TrackImportCandidate(identity=identity, metadata=metadata)
+            candidates.append(candidate)
+            seen_track_ids[identity.track_id] = identity.source_path
+
+        ordered_candidates = tuple(
+            sorted(
+                candidates,
+                key=lambda candidate: _text_sort_key(candidate.identity.source_path),
+            )
+        )
+        ordered_issues = tuple(
+            sorted(
+                issues,
+                key=lambda issue: (
+                    issue.path.casefold(),
+                    issue.path,
+                    issue.code.casefold(),
+                    issue.code,
+                ),
+            )
+        )
+        return TrackImportBatchResult(
+            candidates=ordered_candidates,
+            issues=ordered_issues,
+            source_scan_complete=scan_result.complete,
+        )
+
+    def import_paths(
+        self,
+        paths: Iterable[str],
+        *,
+        source_scan_complete: bool = True,
+    ) -> TrackImportBatchResult:
+        ordered_paths = tuple(sorted(set(paths), key=_text_sort_key))
+        scan_result = LibraryScanResult(
+            root="/",
+            accepted_paths=ordered_paths,
+            skipped=(),
+            errors=(),
+            discovered_entries=len(ordered_paths),
+            cancelled=not source_scan_complete,
+        )
+        return self.import_scan(scan_result)

--- a/services/library/metadata.py
+++ b/services/library/metadata.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+from core.library.track_metadata import MetadataOrigin, TrackMetadata
+
+
+class MetadataReadError(RuntimeError):
+    def __init__(self, *, path: str, code: str, detail: str) -> None:
+        super().__init__(detail)
+        self.path = path
+        self.code = code
+        self.detail = detail
+
+
+class TrackMetadataReader(Protocol):
+    def read(self, path: str | Path) -> TrackMetadata: ...
+
+
+class FilenameFallbackMetadataReader:
+    provider_name = "filename-fallback"
+    provider_version = "1"
+
+    def read(self, path: str | Path) -> TrackMetadata:
+        source = Path(path)
+        if not source.is_absolute():
+            raise MetadataReadError(
+                path=str(source),
+                code="metadata_path_not_absolute",
+                detail="metadata reader requires an absolute path",
+            )
+
+        try:
+            resolved = source.resolve(strict=True)
+        except FileNotFoundError as exc:
+            raise MetadataReadError(
+                path=str(source),
+                code="metadata_file_missing",
+                detail="metadata source file does not exist",
+            ) from exc
+        except OSError as exc:
+            raise MetadataReadError(
+                path=str(source),
+                code="metadata_path_unreadable",
+                detail="metadata source path cannot be resolved",
+            ) from exc
+
+        if not resolved.is_file():
+            raise MetadataReadError(
+                path=str(resolved),
+                code="metadata_not_regular_file",
+                detail="metadata source must be a regular file",
+            )
+
+        title = " ".join(resolved.stem.replace("_", " ").split()) or None
+        return TrackMetadata(
+            source_path=str(resolved),
+            provider=self.provider_name,
+            provider_version=self.provider_version,
+            origin=MetadataOrigin.FILENAME_FALLBACK,
+            title=title,
+            warnings=("tagged metadata not read; title derived from filename",),
+        )

--- a/tests/test_library_track_identity.py
+++ b/tests/test_library_track_identity.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.library import LibraryScanResult, MetadataOrigin, TrackMetadata
+from services.library import (
+    ContentTrackIdentityService,
+    FilenameFallbackMetadataReader,
+    LibraryCandidateImporter,
+    MetadataReadError,
+    TrackIdentityError,
+)
+
+
+def _scan_result(*paths: Path, complete: bool = True) -> LibraryScanResult:
+    ordered = tuple(
+        sorted(
+            (str(path.resolve()) for path in paths),
+            key=lambda value: (value.casefold(), value),
+        )
+    )
+    return LibraryScanResult(
+        root=str(paths[0].parent.resolve()) if paths else str(Path("/").resolve()),
+        accepted_paths=ordered,
+        skipped=(),
+        errors=(),
+        discovered_entries=len(ordered),
+        cancelled=not complete,
+    )
+
+
+def test_same_content_at_different_paths_has_same_track_id(tmp_path: Path) -> None:
+    first = tmp_path / "first.wav"
+    second = tmp_path / "moved.wav"
+    first.write_bytes(b"same-audio-content")
+    second.write_bytes(b"same-audio-content")
+
+    service = ContentTrackIdentityService(chunk_size=4)
+
+    first_identity = service.identify(first.resolve())
+    second_identity = service.identify(second.resolve())
+
+    assert first_identity.track_id == second_identity.track_id
+    assert first_identity.digest_hex == second_identity.digest_hex
+    assert first_identity.source_path != second_identity.source_path
+
+
+def test_changed_content_changes_track_id(tmp_path: Path) -> None:
+    track = tmp_path / "track.flac"
+    track.write_bytes(b"version-one")
+    service = ContentTrackIdentityService(chunk_size=3)
+
+    before = service.identify(track.resolve())
+    track.write_bytes(b"version-two")
+    after = service.identify(track.resolve())
+
+    assert before.track_id != after.track_id
+
+
+def test_identity_hashing_uses_configured_chunk_size(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    track = tmp_path / "large.wav"
+    track.write_bytes(b"abcdefghij")
+    read_sizes: list[int] = []
+    original_open = Path.open
+
+    class RecordingReader:
+        def __init__(self, wrapped):
+            self._wrapped = wrapped
+
+        def __enter__(self):
+            self._wrapped.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self._wrapped.__exit__(*args)
+
+        def read(self, size: int = -1):
+            read_sizes.append(size)
+            return self._wrapped.read(size)
+
+    def recording_open(path: Path, *args, **kwargs):
+        return RecordingReader(original_open(path, *args, **kwargs))
+
+    monkeypatch.setattr(Path, "open", recording_open)
+
+    ContentTrackIdentityService(chunk_size=4).identify(track.resolve())
+
+    assert read_sizes
+    assert set(read_sizes) == {4}
+    assert len(read_sizes) >= 3
+
+
+def test_identity_rejects_relative_missing_and_directory_paths(tmp_path: Path) -> None:
+    service = ContentTrackIdentityService()
+
+    with pytest.raises(TrackIdentityError) as relative:
+        service.identify("relative.wav")
+    assert relative.value.code == "identity_path_not_absolute"
+
+    with pytest.raises(TrackIdentityError) as missing:
+        service.identify((tmp_path / "missing.wav").resolve())
+    assert missing.value.code == "identity_file_missing"
+
+    with pytest.raises(TrackIdentityError) as directory:
+        service.identify(tmp_path.resolve())
+    assert directory.value.code == "identity_not_regular_file"
+
+
+def test_filename_fallback_is_explicit_and_does_not_invent_artist(tmp_path: Path) -> None:
+    track = tmp_path / "Artist - Track_Name.wav"
+    track.write_bytes(b"audio")
+
+    metadata = FilenameFallbackMetadataReader().read(track.resolve())
+
+    assert metadata.origin is MetadataOrigin.FILENAME_FALLBACK
+    assert metadata.title == "Artist - Track Name"
+    assert metadata.artist is None
+    assert metadata.album is None
+    assert metadata.genre is None
+    assert metadata.provider == "filename-fallback"
+    assert metadata.warnings == (
+        "tagged metadata not read; title derived from filename",
+    )
+
+
+def test_filename_metadata_reader_rejects_invalid_paths(tmp_path: Path) -> None:
+    reader = FilenameFallbackMetadataReader()
+
+    with pytest.raises(MetadataReadError) as relative:
+        reader.read("track.wav")
+    assert relative.value.code == "metadata_path_not_absolute"
+
+    with pytest.raises(MetadataReadError) as missing:
+        reader.read((tmp_path / "missing.wav").resolve())
+    assert missing.value.code == "metadata_file_missing"
+
+
+def test_importer_deduplicates_identical_content_deterministically(tmp_path: Path) -> None:
+    first = tmp_path / "A.wav"
+    second = tmp_path / "B.wav"
+    first.write_bytes(b"same")
+    second.write_bytes(b"same")
+
+    result = LibraryCandidateImporter().import_scan(_scan_result(second, first))
+
+    assert len(result.candidates) == 1
+    assert result.candidates[0].identity.source_path == str(first.resolve())
+    assert len(result.issues) == 1
+    assert result.issues[0].path == str(second.resolve())
+    assert result.issues[0].code == "duplicate_content"
+
+
+def test_importer_preserves_incomplete_scan_evidence(tmp_path: Path) -> None:
+    track = tmp_path / "track.wav"
+    track.write_bytes(b"audio")
+
+    result = LibraryCandidateImporter().import_scan(
+        _scan_result(track, complete=False)
+    )
+
+    assert len(result.candidates) == 1
+    assert result.source_scan_complete is False
+
+
+def test_importer_converts_invalid_metadata_output_to_controlled_issue(
+    tmp_path: Path,
+) -> None:
+    track = tmp_path / "track.wav"
+    track.write_bytes(b"audio")
+
+    class WrongPathReader:
+        def read(self, path):
+            return TrackMetadata(
+                source_path=str((tmp_path / "other.wav").resolve()),
+                provider="test",
+                provider_version="1",
+                origin=MetadataOrigin.TAGS,
+                title="Track",
+            )
+
+    result = LibraryCandidateImporter(metadata_reader=WrongPathReader()).import_scan(
+        _scan_result(track)
+    )
+
+    assert result.candidates == ()
+    assert len(result.issues) == 1
+    assert result.issues[0].code == "metadata_output_invalid"
+
+
+def test_metadata_contract_rejects_non_finite_and_malformed_values(
+    tmp_path: Path,
+) -> None:
+    path = str((tmp_path / "track.wav").resolve())
+
+    with pytest.raises(ValueError, match="finite and positive"):
+        TrackMetadata(
+            source_path=path,
+            provider="test",
+            provider_version="1",
+            origin=MetadataOrigin.TAGS,
+            duration_seconds=float("nan"),
+        )
+
+    with pytest.raises(TypeError, match="provider must be a string"):
+        TrackMetadata(
+            source_path=path,
+            provider=123,  # type: ignore[arg-type]
+            provider_version="1",
+            origin=MetadataOrigin.TAGS,
+        )
+
+    with pytest.raises(TypeError, match="warnings must be strings"):
+        TrackMetadata(
+            source_path=path,
+            provider="test",
+            provider_version="1",
+            origin=MetadataOrigin.TAGS,
+            warnings=(123,),  # type: ignore[arg-type]
+        )

--- a/tests/test_library_track_identity.py
+++ b/tests/test_library_track_identity.py
@@ -79,6 +79,9 @@ def test_identity_hashing_uses_configured_chunk_size(
         def __exit__(self, *args):
             return self._wrapped.__exit__(*args)
 
+        def fileno(self):
+            return self._wrapped.fileno()
+
         def read(self, size: int = -1):
             read_sizes.append(size)
             return self._wrapped.read(size)


### PR DESCRIPTION
## Summary
- add immutable content identity and metadata contracts
- derive stable `aptrack:v1:sha256:<digest>` identifiers independent of path
- bind streaming SHA-256 hashing to the opened file descriptor
- validate inode/device, size and mtime stability during hashing
- add a read-only metadata provider boundary with explicit provider/version/origin evidence
- add a conservative filename fallback that does not invent artist certainty
- add deterministic scan-to-candidate import with duplicate-content evidence
- add schema tree and recognition roadmap documentation

## Verification
- branch created directly from Bundle 42 squash commit `a9733d6459258838d85d141a8921e9759691d4d6`
- ahead-only diff limited to eight library contract/service/test/documentation files
- Python 3.11 and 3.12 install, compile, critical Ruff and full pytest are required
- no local test execution is claimed

## Isolation
- no database migration or repository write
- no API or desktop integration
- no audio decoding or BPM/key/energy extraction
- no new dependency
- no tag mutation or network access
- no historic code merge

## Bundle Context
- Bundle: 43 — Metadata and Stable Track Identity
- Base branch: `feature/bundle-0-bootstrap`
- Base commit: `a9733d6459258838d85d141a8921e9759691d4d6`
- Related issue: #64
- Next: tagged metadata persistence, then real baseline MIR provider
- Rollback: revert the future isolated squash commit; no data rollback required