### PR TITLE
Bundle 44: tagged metadata and track persistence

### DIFF
--- a/core/library/__init__.py
+++ b/core/library/__init__.py
@@ -5,6 +5,12 @@ from core.library.contracts import (
     LibraryScanResult,
     SymlinkPolicy,
 )
+from core.library.persistence import (
+    LibraryTrackIngestionResult,
+    PersistedTrack,
+    TrackPersistenceBatchResult,
+    TrackPersistenceIssue,
+)
 from core.library.track_metadata import (
     MetadataOrigin,
     TrackIdentity,
@@ -19,11 +25,15 @@ __all__ = [
     "LibraryScanIssue",
     "LibraryScanPolicy",
     "LibraryScanResult",
+    "LibraryTrackIngestionResult",
     "MetadataOrigin",
+    "PersistedTrack",
     "SymlinkPolicy",
     "TrackIdentity",
     "TrackImportBatchResult",
     "TrackImportCandidate",
     "TrackImportIssue",
     "TrackMetadata",
+    "TrackPersistenceBatchResult",
+    "TrackPersistenceIssue",
 ]

--- a/core/library/persistence.py
+++ b/core/library/persistence.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-from core.library.track_metadata import MetadataOrigin
+from core.library.track_metadata import MetadataOrigin, TrackImportBatchResult
 
 
 def _sort_key(value: str) -> tuple[str, str]:
@@ -26,7 +26,10 @@ class PersistedTrack:
             raise ValueError("persisted track path must be absolute")
         if not isinstance(self.metadata_provider, str) or not self.metadata_provider.strip():
             raise ValueError("persisted metadata provider is required")
-        if not isinstance(self.metadata_provider_version, str) or not self.metadata_provider_version.strip():
+        if (
+            not isinstance(self.metadata_provider_version, str)
+            or not self.metadata_provider_version.strip()
+        ):
             raise ValueError("persisted metadata provider version is required")
         if not isinstance(self.metadata_origin, MetadataOrigin):
             try:
@@ -70,7 +73,10 @@ class TrackPersistenceBatchResult:
     requested_count: int
 
     def __post_init__(self) -> None:
-        if not isinstance(self.requested_count, int) or isinstance(self.requested_count, bool):
+        if not isinstance(self.requested_count, int) or isinstance(
+            self.requested_count,
+            bool,
+        ):
             raise TypeError("requested_count must be an integer")
         if self.requested_count < 0:
             raise ValueError("requested_count must be non-negative")
@@ -106,3 +112,21 @@ class TrackPersistenceBatchResult:
     @property
     def complete(self) -> bool:
         return not self.issues
+
+
+@dataclass(frozen=True, slots=True)
+class LibraryTrackIngestionResult:
+    import_result: TrackImportBatchResult
+    persistence_result: TrackPersistenceBatchResult
+
+    def __post_init__(self) -> None:
+        if self.persistence_result.requested_count != len(self.import_result.candidates):
+            raise ValueError("persistence result must account for all import candidates")
+
+    @property
+    def complete(self) -> bool:
+        return (
+            self.import_result.source_scan_complete
+            and not self.import_result.issues
+            and self.persistence_result.complete
+        )

--- a/core/library/persistence.py
+++ b/core/library/persistence.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from core.library.track_metadata import MetadataOrigin
+
+
+def _sort_key(value: str) -> tuple[str, str]:
+    return value.casefold(), value
+
+
+@dataclass(frozen=True, slots=True)
+class PersistedTrack:
+    track_id: str
+    current_path: str
+    metadata_provider: str
+    metadata_provider_version: str
+    metadata_origin: MetadataOrigin
+    relinked: bool
+
+    def __post_init__(self) -> None:
+        if not self.track_id:
+            raise ValueError("persisted track id is required")
+        if not Path(self.current_path).is_absolute():
+            raise ValueError("persisted track path must be absolute")
+        if not isinstance(self.metadata_provider, str) or not self.metadata_provider.strip():
+            raise ValueError("persisted metadata provider is required")
+        if not isinstance(self.metadata_provider_version, str) or not self.metadata_provider_version.strip():
+            raise ValueError("persisted metadata provider version is required")
+        if not isinstance(self.metadata_origin, MetadataOrigin):
+            try:
+                origin = MetadataOrigin(self.metadata_origin)
+            except (TypeError, ValueError) as exc:
+                raise ValueError("unsupported persisted metadata origin") from exc
+            object.__setattr__(self, "metadata_origin", origin)
+        if not isinstance(self.relinked, bool):
+            raise TypeError("persisted relinked flag must be boolean")
+
+        object.__setattr__(self, "metadata_provider", self.metadata_provider.strip())
+        object.__setattr__(
+            self,
+            "metadata_provider_version",
+            self.metadata_provider_version.strip(),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TrackPersistenceIssue:
+    path: str
+    code: str
+    detail: str
+    track_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.path:
+            raise ValueError("persistence issue path is required")
+        if not self.code:
+            raise ValueError("persistence issue code is required")
+        if not self.detail:
+            raise ValueError("persistence issue detail is required")
+        if self.track_id is not None and not self.track_id:
+            raise ValueError("persistence issue track id cannot be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class TrackPersistenceBatchResult:
+    persisted: tuple[PersistedTrack, ...]
+    issues: tuple[TrackPersistenceIssue, ...]
+    requested_count: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.requested_count, int) or isinstance(self.requested_count, bool):
+            raise TypeError("requested_count must be an integer")
+        if self.requested_count < 0:
+            raise ValueError("requested_count must be non-negative")
+        if len(self.persisted) + len(self.issues) != self.requested_count:
+            raise ValueError("persistence result must account for every requested candidate")
+
+        track_ids = tuple(item.track_id for item in self.persisted)
+        if len(set(track_ids)) != len(track_ids):
+            raise ValueError("persisted track ids must be unique")
+
+        expected_persisted = tuple(
+            sorted(
+                self.persisted,
+                key=lambda item: (_sort_key(item.current_path), item.track_id),
+            )
+        )
+        if self.persisted != expected_persisted:
+            raise ValueError("persisted tracks must be deterministically sorted")
+
+        expected_issues = tuple(
+            sorted(
+                self.issues,
+                key=lambda item: (
+                    _sort_key(item.path),
+                    _sort_key(item.code),
+                    item.track_id or "",
+                ),
+            )
+        )
+        if self.issues != expected_issues:
+            raise ValueError("persistence issues must be deterministically sorted")
+
+    @property
+    def complete(self) -> bool:
+        return not self.issues

--- a/core/library/track_metadata.py
+++ b/core/library/track_metadata.py
@@ -12,6 +12,7 @@ _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 class MetadataOrigin(str, Enum):
     TAGS = "tags"
+    TAGS_WITH_FILENAME_FALLBACK = "tags_with_filename_fallback"
     FILENAME_FALLBACK = "filename_fallback"
 
 

--- a/data/repositories/__init__.py
+++ b/data/repositories/__init__.py
@@ -1,0 +1,3 @@
+from data.repositories.library_track_repository import LibraryTrackRepository
+
+__all__ = ["LibraryTrackRepository"]

--- a/data/repositories/library_track_repository.py
+++ b/data/repositories/library_track_repository.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+import hashlib
+import json
+import sqlite3
+
+from core.library.persistence import PersistedTrack
+from core.library.track_metadata import TrackImportCandidate
+from data.connection import get_sqlite_connection
+
+
+class LibraryTrackRepository:
+    def __init__(
+        self,
+        *,
+        connection_factory: Callable[[], sqlite3.Connection] = get_sqlite_connection,
+    ) -> None:
+        self._connection_factory = connection_factory
+
+    @staticmethod
+    def _ensure_schema(conn: sqlite3.Connection) -> None:
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS tracks (
+                track_id TEXT PRIMARY KEY,
+                path TEXT NOT NULL,
+                title TEXT,
+                artist TEXT,
+                album TEXT,
+                genre TEXT,
+                source TEXT,
+                duration_seconds REAL,
+                sample_rate_hz INTEGER,
+                bitrate_kbps INTEGER
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS track_files (
+                track_id TEXT NOT NULL,
+                path TEXT NOT NULL,
+                size_bytes INTEGER NOT NULL CHECK(size_bytes >= 0),
+                mtime_ns INTEGER NOT NULL CHECK(mtime_ns >= 0),
+                is_current INTEGER NOT NULL CHECK(is_current IN (0, 1)),
+                first_seen_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                last_seen_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (track_id, path),
+                FOREIGN KEY (track_id) REFERENCES tracks(track_id) ON DELETE CASCADE
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_track_files_current
+            ON track_files(track_id, is_current)
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_track_files_path
+            ON track_files(path, is_current)
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS track_metadata_snapshots (
+                track_id TEXT NOT NULL,
+                snapshot_digest TEXT NOT NULL,
+                provider TEXT NOT NULL,
+                provider_version TEXT NOT NULL,
+                origin TEXT NOT NULL,
+                title TEXT,
+                artist TEXT,
+                album TEXT,
+                genre TEXT,
+                duration_seconds REAL,
+                sample_rate_hz INTEGER,
+                bitrate_kbps INTEGER,
+                warnings_json TEXT NOT NULL,
+                is_current INTEGER NOT NULL CHECK(is_current IN (0, 1)),
+                first_seen_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                last_seen_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (track_id, snapshot_digest),
+                FOREIGN KEY (track_id) REFERENCES tracks(track_id) ON DELETE CASCADE
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_track_metadata_current
+            ON track_metadata_snapshots(track_id, is_current)
+            """
+        )
+
+    @staticmethod
+    def _metadata_payload(candidate: TrackImportCandidate) -> dict[str, object]:
+        metadata = candidate.metadata
+        return {
+            "provider": metadata.provider,
+            "provider_version": metadata.provider_version,
+            "origin": metadata.origin.value,
+            "title": metadata.title,
+            "artist": metadata.artist,
+            "album": metadata.album,
+            "genre": metadata.genre,
+            "duration_seconds": metadata.duration_seconds,
+            "sample_rate_hz": metadata.sample_rate_hz,
+            "bitrate_kbps": metadata.bitrate_kbps,
+            "warnings": list(metadata.warnings),
+        }
+
+    @classmethod
+    def _metadata_digest(cls, candidate: TrackImportCandidate) -> str:
+        payload = json.dumps(
+            cls._metadata_payload(candidate),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return hashlib.sha256(payload).hexdigest()
+
+    def persist_candidate(self, candidate: TrackImportCandidate) -> PersistedTrack:
+        identity = candidate.identity
+        metadata = candidate.metadata
+        snapshot_digest = self._metadata_digest(candidate)
+
+        with self._connection_factory() as conn:
+            self._ensure_schema(conn)
+            current_row = conn.execute(
+                """
+                SELECT path
+                FROM track_files
+                WHERE track_id = ? AND is_current = 1
+                ORDER BY last_seen_at DESC, path ASC
+                LIMIT 1
+                """,
+                (identity.track_id,),
+            ).fetchone()
+            previous_path = None if current_row is None else str(current_row["path"])
+            relinked = previous_path is not None and previous_path != identity.source_path
+
+            conn.execute(
+                """
+                INSERT INTO tracks (
+                    track_id, path, title, artist, album, genre, source,
+                    duration_seconds, sample_rate_hz, bitrate_kbps
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(track_id) DO UPDATE SET
+                    path = excluded.path,
+                    title = excluded.title,
+                    artist = excluded.artist,
+                    album = excluded.album,
+                    genre = excluded.genre,
+                    source = excluded.source,
+                    duration_seconds = excluded.duration_seconds,
+                    sample_rate_hz = excluded.sample_rate_hz,
+                    bitrate_kbps = excluded.bitrate_kbps
+                """,
+                (
+                    identity.track_id,
+                    identity.source_path,
+                    metadata.title,
+                    metadata.artist,
+                    metadata.album,
+                    metadata.genre,
+                    metadata.provider,
+                    metadata.duration_seconds,
+                    metadata.sample_rate_hz,
+                    metadata.bitrate_kbps,
+                ),
+            )
+
+            conn.execute(
+                "UPDATE track_files SET is_current = 0 WHERE track_id = ?",
+                (identity.track_id,),
+            )
+            conn.execute(
+                "UPDATE track_files SET is_current = 0 WHERE path = ? AND track_id <> ?",
+                (identity.source_path, identity.track_id),
+            )
+            conn.execute(
+                """
+                INSERT INTO track_files (
+                    track_id, path, size_bytes, mtime_ns, is_current
+                )
+                VALUES (?, ?, ?, ?, 1)
+                ON CONFLICT(track_id, path) DO UPDATE SET
+                    size_bytes = excluded.size_bytes,
+                    mtime_ns = excluded.mtime_ns,
+                    is_current = 1,
+                    last_seen_at = CURRENT_TIMESTAMP
+                """,
+                (
+                    identity.track_id,
+                    identity.source_path,
+                    identity.size_bytes,
+                    identity.mtime_ns,
+                ),
+            )
+
+            conn.execute(
+                "UPDATE track_metadata_snapshots SET is_current = 0 WHERE track_id = ?",
+                (identity.track_id,),
+            )
+            payload = self._metadata_payload(candidate)
+            conn.execute(
+                """
+                INSERT INTO track_metadata_snapshots (
+                    track_id, snapshot_digest, provider, provider_version, origin,
+                    title, artist, album, genre, duration_seconds,
+                    sample_rate_hz, bitrate_kbps, warnings_json, is_current
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
+                ON CONFLICT(track_id, snapshot_digest) DO UPDATE SET
+                    is_current = 1,
+                    last_seen_at = CURRENT_TIMESTAMP
+                """,
+                (
+                    identity.track_id,
+                    snapshot_digest,
+                    payload["provider"],
+                    payload["provider_version"],
+                    payload["origin"],
+                    payload["title"],
+                    payload["artist"],
+                    payload["album"],
+                    payload["genre"],
+                    payload["duration_seconds"],
+                    payload["sample_rate_hz"],
+                    payload["bitrate_kbps"],
+                    json.dumps(payload["warnings"], ensure_ascii=False),
+                ),
+            )
+
+        return PersistedTrack(
+            track_id=identity.track_id,
+            current_path=identity.source_path,
+            metadata_provider=metadata.provider,
+            metadata_provider_version=metadata.provider_version,
+            metadata_origin=metadata.origin,
+            relinked=relinked,
+        )
+
+    def get_current_path(self, track_id: str) -> str | None:
+        with self._connection_factory() as conn:
+            self._ensure_schema(conn)
+            row = conn.execute(
+                """
+                SELECT path
+                FROM track_files
+                WHERE track_id = ? AND is_current = 1
+                ORDER BY last_seen_at DESC, path ASC
+                LIMIT 1
+                """,
+                (track_id,),
+            ).fetchone()
+            return None if row is None else str(row["path"])
+
+    def list_file_history(self, track_id: str) -> tuple[tuple[str, bool], ...]:
+        with self._connection_factory() as conn:
+            self._ensure_schema(conn)
+            rows = conn.execute(
+                """
+                SELECT path, is_current
+                FROM track_files
+                WHERE track_id = ?
+                ORDER BY path COLLATE NOCASE, path
+                """,
+                (track_id,),
+            ).fetchall()
+            return tuple((str(row["path"]), bool(row["is_current"])) for row in rows)
+
+    def metadata_snapshot_count(self, track_id: str) -> int:
+        with self._connection_factory() as conn:
+            self._ensure_schema(conn)
+            row = conn.execute(
+                "SELECT COUNT(*) AS count FROM track_metadata_snapshots WHERE track_id = ?",
+                (track_id,),
+            ).fetchone()
+            return int(row["count"])

--- a/docs/compliance/APPLAYLIST_LICENSE_DECISION_REGISTER_V1.md
+++ b/docs/compliance/APPLAYLIST_LICENSE_DECISION_REGISTER_V1.md
@@ -25,6 +25,7 @@ This document is an engineering control, not legal advice. Final commercial dist
 | SciPy | signal-processing baseline | approved_dev | verify binary-wheel notices in packaged app |
 | SoundFile | audio decode boundary | approved_dev | audit bundled native `libsndfile` obligations |
 | Librosa | baseline MIR candidate | approved_dev | benchmark; move behind lazy provider boundary |
+| TinyTag 2.2.1 | read-only audio metadata | approved_dev | retain MIT notice; verify exact resolved version and packaged SBOM before distribution |
 
 `approved_dev` does not automatically mean approved for a signed commercial installer.
 
@@ -32,8 +33,8 @@ This document is an engineering control, not legal advice. Final commercial dist
 
 | Component | Candidate use | State | Decision notes |
 |---|---|---|---|
-| TinyTag | read-only audio metadata | review_required | verify exact version, license, supported formats and packaging before adding |
-| Mutagen | metadata read/write | review_required | broader functionality than MVP needs; legal and distribution review required before use |
+| TinyTag 2.2.1 | read-only audio metadata | approved_dev | MIT, pure Python, no dependencies, read-only API; supports MP3/MP2/MP1, M4A/AAC/ALAC, WAV, OGG/Opus/Vorbis, FLAC, WMA and AIFF families |
+| Mutagen | metadata read/write | review_required | broader functionality than MVP needs; do not add while read-only TinyTag satisfies the accepted scope |
 
 Product preference is the smallest read-only metadata dependency that satisfies supported formats and can be safely packaged.
 
@@ -54,7 +55,7 @@ Product preference is the smallest read-only metadata dependency that satisfies 
 | Qt commercial distribution | desktop shell | review_required | evaluate cost and licensing against business model before dependency approval |
 | pyside6-deploy / Nuitka path | packaging | review_required | run reproducible macOS and Windows packaging proof; audit transitive licenses and generated notices |
 
-No desktop dependency may be added to the main runtime dependency set in Bundle 41.
+No desktop dependency may be added to the main runtime dependency set before the desktop licensing gate.
 
 ## Export formats and interoperability
 
@@ -113,9 +114,10 @@ A dependency may move to `approved_distribution` only with a decision record con
 
 ## Immediate decisions
 
-- keep the current backend dependency set unchanged in Bundle 41,
+- use TinyTag only for read-only tagged metadata ingestion,
+- retain filename fallback as explicit degraded evidence rather than silent success,
 - use Librosa only as a baseline benchmark candidate until quality gates pass,
 - keep Essentia out of production dependencies,
-- do not start the PySide6 implementation before a desktop licensing and packaging decision,
+- do not start the desktop implementation before a desktop licensing and packaging decision,
 - implement M3U8 before proprietary ecosystem adapters,
 - prohibit unreviewed pretrained-model downloads in runtime or CI.

--- a/docs/status/BUNDLE_44_TAGGED_METADATA_PERSISTENCE.md
+++ b/docs/status/BUNDLE_44_TAGGED_METADATA_PERSISTENCE.md
@@ -1,0 +1,126 @@
+# Bundle 44 — Tagged Metadata and Track Persistence
+
+## Status
+
+Implemented on an isolated feature branch. Not yet merged.
+
+## Product Goal
+
+Persist a scanned local audio track as stable content identity, read-only tagged metadata, current file location and audit-preserving metadata snapshots before any BPM/key/energy analysis runs.
+
+## Schema Tree
+
+```text
+APPLAYLIST
+└── Library ingestion
+    ├── Bundle 42: LibraryScanner
+    │   └── LibraryScanResult
+    │
+    ├── Bundle 43: identity + metadata boundary
+    │   ├── ContentTrackIdentityService
+    │   ├── TrackIdentity
+    │   └── TrackMetadataReader protocol
+    │
+    └── Bundle 44: tagged metadata + persistence
+        ├── TinyTagMetadataReader
+        │   ├── read-only tag parsing
+        │   ├── provider/version evidence
+        │   ├── normalized text and numeric fields
+        │   ├── explicit filename-title fallback
+        │   └── controlled parser/output errors
+        │
+        ├── LibraryCandidateImporter
+        │   └── TrackImportBatchResult
+        │
+        ├── TrackImportPersistenceService
+        │   └── per-candidate transaction boundary
+        │
+        └── LibraryTrackRepository
+            ├── tracks
+            │   └── compatibility projection for existing composer/runtime
+            ├── track_files
+            │   ├── current path
+            │   ├── historical paths
+            │   └── size + mtime evidence
+            └── track_metadata_snapshots
+                ├── provider + provider version
+                ├── metadata origin
+                ├── normalized values
+                ├── warnings JSON
+                ├── deterministic snapshot digest
+                └── current/historical evidence
+```
+
+## Runtime Flow
+
+```text
+selected directory
+  → bounded LibraryScanner
+  → stable SHA-256 TrackIdentity
+  → TinyTagMetadataReader
+  → validated TrackImportCandidate
+  → transactional persistence
+       ├── legacy-compatible tracks projection
+       ├── active + historical file paths
+       └── versioned metadata snapshots
+  → ready for later MIR analysis
+```
+
+## Key Decisions
+
+- TinyTag 2.2.1 is pinned for development and CI as a small read-only metadata dependency.
+- Tag parser failures are controlled errors, not silent filename fallback.
+- Filename fallback is used only when a parsed file lacks a title tag.
+- Artist, album and genre are never invented from filename structure.
+- Track identity remains derived from bytes, never from path or metadata.
+- Same content moved to a new path preserves old path evidence and marks exactly one current path.
+- Identical metadata state is idempotent; changed metadata creates a new snapshot.
+- Existing `tracks` consumers remain compatible while normalized evidence is added beside them.
+
+## Transaction Boundary
+
+For one candidate, these writes succeed or roll back together:
+
+```text
+tracks upsert
+  + track_files current-path update
+  + metadata snapshot current-state update
+```
+
+A database failure must not leave a track without matching file or metadata evidence.
+
+## Explicitly Out of Scope
+
+- BPM, beat, key, Camelot, energy, loudness or cue analysis,
+- API routes and desktop UI,
+- tag mutation,
+- network metadata lookup,
+- Spotify/Last.fm/Soundcharts signals,
+- cleanup of historical duplicate `* 2.py` files,
+- permanent deletion of local files.
+
+## Verification Requirements
+
+- TinyTag normalization and fallback tests,
+- controlled corrupt/unsupported file error,
+- idempotent repeated import,
+- move/relink history,
+- changed metadata snapshot evidence,
+- rollback proof on forced SQLite failure,
+- existing repository/composition tests unchanged,
+- Python 3.11 and 3.12 full CI.
+
+## Next Slices
+
+```text
+Repository Hygiene Bundle
+  → audit / dry-run / quarantine / verify
+  → no automatic purge
+
+Bundle 45 — Baseline MIR Provider
+  → BPM + beat confidence
+  → key + scale + Camelot
+  → tonal strength
+  → energy features
+  → versioned warnings and evidence
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "soundfile>=0.12,<1.0",
   "scipy>=1.10,<1.14",
   "numpy>=1.24,<2.0",
-  "tinytag>=2.2.1,<3.0",
+  "tinytag==2.2.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   "soundfile>=0.12,<1.0",
   "scipy>=1.10,<1.14",
   "numpy>=1.24,<2.0",
+  "tinytag>=2.2.1,<3.0",
 ]
 
 [project.optional-dependencies]

--- a/services/library/__init__.py
+++ b/services/library/__init__.py
@@ -1,10 +1,13 @@
 from services.library.identity import ContentTrackIdentityService, TrackIdentityError
 from services.library.importer import LibraryCandidateImporter
+from services.library.ingestion import LibraryTrackIngestionService
 from services.library.metadata import (
     FilenameFallbackMetadataReader,
     MetadataReadError,
+    TinyTagMetadataReader,
     TrackMetadataReader,
 )
+from services.library.persistence import TrackImportPersistenceService
 from services.library.scanner import LibraryScanner
 
 __all__ = [
@@ -12,7 +15,10 @@ __all__ = [
     "FilenameFallbackMetadataReader",
     "LibraryCandidateImporter",
     "LibraryScanner",
+    "LibraryTrackIngestionService",
     "MetadataReadError",
+    "TinyTagMetadataReader",
     "TrackIdentityError",
+    "TrackImportPersistenceService",
     "TrackMetadataReader",
 ]

--- a/services/library/ingestion.py
+++ b/services/library/ingestion.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from core.library.contracts import LibraryScanResult
+from core.library.persistence import LibraryTrackIngestionResult
+from services.library.importer import LibraryCandidateImporter
+from services.library.metadata import TinyTagMetadataReader
+from services.library.persistence import TrackImportPersistenceService
+
+
+class LibraryTrackIngestionService:
+    def __init__(
+        self,
+        *,
+        importer: LibraryCandidateImporter | None = None,
+        persistence: TrackImportPersistenceService | None = None,
+    ) -> None:
+        self._importer = importer or LibraryCandidateImporter(
+            metadata_reader=TinyTagMetadataReader()
+        )
+        self._persistence = persistence or TrackImportPersistenceService()
+
+    def ingest(self, scan_result: LibraryScanResult) -> LibraryTrackIngestionResult:
+        import_result = self._importer.import_scan(scan_result)
+        persistence_result = self._persistence.persist(import_result)
+        return LibraryTrackIngestionResult(
+            import_result=import_result,
+            persistence_result=persistence_result,
+        )

--- a/services/library/metadata.py
+++ b/services/library/metadata.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
+from importlib.metadata import PackageNotFoundError, version
+import math
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol
+
+from tinytag import TinyTag, TinyTagException
 
 from core.library.track_metadata import MetadataOrigin, TrackMetadata
 
@@ -18,41 +23,93 @@ class TrackMetadataReader(Protocol):
     def read(self, path: str | Path) -> TrackMetadata: ...
 
 
+def _resolve_regular_file(path: str | Path) -> Path:
+    source = Path(path)
+    if not source.is_absolute():
+        raise MetadataReadError(
+            path=str(source),
+            code="metadata_path_not_absolute",
+            detail="metadata reader requires an absolute path",
+        )
+
+    try:
+        resolved = source.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise MetadataReadError(
+            path=str(source),
+            code="metadata_file_missing",
+            detail="metadata source file does not exist",
+        ) from exc
+    except OSError as exc:
+        raise MetadataReadError(
+            path=str(source),
+            code="metadata_path_unreadable",
+            detail="metadata source path cannot be resolved",
+        ) from exc
+
+    if not resolved.is_file():
+        raise MetadataReadError(
+            path=str(resolved),
+            code="metadata_not_regular_file",
+            detail="metadata source must be a regular file",
+        )
+    return resolved
+
+
+def _normalize_text(value: Any, *, field_name: str) -> str | None:
+    if value is None:
+        return None
+    values: Iterable[Any]
+    if isinstance(value, str):
+        values = (value,)
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        values = value
+    else:
+        raise TypeError(f"TinyTag {field_name} must be text or a text collection")
+
+    normalized_values: list[str] = []
+    for item in values:
+        if item is None:
+            continue
+        if not isinstance(item, str):
+            raise TypeError(f"TinyTag {field_name} values must be strings")
+        normalized = " ".join(item.split())
+        if normalized:
+            normalized_values.append(normalized)
+
+    if not normalized_values:
+        return None
+    if isinstance(value, (set, frozenset)):
+        normalized_values.sort(key=lambda item: (item.casefold(), item))
+    return "; ".join(dict.fromkeys(normalized_values))
+
+
+def _positive_float(value: Any, *, field_name: str, warnings: list[str]) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        warnings.append(f"TinyTag {field_name} was non-numeric and was ignored")
+        return None
+    normalized = float(value)
+    if not math.isfinite(normalized) or normalized <= 0:
+        warnings.append(f"TinyTag {field_name} was non-positive or non-finite and was ignored")
+        return None
+    return normalized
+
+
+def _positive_int(value: Any, *, field_name: str, warnings: list[str]) -> int | None:
+    normalized = _positive_float(value, field_name=field_name, warnings=warnings)
+    if normalized is None:
+        return None
+    return max(1, int(round(normalized)))
+
+
 class FilenameFallbackMetadataReader:
     provider_name = "filename-fallback"
     provider_version = "1"
 
     def read(self, path: str | Path) -> TrackMetadata:
-        source = Path(path)
-        if not source.is_absolute():
-            raise MetadataReadError(
-                path=str(source),
-                code="metadata_path_not_absolute",
-                detail="metadata reader requires an absolute path",
-            )
-
-        try:
-            resolved = source.resolve(strict=True)
-        except FileNotFoundError as exc:
-            raise MetadataReadError(
-                path=str(source),
-                code="metadata_file_missing",
-                detail="metadata source file does not exist",
-            ) from exc
-        except OSError as exc:
-            raise MetadataReadError(
-                path=str(source),
-                code="metadata_path_unreadable",
-                detail="metadata source path cannot be resolved",
-            ) from exc
-
-        if not resolved.is_file():
-            raise MetadataReadError(
-                path=str(resolved),
-                code="metadata_not_regular_file",
-                detail="metadata source must be a regular file",
-            )
-
+        resolved = _resolve_regular_file(path)
         title = " ".join(resolved.stem.replace("_", " ").split()) or None
         return TrackMetadata(
             source_path=str(resolved),
@@ -61,4 +118,84 @@ class FilenameFallbackMetadataReader:
             origin=MetadataOrigin.FILENAME_FALLBACK,
             title=title,
             warnings=("tagged metadata not read; title derived from filename",),
+        )
+
+
+class TinyTagMetadataReader:
+    provider_name = "tinytag"
+
+    def __init__(self) -> None:
+        try:
+            self.provider_version = version("tinytag")
+        except PackageNotFoundError:
+            self.provider_version = "unknown"
+        self._filename_fallback = FilenameFallbackMetadataReader()
+
+    def read(self, path: str | Path) -> TrackMetadata:
+        resolved = _resolve_regular_file(path)
+        try:
+            tag = TinyTag.get(str(resolved))
+        except (TinyTagException, OSError, ValueError) as exc:
+            raise MetadataReadError(
+                path=str(resolved),
+                code="metadata_parse_failed",
+                detail="TinyTag could not parse the audio metadata",
+            ) from exc
+
+        warnings: list[str] = []
+        try:
+            title = _normalize_text(tag.title, field_name="title")
+            artist = _normalize_text(tag.artist, field_name="artist")
+            album = _normalize_text(tag.album, field_name="album")
+            genre = _normalize_text(tag.genre, field_name="genre")
+        except TypeError as exc:
+            raise MetadataReadError(
+                path=str(resolved),
+                code="metadata_output_invalid",
+                detail=str(exc),
+            ) from exc
+
+        origin = MetadataOrigin.TAGS
+        if title is None:
+            fallback = self._filename_fallback.read(resolved)
+            title = fallback.title
+            origin = MetadataOrigin.TAGS_WITH_FILENAME_FALLBACK
+            warnings.append("title tag missing; title derived from filename")
+
+        duration = _positive_float(
+            getattr(tag, "duration", None),
+            field_name="duration",
+            warnings=warnings,
+        )
+        sample_rate = _positive_int(
+            getattr(tag, "samplerate", None),
+            field_name="sample rate",
+            warnings=warnings,
+        )
+        bitrate = _positive_int(
+            getattr(tag, "bitrate", None),
+            field_name="bitrate",
+            warnings=warnings,
+        )
+
+        if artist is None:
+            warnings.append("artist tag missing")
+        if album is None:
+            warnings.append("album tag missing")
+        if genre is None:
+            warnings.append("genre tag missing")
+
+        return TrackMetadata(
+            source_path=str(resolved),
+            provider=self.provider_name,
+            provider_version=self.provider_version,
+            origin=origin,
+            title=title,
+            artist=artist,
+            album=album,
+            genre=genre,
+            duration_seconds=duration,
+            sample_rate_hz=sample_rate,
+            bitrate_kbps=bitrate,
+            warnings=tuple(warnings),
         )

--- a/services/library/persistence.py
+++ b/services/library/persistence.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import sqlite3
+from typing import Protocol
+
+from core.library.persistence import (
+    PersistedTrack,
+    TrackPersistenceBatchResult,
+    TrackPersistenceIssue,
+)
+from core.library.track_metadata import TrackImportBatchResult, TrackImportCandidate
+from data.repositories.library_track_repository import LibraryTrackRepository
+
+
+class TrackCandidateRepository(Protocol):
+    def persist_candidate(self, candidate: TrackImportCandidate) -> PersistedTrack: ...
+
+
+def _text_sort_key(value: str) -> tuple[str, str]:
+    return value.casefold(), value
+
+
+class TrackImportPersistenceService:
+    def __init__(
+        self,
+        *,
+        repository: TrackCandidateRepository | None = None,
+    ) -> None:
+        self._repository = repository or LibraryTrackRepository()
+
+    def persist(self, batch: TrackImportBatchResult) -> TrackPersistenceBatchResult:
+        persisted: list[PersistedTrack] = []
+        issues: list[TrackPersistenceIssue] = []
+
+        for candidate in batch.candidates:
+            try:
+                persisted.append(self._repository.persist_candidate(candidate))
+            except sqlite3.DatabaseError as exc:
+                issues.append(
+                    TrackPersistenceIssue(
+                        path=candidate.identity.source_path,
+                        track_id=candidate.identity.track_id,
+                        code="track_persistence_failed",
+                        detail=str(exc) or "track persistence transaction failed",
+                    )
+                )
+
+        ordered_persisted = tuple(
+            sorted(
+                persisted,
+                key=lambda item: (_text_sort_key(item.current_path), item.track_id),
+            )
+        )
+        ordered_issues = tuple(
+            sorted(
+                issues,
+                key=lambda item: (
+                    _text_sort_key(item.path),
+                    _text_sort_key(item.code),
+                    item.track_id or "",
+                ),
+            )
+        )
+        return TrackPersistenceBatchResult(
+            persisted=ordered_persisted,
+            issues=ordered_issues,
+            requested_count=len(batch.candidates),
+        )

--- a/tests/test_library_tagged_persistence.py
+++ b/tests/test_library_tagged_persistence.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+from tinytag import TinyTagException
+
+from core.library import (
+    LibraryScanResult,
+    MetadataOrigin,
+    TrackImportBatchResult,
+    TrackImportCandidate,
+    TrackMetadata,
+)
+from data.repositories.library_track_repository import LibraryTrackRepository
+from services.library import (
+    ContentTrackIdentityService,
+    LibraryTrackIngestionService,
+    MetadataReadError,
+    TinyTagMetadataReader,
+    TrackImportPersistenceService,
+)
+
+
+def _connection_factory(database_path: Path):
+    def connect() -> sqlite3.Connection:
+        connection = sqlite3.connect(database_path)
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    return connect
+
+
+def _candidate(path: Path, *, title: str = "Track") -> TrackImportCandidate:
+    identity = ContentTrackIdentityService(chunk_size=3).identify(path.resolve())
+    return TrackImportCandidate(
+        identity=identity,
+        metadata=TrackMetadata(
+            source_path=identity.source_path,
+            provider="test-tags",
+            provider_version="1",
+            origin=MetadataOrigin.TAGS,
+            title=title,
+            artist="Artist",
+            album="Album",
+            genre="House",
+            duration_seconds=180.0,
+            sample_rate_hz=44100,
+            bitrate_kbps=320,
+            warnings=(),
+        ),
+    )
+
+
+def _batch(*candidates: TrackImportCandidate) -> TrackImportBatchResult:
+    ordered = tuple(
+        sorted(
+            candidates,
+            key=lambda candidate: (
+                candidate.identity.source_path.casefold(),
+                candidate.identity.source_path,
+            ),
+        )
+    )
+    return TrackImportBatchResult(
+        candidates=ordered,
+        issues=(),
+        source_scan_complete=True,
+    )
+
+
+def test_tinytag_reader_normalizes_tagged_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    track = tmp_path / "track.flac"
+    track.write_bytes(b"audio")
+    fake_tag = SimpleNamespace(
+        title=["  Main   Track  "],
+        artist=["Artist A", "Artist B"],
+        album="Album",
+        genre=["House", "Deep House"],
+        duration=240.25,
+        samplerate=48000.0,
+        bitrate=320.1,
+    )
+    monkeypatch.setattr("services.library.metadata.TinyTag.get", lambda _path: fake_tag)
+
+    metadata = TinyTagMetadataReader().read(track.resolve())
+
+    assert metadata.provider == "tinytag"
+    assert metadata.origin is MetadataOrigin.TAGS
+    assert metadata.title == "Main Track"
+    assert metadata.artist == "Artist A; Artist B"
+    assert metadata.genre == "House; Deep House"
+    assert metadata.duration_seconds == 240.25
+    assert metadata.sample_rate_hz == 48000
+    assert metadata.bitrate_kbps == 320
+    assert metadata.warnings == ()
+
+
+def test_tinytag_reader_uses_explicit_title_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    track = tmp_path / "Fallback_Title.wav"
+    track.write_bytes(b"audio")
+    fake_tag = SimpleNamespace(
+        title=None,
+        artist=None,
+        album=None,
+        genre=None,
+        duration=30.0,
+        samplerate=44100,
+        bitrate=1411,
+    )
+    monkeypatch.setattr("services.library.metadata.TinyTag.get", lambda _path: fake_tag)
+
+    metadata = TinyTagMetadataReader().read(track.resolve())
+
+    assert metadata.origin is MetadataOrigin.TAGS_WITH_FILENAME_FALLBACK
+    assert metadata.title == "Fallback Title"
+    assert "title tag missing; title derived from filename" in metadata.warnings
+    assert "artist tag missing" in metadata.warnings
+
+
+def test_tinytag_reader_translates_parser_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    track = tmp_path / "broken.mp3"
+    track.write_bytes(b"not-audio")
+
+    def fail(_path):
+        raise TinyTagException("broken")
+
+    monkeypatch.setattr("services.library.metadata.TinyTag.get", fail)
+
+    with pytest.raises(MetadataReadError) as error:
+        TinyTagMetadataReader().read(track.resolve())
+
+    assert error.value.code == "metadata_parse_failed"
+
+
+def test_persistence_is_idempotent_and_keeps_legacy_track_projection(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "library.sqlite"
+    track = tmp_path / "track.wav"
+    track.write_bytes(b"same-content")
+    candidate = _candidate(track)
+    repository = LibraryTrackRepository(
+        connection_factory=_connection_factory(database)
+    )
+
+    first = repository.persist_candidate(candidate)
+    second = repository.persist_candidate(candidate)
+
+    assert first.relinked is False
+    assert second.relinked is False
+    assert repository.metadata_snapshot_count(candidate.identity.track_id) == 1
+    assert repository.list_file_history(candidate.identity.track_id) == (
+        (str(track.resolve()), True),
+    )
+
+    with _connection_factory(database)() as connection:
+        row = connection.execute(
+            "SELECT path, title, source FROM tracks WHERE track_id = ?",
+            (candidate.identity.track_id,),
+        ).fetchone()
+    assert row is not None
+    assert row["path"] == str(track.resolve())
+    assert row["title"] == "Track"
+    assert row["source"] == "test-tags"
+
+
+def test_persistence_records_relink_history_for_same_content(tmp_path: Path) -> None:
+    database = tmp_path / "library.sqlite"
+    first_path = tmp_path / "first.wav"
+    moved_path = tmp_path / "moved.wav"
+    first_path.write_bytes(b"same-content")
+    moved_path.write_bytes(b"same-content")
+    first_candidate = _candidate(first_path)
+    moved_candidate = _candidate(moved_path)
+    repository = LibraryTrackRepository(
+        connection_factory=_connection_factory(database)
+    )
+
+    repository.persist_candidate(first_candidate)
+    moved = repository.persist_candidate(moved_candidate)
+
+    assert first_candidate.identity.track_id == moved_candidate.identity.track_id
+    assert moved.relinked is True
+    assert repository.get_current_path(moved.track_id) == str(moved_path.resolve())
+    assert repository.list_file_history(moved.track_id) == (
+        (str(first_path.resolve()), False),
+        (str(moved_path.resolve()), True),
+    )
+
+
+def test_changed_metadata_creates_new_snapshot(tmp_path: Path) -> None:
+    database = tmp_path / "library.sqlite"
+    track = tmp_path / "track.wav"
+    track.write_bytes(b"same-content")
+    repository = LibraryTrackRepository(
+        connection_factory=_connection_factory(database)
+    )
+
+    repository.persist_candidate(_candidate(track, title="First Title"))
+    repository.persist_candidate(_candidate(track, title="Second Title"))
+
+    identity = ContentTrackIdentityService().identify(track.resolve())
+    assert repository.metadata_snapshot_count(identity.track_id) == 2
+
+
+def test_transaction_failure_does_not_leave_partial_track_state(tmp_path: Path) -> None:
+    database = tmp_path / "library.sqlite"
+    first = tmp_path / "first.wav"
+    second = tmp_path / "second.wav"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+    repository = LibraryTrackRepository(
+        connection_factory=_connection_factory(database)
+    )
+    repository.persist_candidate(_candidate(first))
+
+    with _connection_factory(database)() as connection:
+        connection.execute(
+            """
+            CREATE TRIGGER fail_track_file_insert
+            BEFORE INSERT ON track_files
+            BEGIN
+                SELECT RAISE(ABORT, 'forced failure');
+            END
+            """
+        )
+        connection.commit()
+
+    persistence = TrackImportPersistenceService(repository=repository)
+    candidate = _candidate(second)
+    result = persistence.persist(_batch(candidate))
+
+    assert result.persisted == ()
+    assert result.issues[0].code == "track_persistence_failed"
+    with _connection_factory(database)() as connection:
+        track_row = connection.execute(
+            "SELECT track_id FROM tracks WHERE track_id = ?",
+            (candidate.identity.track_id,),
+        ).fetchone()
+        file_row = connection.execute(
+            "SELECT path FROM track_files WHERE track_id = ?",
+            (candidate.identity.track_id,),
+        ).fetchone()
+        metadata_row = connection.execute(
+            "SELECT track_id FROM track_metadata_snapshots WHERE track_id = ?",
+            (candidate.identity.track_id,),
+        ).fetchone()
+    assert track_row is None
+    assert file_row is None
+    assert metadata_row is None
+
+
+def test_ingestion_service_connects_scan_import_and_persistence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database = tmp_path / "library.sqlite"
+    track = tmp_path / "track.wav"
+    track.write_bytes(b"audio")
+    fake_tag = SimpleNamespace(
+        title="Tagged Track",
+        artist="DJ",
+        album=None,
+        genre="Techno",
+        duration=180.0,
+        samplerate=44100,
+        bitrate=320,
+    )
+    monkeypatch.setattr("services.library.metadata.TinyTag.get", lambda _path: fake_tag)
+    scan = LibraryScanResult(
+        root=str(tmp_path.resolve()),
+        accepted_paths=(str(track.resolve()),),
+        skipped=(),
+        errors=(),
+        discovered_entries=1,
+    )
+    repository = LibraryTrackRepository(
+        connection_factory=_connection_factory(database)
+    )
+    service = LibraryTrackIngestionService(
+        persistence=TrackImportPersistenceService(repository=repository)
+    )
+
+    result = service.ingest(scan)
+
+    assert result.complete is True
+    assert result.import_result.candidates[0].metadata.title == "Tagged Track"
+    assert result.persistence_result.persisted[0].current_path == str(track.resolve())


### PR DESCRIPTION
## Summary
- add pinned TinyTag 2.2.1 read-only metadata ingestion
- normalize tag text and numeric fields with explicit provider/version/origin evidence
- distinguish parsed tags from title-only filename fallback
- add transactional persistence across legacy-compatible `tracks`, normalized `track_files`, and versioned metadata snapshots
- preserve historical paths and mark exactly one current path per track
- make repeated identical imports idempotent
- add orchestration from scan result through tagged metadata import to persistence
- add rollback, relink, idempotency, parser failure and end-to-end ingestion tests
- update license register and add per-bundle schema tree

## Verification
- branch created directly from Bundle 43 squash commit `892b7dff2217db79f764ac53daf9e5e87c6b19b1`
- ahead-only diff limited to metadata/persistence contracts, repository/service code, one pinned dependency, tests and documentation
- Python 3.11 and 3.12 install, compile, critical Ruff and full pytest are required
- no local test execution is claimed

## Isolation
- no BPM, key, Camelot, energy or cue analysis
- no API or desktop integration
- no tag mutation or network access
- no destructive migration
- no cleanup of historical duplicate files in this bundle

## Bundle Context
- Bundle: 44 — Tagged Metadata and Track Persistence
- Base branch: `feature/bundle-0-bootstrap`
- Base commit: `892b7dff2217db79f764ac53daf9e5e87c6b19b1`
- Related issue: #66
- Related hygiene follow-up: #67
- Next product slice: baseline MIR provider
- Rollback: revert the future isolated squash commit; added SQLite tables may remain unused