### PR TITLE
Maintenance H1: safe repository hygiene audit and quarantine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ data/config/path_profiles.json
 *.log
 *.tmp
 
+# Repository hygiene local state
+.repo-hygiene/
+
 # Backups and editor temporary files
 .backup_*
 .backup_*/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev test lint tree
+.PHONY: dev test lint tree hygiene-audit hygiene-plan hygiene-verify
 
 dev:
 	uvicorn api.main:app --reload --host 0.0.0.0 --port 8000
@@ -11,3 +11,12 @@ lint:
 
 tree:
 	find . -maxdepth 3 -type f | sort
+
+hygiene-audit:
+	bash scripts/repo_hygiene.sh audit --stdout
+
+hygiene-plan:
+	bash scripts/repo_hygiene.sh quarantine
+
+hygiene-verify:
+	bash scripts/repo_hygiene.sh verify

--- a/docs/operations/REPOSITORY_HYGIENE_OPERATOR_GUIDE.md
+++ b/docs/operations/REPOSITORY_HYGIENE_OPERATOR_GUIDE.md
@@ -1,0 +1,220 @@
+# APPLAYLIST Repository Hygiene Operator Guide
+
+## Purpose
+
+The repository hygiene tool keeps a local APPLAYLIST checkout understandable and reproducible without deleting unknown data, source code, databases, secrets or music files.
+
+It is an operator tool, not an automatic garbage collector.
+
+## Safety model
+
+```text
+selected Git checkout
+  → resolve canonical Git root
+  → inventory tracked and worktree state
+  → classify only known candidate types
+  → protect tracked/modified/secret/database/audio/symlink content
+  → write JSON + Markdown evidence
+  → dry-run by default
+  → explicit quarantine --apply
+  → timestamped manifest
+  → optional verified restore
+```
+
+Permanent purge is deliberately not implemented.
+
+## Schema tree
+
+```text
+RepositoryHygiene
+├── audit
+│   ├── Git tracked-file inventory
+│   ├── dirty-worktree evidence
+│   ├── bounded size calculation
+│   ├── candidate classification
+│   ├── report-only protections
+│   └── JSON + Markdown reports
+│
+├── quarantine
+│   ├── dry-run by default
+│   ├── explicit --apply
+│   ├── repository-root containment
+│   ├── preserved relative paths
+│   ├── timestamped payload tree
+│   └── rollback manifest
+│
+├── restore
+│   ├── dry-run by default
+│   ├── repository identity validation
+│   ├── destination collision prevention
+│   ├── file digest validation
+│   └── explicit --apply
+│
+└── verify
+    ├── git diff --check
+    ├── tracked Python syntax compilation in memory
+    ├── import smoke test with bytecode disabled
+    ├── tracked-quarantine invariant
+    └── audit summary
+```
+
+## Protected by default
+
+The tool never automatically quarantines:
+
+- `.git`,
+- tracked files or directories containing tracked files,
+- modified tracked content,
+- `.env` or `.env.*`,
+- SQLite databases,
+- supported audio files,
+- unknown files,
+- symlinks,
+- anything outside the selected Git repository root,
+- `.repo-hygiene` state and evidence.
+
+## Candidate categories
+
+Automatically eligible when untracked and unmodified:
+
+- Python bytecode and `__pycache__`,
+- pytest, Ruff, Mypy, Tox and Nox caches,
+- coverage and editor temporary files,
+- `.DS_Store`,
+- standard build outputs,
+- byte-identical untracked duplicate files such as `module 2.py` when the canonical file is tracked and the duplicate is not referenced.
+
+Report-only unless explicitly enabled:
+
+- `artifacts/`, `exports/`, `logs/`, `tmp/`, `data/cache/`, `data/tmp/`,
+- `.venv`, `venv`, `node_modules`, `frontend/node_modules`, `frontend/dist`.
+
+## Commands
+
+Run from any path inside the APPLAYLIST Git checkout.
+
+### Audit only
+
+```bash
+bash scripts/repo_hygiene.sh audit --stdout
+```
+
+Or:
+
+```bash
+make hygiene-audit
+```
+
+The command writes reports under:
+
+```text
+.repo-hygiene/reports/
+```
+
+### Quarantine plan without changes
+
+```bash
+bash scripts/repo_hygiene.sh quarantine
+```
+
+Or:
+
+```bash
+make hygiene-plan
+```
+
+### Apply safe default quarantine
+
+Review the generated plan first, then run:
+
+```bash
+bash scripts/repo_hygiene.sh quarantine --apply
+```
+
+### Include generated runtime outputs
+
+```bash
+bash scripts/repo_hygiene.sh quarantine --include-generated
+```
+
+Apply only after reviewing the report:
+
+```bash
+bash scripts/repo_hygiene.sh quarantine --include-generated --apply
+```
+
+### Include heavy generated directories
+
+This is intentionally a separate opt-in:
+
+```bash
+bash scripts/repo_hygiene.sh quarantine --include-generated --include-heavy
+```
+
+Use `--apply` only after verifying that the environment or frontend dependencies can be reproduced.
+
+### Verify repository safety
+
+```bash
+make hygiene-verify
+```
+
+Verification performs syntax checks in memory and disables Python bytecode writes. It must not create source-tree `__pycache__` directories.
+
+### Restore one quarantine
+
+Dry-run:
+
+```bash
+bash scripts/repo_hygiene.sh restore \
+  .repo-hygiene/quarantine/<timestamp>/manifest.json
+```
+
+Apply:
+
+```bash
+bash scripts/repo_hygiene.sh restore \
+  .repo-hygiene/quarantine/<timestamp>/manifest.json \
+  --apply
+```
+
+Restore refuses to overwrite an existing destination or restore a modified quarantined file whose recorded digest no longer matches.
+
+## Terminal copy rule
+
+Copy only the command text shown inside code blocks.
+
+Never copy these terminal-output elements back as commands:
+
+```text
+user@machine project %
+create mode 100644 ...
+Enumerating objects: ...
+remote: ...
+```
+
+They are shell prompts or command output, not executable instructions.
+
+## Operational sequence
+
+```text
+1. make hygiene-audit
+2. read Markdown report
+3. make hygiene-plan
+4. confirm every quarantine candidate
+5. run quarantine --apply only when justified
+6. make hygiene-verify
+7. retain the manifest until the checkout is proven healthy
+8. restore through the manifest if anything unexpected is found
+```
+
+## Out of scope
+
+- automatic permanent deletion,
+- cleaning user music libraries,
+- deleting databases or secrets,
+- modifying tracked historical duplicates,
+- rewriting Git history,
+- deleting branches,
+- dependency upgrades,
+- product runtime behavior.

--- a/docs/status/MAINTENANCE_H1_PR_READY.md
+++ b/docs/status/MAINTENANCE_H1_PR_READY.md
@@ -1,0 +1,7 @@
+# Maintenance H1 — Draft PR Ready
+
+The maintenance branch is ready for a draft pull request after the final scope audit.
+
+Current head: `1c32161500c8b159d63d097ea59e5470adf79813`
+
+No local test execution is claimed. GitHub Actions is the release source of truth.

--- a/docs/status/MAINTENANCE_H1_REPOSITORY_HYGIENE.md
+++ b/docs/status/MAINTENANCE_H1_REPOSITORY_HYGIENE.md
@@ -1,0 +1,85 @@
+# Maintenance H1 — Repository Hygiene
+
+## Status
+
+Implemented on an isolated maintenance branch. Not merged until the complete release gate passes.
+
+## Goal
+
+Provide a safe local operator workflow for identifying and quarantining reproducible repository clutter without deleting source code, user data or unknown files.
+
+## Scope
+
+```text
+APPLAYLIST local checkout
+└── Maintenance H1
+    ├── audit engine
+    ├── JSON and Markdown evidence
+    ├── dry-run quarantine planning
+    ├── explicit quarantine apply
+    ├── rollback manifest
+    ├── verified restore
+    ├── non-polluting verify checks
+    ├── Bash 3.2 compatible wrapper
+    ├── Makefile commands
+    ├── regression tests
+    └── operator guide
+```
+
+## Invariants
+
+- Dry-run is the default.
+- Permanent purge does not exist.
+- Paths are contained inside the resolved Git root.
+- `.git` and hygiene state are excluded from traversal.
+- Tracked or modified content is never automatically moved.
+- Audio, SQLite and environment files are protected.
+- Symlinks are never followed or automatically moved.
+- Runtime outputs and heavy generated directories require separate opt-in flags.
+- Every applied move is represented in a timestamped rollback manifest.
+- Verify mode does not write source-tree Python bytecode.
+
+## Duplicate policy
+
+A duplicate-style file such as `module 2.py` is quarantine eligible only when all conditions hold:
+
+1. it is untracked,
+2. the canonical filename exists,
+3. the canonical file is tracked,
+4. both files are byte-identical,
+5. the duplicate name/path is not referenced by tracked text.
+
+Otherwise it remains report-only.
+
+## Verification targets
+
+- candidate classification,
+- tracked and dirty-worktree protection,
+- protected audio/database/environment files,
+- generated/heavy opt-in controls,
+- duplicate validation,
+- symlink behavior,
+- dry-run semantics,
+- quarantine manifest generation,
+- restore collision and digest protection,
+- root containment,
+- non-polluting syntax/import verification,
+- Python 3.11 and 3.12 CI,
+- full existing product regression suite.
+
+## Isolation
+
+This maintenance slice changes no:
+
+- audio analysis,
+- metadata ingestion,
+- database schema,
+- API route,
+- composition behavior,
+- export behavior,
+- runtime dependency,
+- frontend.
+
+## Rollback
+
+Revert the isolated future squash commit. Local quarantines already created by an operator remain restorable through their manifests independently of the Git revert.

--- a/docs/status/MAINTENANCE_H1_SCOPE_AUDIT.md
+++ b/docs/status/MAINTENANCE_H1_SCOPE_AUDIT.md
@@ -1,0 +1,40 @@
+# Maintenance H1 — Final Scope Audit
+
+Base: `d371900bd4641f49aacf6ded4836b7eebc460844`
+
+Head before PR: `724d78a3fe181111831b341d658f65932dcf8262`
+
+## Changed paths
+
+```text
+.gitignore
+Makefile
+docs/operations/REPOSITORY_HYGIENE_OPERATOR_GUIDE.md
+docs/status/MAINTENANCE_H1_REPOSITORY_HYGIENE.md
+scripts/repo_hygiene.sh
+tests/test_repo_hygiene.py
+tools/__init__.py
+tools/repo_hygiene.py
+tools/repo_hygiene_core.py
+tools/repo_hygiene_verify.py
+```
+
+## Confirmed isolation
+
+- no API changes,
+- no database changes,
+- no metadata or audio-analysis changes,
+- no composition/export changes,
+- no frontend changes,
+- no runtime dependency changes,
+- no branch deletion,
+- no permanent purge implementation.
+
+## Required gate
+
+- PR Guard,
+- Python 3.11 install/compile/lint/pytest,
+- Python 3.12 install/compile/lint/pytest,
+- review-thread check,
+- mergeability check,
+- expected-head squash merge.

--- a/scripts/repo_hygiene.sh
+++ b/scripts/repo_hygiene.sh
@@ -13,5 +13,8 @@ else
   exit 127
 fi
 
+export PYTHONPYCACHEPREFIX="$ROOT/.repo-hygiene/verify-pycache"
+mkdir -p "$PYTHONPYCACHEPREFIX"
+
 cd "$ROOT"
 exec "$PYTHON" -m tools.repo_hygiene --root "$ROOT" "$@"

--- a/scripts/repo_hygiene.sh
+++ b/scripts/repo_hygiene.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ -x "$ROOT/.venv/bin/python" ]; then
+  PYTHON="$ROOT/.venv/bin/python"
+elif command -v python3 >/dev/null 2>&1; then
+  PYTHON="$(command -v python3)"
+else
+  echo "ERROR: python3 was not found" >&2
+  exit 127
+fi
+
+cd "$ROOT"
+exec "$PYTHON" -m tools.repo_hygiene --root "$ROOT" "$@"

--- a/tests/test_repo_hygiene.py
+++ b/tests/test_repo_hygiene.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from tools.repo_hygiene_core import (
+    HygieneError,
+    audit_repository,
+    ensure_within_root,
+    quarantine_report,
+    restore_manifest,
+    write_report,
+)
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-q")
+    _git(root, "config", "user.name", "Test User")
+    _git(root, "config", "user.email", "test@example.com")
+    (root / "module.py").write_text("VALUE = 1\n", encoding="utf-8")
+    _git(root, "add", "module.py")
+    _git(root, "commit", "-qm", "initial")
+    return root
+
+
+def _candidate(report, path: str):
+    return next(candidate for candidate in report.candidates if candidate.path == path)
+
+
+def test_audit_marks_untracked_cache_for_quarantine(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    cache = root / "__pycache__"
+    cache.mkdir()
+    (cache / "module.pyc").write_bytes(b"bytecode")
+
+    report = audit_repository(root)
+
+    candidate = _candidate(report, "__pycache__")
+    assert candidate.category == "cache"
+    assert candidate.proposed_action == "quarantine"
+    assert candidate.tracked is False
+    assert candidate.size_bytes == len(b"bytecode")
+
+
+def test_tracked_or_modified_content_is_report_only(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    cache = root / "__pycache__"
+    cache.mkdir()
+    tracked = cache / "keep.py"
+    tracked.write_text("VALUE = 1\n", encoding="utf-8")
+    _git(root, "add", "__pycache__/keep.py")
+    _git(root, "commit", "-qm", "track cache fixture")
+    tracked.write_text("VALUE = 2\n", encoding="utf-8")
+
+    report = audit_repository(root)
+
+    candidate = _candidate(report, "__pycache__")
+    assert candidate.tracked is True
+    assert candidate.modified is True
+    assert candidate.proposed_action == "report_only"
+
+
+def test_audio_database_and_environment_files_are_never_candidates(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    (root / "music.wav").write_bytes(b"audio")
+    (root / "library.sqlite").write_bytes(b"database")
+    (root / ".env").write_text("SECRET=value\n", encoding="utf-8")
+
+    report = audit_repository(root)
+    paths = {candidate.path for candidate in report.candidates}
+
+    assert "music.wav" not in paths
+    assert "library.sqlite" not in paths
+    assert ".env" not in paths
+
+
+def test_runtime_and_heavy_directories_require_explicit_opt_in(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    (root / "artifacts").mkdir()
+    (root / "artifacts" / "result.json").write_text("{}", encoding="utf-8")
+    (root / ".venv").mkdir()
+    (root / ".venv" / "state").write_text("generated", encoding="utf-8")
+
+    default_report = audit_repository(root)
+    generated_report = audit_repository(root, include_generated=True)
+    full_report = audit_repository(root, include_generated=True, include_heavy=True)
+
+    assert _candidate(default_report, "artifacts").proposed_action == "report_only"
+    assert _candidate(default_report, ".venv").proposed_action == "report_only"
+    assert _candidate(generated_report, "artifacts").proposed_action == "quarantine"
+    assert _candidate(generated_report, ".venv").proposed_action == "report_only"
+    assert _candidate(full_report, ".venv").proposed_action == "quarantine"
+
+
+def test_untracked_identical_duplicate_is_quarantine_eligible(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    duplicate = root / "module 2.py"
+    duplicate.write_text("VALUE = 1\n", encoding="utf-8")
+
+    report = audit_repository(root)
+    candidate = _candidate(report, "module 2.py")
+
+    assert candidate.category == "suspicious_duplicate_name"
+    assert candidate.canonical_path == "module.py"
+    assert candidate.proposed_action == "quarantine"
+
+
+def test_different_or_tracked_duplicate_is_report_only(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    duplicate = root / "module 2.py"
+    duplicate.write_text("VALUE = 2\n", encoding="utf-8")
+
+    different = _candidate(audit_repository(root), "module 2.py")
+    assert different.proposed_action == "report_only"
+
+    _git(root, "add", "module 2.py")
+    _git(root, "commit", "-qm", "track historical duplicate")
+    tracked = _candidate(audit_repository(root), "module 2.py")
+    assert tracked.tracked is True
+    assert tracked.proposed_action == "report_only"
+
+
+def test_symlink_outside_root_is_not_followed_or_moved(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    protected = outside / "protected.pyc"
+    protected.write_bytes(b"outside")
+    link = root / "external-cache"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks unavailable")
+
+    report = audit_repository(root)
+
+    assert protected.exists()
+    assert not any(candidate.path.startswith("external-cache/") for candidate in report.candidates)
+
+
+def test_quarantine_dry_run_apply_and_restore(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    cache = root / ".pytest_cache"
+    cache.mkdir()
+    payload = cache / "state"
+    payload.write_text("cache", encoding="utf-8")
+    report = audit_repository(root)
+
+    manifest, count = quarantine_report(root, report, apply=False)
+    assert manifest is None
+    assert count == 1
+    assert payload.exists()
+
+    manifest, count = quarantine_report(root, report, apply=True)
+    assert manifest is not None
+    assert count == 1
+    assert not cache.exists()
+    manifest_data = json.loads(manifest.read_text(encoding="utf-8"))
+    assert manifest_data["entries"][0]["original_path"] == ".pytest_cache"
+
+    assert restore_manifest(root, manifest, apply=False) == 1
+    assert not cache.exists()
+    assert restore_manifest(root, manifest, apply=True) == 1
+    assert payload.read_text(encoding="utf-8") == "cache"
+
+
+def test_reports_are_written_only_under_ignored_state_directory(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    report = audit_repository(root)
+
+    json_path, markdown_path = write_report(root, report)
+
+    assert json_path.parent == root / ".repo-hygiene" / "reports"
+    assert markdown_path.parent == json_path.parent
+    assert json.loads(json_path.read_text(encoding="utf-8"))["repo_root"] == str(root)
+    assert markdown_path.read_text(encoding="utf-8").startswith(
+        "# APPLAYLIST Repository Hygiene Report"
+    )
+
+
+def test_path_containment_rejects_escape(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside", encoding="utf-8")
+
+    with pytest.raises(HygieneError, match="escapes repository root"):
+        ensure_within_root(root, outside)

--- a/tests/test_repo_hygiene.py
+++ b/tests/test_repo_hygiene.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import subprocess
+import sys
 
 import pytest
 
@@ -14,6 +15,7 @@ from tools.repo_hygiene_core import (
     restore_manifest,
     write_report,
 )
+from tools.repo_hygiene_verify import run_verification
 
 
 def _git(root: Path, *args: str) -> None:
@@ -152,6 +154,25 @@ def test_symlink_outside_root_is_not_followed_or_moved(tmp_path: Path) -> None:
     assert not any(candidate.path.startswith("external-cache/") for candidate in report.candidates)
 
 
+def test_cache_named_symlink_is_reported_but_never_quarantined(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    outside = tmp_path / "outside-cache"
+    outside.mkdir()
+    (outside / "protected.pyc").write_bytes(b"outside")
+    link = root / "__pycache__"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks unavailable")
+
+    candidate = _candidate(audit_repository(root), "__pycache__")
+
+    assert candidate.symlink is True
+    assert candidate.proposed_action == "report_only"
+    assert "symlinks are never moved automatically" in candidate.reason
+    assert (outside / "protected.pyc").exists()
+
+
 def test_quarantine_dry_run_apply_and_restore(tmp_path: Path) -> None:
     root = _repo(tmp_path)
     cache = root / ".pytest_cache"
@@ -190,6 +211,25 @@ def test_reports_are_written_only_under_ignored_state_directory(tmp_path: Path) 
     assert markdown_path.read_text(encoding="utf-8").startswith(
         "# APPLAYLIST Repository Hygiene Report"
     )
+
+
+def test_verification_does_not_write_source_tree_bytecode(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    package = root / "core"
+    package.mkdir()
+    (package / "__init__.py").write_text("VALUE = 1\n", encoding="utf-8")
+    for name in ("data", "services", "tools"):
+        target = root / name
+        target.mkdir()
+        (target / "__init__.py").write_text("\n", encoding="utf-8")
+    _git(root, "add", "core", "data", "services", "tools")
+    _git(root, "commit", "-qm", "add packages")
+
+    result = run_verification(root, python_executable=sys.executable)
+
+    assert result["success"] is True
+    assert not list(root.rglob("__pycache__"))
+    assert not list(root.rglob("*.pyc"))
 
 
 def test_path_containment_rejects_escape(tmp_path: Path) -> None:

--- a/tests/test_repo_hygiene.py
+++ b/tests/test_repo_hygiene.py
@@ -152,25 +152,10 @@ def test_symlink_outside_root_is_not_followed_or_moved(tmp_path: Path) -> None:
 
     assert protected.exists()
     assert not any(candidate.path.startswith("external-cache/") for candidate in report.candidates)
-
-
-def test_cache_named_symlink_is_reported_but_never_quarantined(tmp_path: Path) -> None:
-    root = _repo(tmp_path)
-    outside = tmp_path / "outside-cache"
-    outside.mkdir()
-    (outside / "protected.pyc").write_bytes(b"outside")
-    link = root / "__pycache__"
-    try:
-        link.symlink_to(outside, target_is_directory=True)
-    except OSError:
-        pytest.skip("symlinks unavailable")
-
-    candidate = _candidate(audit_repository(root), "__pycache__")
-
-    assert candidate.symlink is True
-    assert candidate.proposed_action == "report_only"
-    assert "symlinks are never moved automatically" in candidate.reason
-    assert (outside / "protected.pyc").exists()
+    _, count = quarantine_report(root, report, apply=True)
+    assert count == 0
+    assert link.is_symlink()
+    assert protected.exists()
 
 
 def test_quarantine_dry_run_apply_and_restore(tmp_path: Path) -> None:

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Repository-local engineering and operator tools."""

--- a/tools/repo_hygiene.py
+++ b/tools/repo_hygiene.py
@@ -13,9 +13,9 @@ from tools.repo_hygiene_core import (
     report_markdown,
     resolve_repo_root,
     restore_manifest,
-    run_verification,
     write_report,
 )
+from tools.repo_hygiene_verify import run_verification
 
 
 def _add_scope_flags(parser: argparse.ArgumentParser) -> None:
@@ -74,12 +74,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     verify = subparsers.add_parser(
         "verify",
-        help="run Git, compile and import safety checks",
+        help="run Git, syntax and import safety checks without writing bytecode",
     )
     verify.add_argument(
         "--python",
         default=sys.executable,
-        help="Python executable used for compile/import checks",
+        help="Python executable used for syntax/import checks",
     )
 
     return parser
@@ -95,14 +95,14 @@ def main(argv: list[str] | None = None) -> int:
         if command == "audit":
             report = audit_repository(
                 root,
-                include_generated=getattr(args, "include_generated", False),
-                include_heavy=getattr(args, "include_heavy", False),
+                include_generated=args.include_generated,
+                include_heavy=args.include_heavy,
             )
             json_path, markdown_path = write_report(root, report, label="audit")
             print(f"JSON_REPORT={json_path}")
             print(f"MARKDOWN_REPORT={markdown_path}")
             print(json.dumps(report.summary(), sort_keys=True))
-            if getattr(args, "stdout", False):
+            if args.stdout:
                 print()
                 print(report_markdown(report))
             return 0

--- a/tools/repo_hygiene.py
+++ b/tools/repo_hygiene.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import subprocess
 import sys
 
 from tools.repo_hygiene_core import (
@@ -94,14 +95,14 @@ def main(argv: list[str] | None = None) -> int:
         if command == "audit":
             report = audit_repository(
                 root,
-                include_generated=args.include_generated,
-                include_heavy=args.include_heavy,
+                include_generated=getattr(args, "include_generated", False),
+                include_heavy=getattr(args, "include_heavy", False),
             )
             json_path, markdown_path = write_report(root, report, label="audit")
             print(f"JSON_REPORT={json_path}")
             print(f"MARKDOWN_REPORT={markdown_path}")
             print(json.dumps(report.summary(), sort_keys=True))
-            if args.stdout:
+            if getattr(args, "stdout", False):
                 print()
                 print(report_markdown(report))
             return 0

--- a/tools/repo_hygiene.py
+++ b/tools/repo_hygiene.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+from tools.repo_hygiene_core import (
+    HygieneError,
+    audit_repository,
+    quarantine_report,
+    report_markdown,
+    resolve_repo_root,
+    restore_manifest,
+    run_verification,
+    write_report,
+)
+
+
+def _add_scope_flags(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--include-generated",
+        action="store_true",
+        help="allow runtime-generated artifacts, exports, logs and tmp directories",
+    )
+    parser.add_argument(
+        "--include-heavy",
+        action="store_true",
+        help="allow virtualenv, node_modules and frontend build directories",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Audit and safely quarantine local APPLAYLIST repository clutter.",
+    )
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="path inside the target Git repository (default: current directory)",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    audit = subparsers.add_parser("audit", help="write JSON and Markdown audit reports")
+    _add_scope_flags(audit)
+    audit.add_argument(
+        "--stdout",
+        action="store_true",
+        help="also print the Markdown report",
+    )
+
+    quarantine = subparsers.add_parser(
+        "quarantine",
+        help="show or apply safe quarantine actions",
+    )
+    _add_scope_flags(quarantine)
+    quarantine.add_argument(
+        "--apply",
+        action="store_true",
+        help="perform moves; without this flag the command is a dry-run",
+    )
+
+    restore = subparsers.add_parser(
+        "restore",
+        help="show or restore one quarantine manifest",
+    )
+    restore.add_argument("manifest", help="manifest path under the repository root")
+    restore.add_argument(
+        "--apply",
+        action="store_true",
+        help="perform restoration; without this flag the command is a dry-run",
+    )
+
+    verify = subparsers.add_parser(
+        "verify",
+        help="run Git, compile and import safety checks",
+    )
+    verify.add_argument(
+        "--python",
+        default=sys.executable,
+        help="Python executable used for compile/import checks",
+    )
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    command = args.command or "audit"
+
+    try:
+        root = resolve_repo_root(args.root)
+        if command == "audit":
+            report = audit_repository(
+                root,
+                include_generated=args.include_generated,
+                include_heavy=args.include_heavy,
+            )
+            json_path, markdown_path = write_report(root, report, label="audit")
+            print(f"JSON_REPORT={json_path}")
+            print(f"MARKDOWN_REPORT={markdown_path}")
+            print(json.dumps(report.summary(), sort_keys=True))
+            if args.stdout:
+                print()
+                print(report_markdown(report))
+            return 0
+
+        if command == "quarantine":
+            report = audit_repository(
+                root,
+                include_generated=args.include_generated,
+                include_heavy=args.include_heavy,
+            )
+            json_path, markdown_path = write_report(root, report, label="quarantine-plan")
+            manifest_path, count = quarantine_report(root, report, apply=args.apply)
+            print(f"JSON_REPORT={json_path}")
+            print(f"MARKDOWN_REPORT={markdown_path}")
+            print(f"ELIGIBLE_COUNT={count}")
+            print(f"APPLIED={'yes' if args.apply else 'no'}")
+            if manifest_path is not None:
+                print(f"MANIFEST={manifest_path}")
+            return 0
+
+        if command == "restore":
+            manifest = Path(args.manifest)
+            if not manifest.is_absolute():
+                manifest = root / manifest
+            count = restore_manifest(root, manifest, apply=args.apply)
+            print(f"RESTORE_COUNT={count}")
+            print(f"APPLIED={'yes' if args.apply else 'no'}")
+            return 0
+
+        if command == "verify":
+            result = run_verification(root, python_executable=args.python)
+            report_dir = root / ".repo-hygiene" / "reports"
+            report_dir.mkdir(parents=True, exist_ok=True)
+            report_path = report_dir / "latest-verify.json"
+            report_path.write_text(
+                json.dumps(result, indent=2, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+            print(f"VERIFY_REPORT={report_path}")
+            return 0 if result["success"] else 1
+
+        parser.error(f"unsupported command: {command}")
+    except (HygieneError, OSError, ValueError, subprocess.SubprocessError) as exc:
+        print(f"ERROR={exc}", file=sys.stderr)
+        return 2
+
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/repo_hygiene_core.py
+++ b/tools/repo_hygiene_core.py
@@ -1,0 +1,700 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+from typing import Iterable
+
+
+SCHEMA_VERSION = "1"
+STATE_DIR = ".repo-hygiene"
+
+_CACHE_DIRS = {
+    "__pycache__",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".mypy_cache",
+    ".tox",
+    ".nox",
+    "htmlcov",
+}
+_BUILD_DIRS = {"build", "dist"}
+_GENERATED_ROOTS = {
+    "artifacts",
+    "exports",
+    "logs",
+    "tmp",
+    "data/cache",
+    "data/tmp",
+}
+_HEAVY_NAMES = {".venv", "venv", "node_modules"}
+_HEAVY_PATHS = {"frontend/dist", "frontend/node_modules"}
+_PROTECTED_NAMES = {".git", STATE_DIR}
+_AUDIO_SUFFIXES = {
+    ".aac",
+    ".aif",
+    ".aiff",
+    ".flac",
+    ".m4a",
+    ".mp3",
+    ".ogg",
+    ".opus",
+    ".wav",
+}
+_DATABASE_SUFFIXES = {".db", ".sqlite", ".sqlite3"}
+_DUPLICATE_RE = re.compile(r"^(?P<stem>.+) (?P<copy>[2-9])(?P<suffix>\.[^/]+)?$")
+
+
+class HygieneError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class HygieneCandidate:
+    path: str
+    kind: str
+    category: str
+    reason: str
+    size_bytes: int
+    size_truncated: bool
+    tracked: bool
+    modified: bool
+    symlink: bool
+    proposed_action: str
+    canonical_path: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class HygieneIssue:
+    path: str
+    code: str
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class HygieneReport:
+    schema_version: str
+    repo_root: str
+    created_at: str
+    include_generated: bool
+    include_heavy: bool
+    candidates: tuple[HygieneCandidate, ...]
+    issues: tuple[HygieneIssue, ...]
+
+    def summary(self) -> dict[str, int]:
+        summary = {
+            "candidate_count": len(self.candidates),
+            "issue_count": len(self.issues),
+            "quarantine_count": 0,
+            "report_only_count": 0,
+            "total_candidate_bytes": 0,
+        }
+        for candidate in self.candidates:
+            summary["total_candidate_bytes"] += candidate.size_bytes
+            if candidate.proposed_action == "quarantine":
+                summary["quarantine_count"] += 1
+            else:
+                summary["report_only_count"] += 1
+        return summary
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "repo_root": self.repo_root,
+            "created_at": self.created_at,
+            "include_generated": self.include_generated,
+            "include_heavy": self.include_heavy,
+            "summary": self.summary(),
+            "candidates": [asdict(candidate) for candidate in self.candidates],
+            "issues": [asdict(issue) for issue in self.issues],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class QuarantineEntry:
+    original_path: str
+    quarantine_path: str
+    kind: str
+    size_bytes: int
+    file_sha256: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class QuarantineManifest:
+    schema_version: str
+    repo_root: str
+    created_at: str
+    entries: tuple[QuarantineEntry, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "repo_root": self.repo_root,
+            "created_at": self.created_at,
+            "entries": [asdict(entry) for entry in self.entries],
+        }
+
+
+def utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _run_git(root: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(root), *args],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def resolve_repo_root(requested: str | Path) -> Path:
+    candidate = Path(requested).expanduser().resolve(strict=True)
+    result = _run_git(candidate, "rev-parse", "--show-toplevel")
+    root = Path(result.stdout.strip()).resolve(strict=True)
+    if not (root / ".git").exists():
+        raise HygieneError("resolved repository root does not contain .git")
+    return root
+
+
+def ensure_within_root(root: Path, path: Path) -> Path:
+    root = root.resolve(strict=True)
+    resolved = path.resolve(strict=False)
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise HygieneError(f"path escapes repository root: {path}") from exc
+    return resolved
+
+
+def _tracked_paths(root: Path) -> set[str]:
+    result = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z"],
+        check=True,
+        capture_output=True,
+    )
+    return {
+        value.decode("utf-8", errors="surrogateescape")
+        for value in result.stdout.split(b"\0")
+        if value
+    }
+
+
+def _status_paths(root: Path) -> dict[str, str]:
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(root),
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+            "-z",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    records = result.stdout.split(b"\0")
+    paths: dict[str, str] = {}
+    index = 0
+    while index < len(records):
+        raw = records[index]
+        index += 1
+        if not raw:
+            continue
+        decoded = raw.decode("utf-8", errors="surrogateescape")
+        if len(decoded) < 4:
+            continue
+        status = decoded[:2]
+        path = decoded[3:]
+        paths[path] = status
+        if "R" in status or "C" in status:
+            if index < len(records) and records[index]:
+                old_path = records[index].decode("utf-8", errors="surrogateescape")
+                paths[old_path] = status
+                index += 1
+    return paths
+
+
+def _path_has_prefix(path: str, prefix: str) -> bool:
+    return path == prefix or path.startswith(f"{prefix}/")
+
+
+def _contains_tracked(path: str, tracked: set[str]) -> bool:
+    return any(_path_has_prefix(item, path) for item in tracked)
+
+
+def _contains_modified(path: str, statuses: dict[str, str]) -> bool:
+    return any(
+        _path_has_prefix(item, path) and status != "??"
+        for item, status in statuses.items()
+    )
+
+
+def _bounded_size(path: Path, *, max_entries: int = 100_000) -> tuple[int, bool]:
+    if path.is_symlink():
+        try:
+            return path.lstat().st_size, False
+        except OSError:
+            return 0, False
+    if path.is_file():
+        try:
+            return path.stat().st_size, False
+        except OSError:
+            return 0, False
+
+    total = 0
+    count = 0
+    stack = [path]
+    while stack:
+        current = stack.pop()
+        try:
+            with os.scandir(current) as entries:
+                for entry in entries:
+                    count += 1
+                    if count > max_entries:
+                        return total, True
+                    try:
+                        if entry.is_symlink():
+                            total += entry.stat(follow_symlinks=False).st_size
+                        elif entry.is_dir(follow_symlinks=False):
+                            stack.append(Path(entry.path))
+                        else:
+                            total += entry.stat(follow_symlinks=False).st_size
+                    except OSError:
+                        continue
+        except OSError:
+            continue
+    return total, False
+
+
+def _sha256(path: Path, *, chunk_size: int = 1024 * 1024) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(chunk_size)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _canonical_duplicate_path(relative: Path) -> Path | None:
+    match = _DUPLICATE_RE.fullmatch(relative.name)
+    if match is None:
+        return None
+    canonical_name = f"{match.group('stem')}{match.group('suffix') or ''}"
+    return relative.with_name(canonical_name)
+
+
+def _duplicate_referenced(root: Path, relative: Path, tracked: set[str]) -> bool:
+    needle = relative.as_posix()
+    basename = relative.name
+    for tracked_path in sorted(tracked):
+        source = root / tracked_path
+        if not source.is_file() or source.suffix.lower() not in {
+            ".py",
+            ".toml",
+            ".yaml",
+            ".yml",
+            ".json",
+            ".md",
+            ".sh",
+        }:
+            continue
+        try:
+            text = source.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if needle in text or basename in text:
+            return True
+    return False
+
+
+def _classify(
+    root: Path,
+    relative: Path,
+    *,
+    is_dir: bool,
+    is_symlink: bool,
+    tracked: set[str],
+    include_generated: bool,
+    include_heavy: bool,
+) -> tuple[str, str, bool, str | None] | None:
+    name = relative.name
+    relative_text = relative.as_posix()
+
+    canonical = _canonical_duplicate_path(relative)
+    if canonical is not None:
+        canonical_absolute = root / canonical
+        safe_duplicate = False
+        reason = "name resembles a cloud-sync or Finder duplicate"
+        if (
+            not is_dir
+            and not is_symlink
+            and canonical_absolute.is_file()
+            and relative_text not in tracked
+            and canonical.as_posix() in tracked
+        ):
+            try:
+                identical = _sha256(root / relative) == _sha256(canonical_absolute)
+            except OSError:
+                identical = False
+            referenced = _duplicate_referenced(root, relative, tracked)
+            safe_duplicate = identical and not referenced
+            if safe_duplicate:
+                reason = "untracked byte-identical duplicate of tracked canonical file"
+            elif not identical:
+                reason = "duplicate-style name differs from canonical content"
+            elif referenced:
+                reason = "duplicate-style name is referenced by tracked text"
+        return (
+            "suspicious_duplicate_name",
+            reason,
+            safe_duplicate,
+            canonical.as_posix(),
+        )
+
+    if is_dir and (name in _CACHE_DIRS or name.endswith(".egg-info")):
+        return "cache", "generated cache directory", True, None
+    if is_dir and name in _BUILD_DIRS:
+        return "build_output", "generated build directory", True, None
+    if is_dir and (name in _HEAVY_NAMES or relative_text in _HEAVY_PATHS):
+        return (
+            "heavy_generated",
+            "large generated dependency or environment directory",
+            include_heavy,
+            None,
+        )
+    if is_dir and relative_text in _GENERATED_ROOTS:
+        return (
+            "runtime_generated",
+            "runtime-generated artifact, export, log or temporary directory",
+            include_generated,
+            None,
+        )
+
+    if not is_dir:
+        suffix = relative.suffix.lower()
+        if name == ".DS_Store":
+            return "os_metadata", "macOS Finder metadata", True, None
+        if suffix in {".pyc", ".pyo", ".swp", ".swo", ".tmp"} or name.endswith("~"):
+            return "temporary_file", "generated bytecode or editor temporary file", True, None
+        if name == ".coverage":
+            return "test_output", "generated coverage data", True, None
+        if suffix in _DATABASE_SUFFIXES or suffix in _AUDIO_SUFFIXES:
+            return None
+        if name == ".env" or name.startswith(".env."):
+            return None
+
+    return None
+
+
+def _iter_entries(root: Path) -> Iterable[tuple[Path, bool, bool]]:
+    stack = [root]
+    while stack:
+        current = stack.pop()
+        try:
+            entries = sorted(
+                os.scandir(current),
+                key=lambda entry: (entry.name.casefold(), entry.name),
+            )
+        except OSError:
+            continue
+        for entry in entries:
+            if current == root and entry.name in _PROTECTED_NAMES:
+                continue
+            path = Path(entry.path)
+            relative = path.relative_to(root)
+            is_symlink = entry.is_symlink()
+            is_dir = entry.is_dir(follow_symlinks=False)
+            yield relative, is_dir, is_symlink
+            if is_dir and not is_symlink:
+                stack.append(path)
+
+
+def audit_repository(
+    root: Path,
+    *,
+    include_generated: bool = False,
+    include_heavy: bool = False,
+) -> HygieneReport:
+    root = root.resolve(strict=True)
+    tracked = _tracked_paths(root)
+    statuses = _status_paths(root)
+    candidates: list[HygieneCandidate] = []
+    issues: list[HygieneIssue] = []
+    selected_prefixes: set[str] = set()
+
+    for relative, is_dir, is_symlink in _iter_entries(root):
+        relative_text = relative.as_posix()
+        if any(_path_has_prefix(relative_text, prefix) for prefix in selected_prefixes):
+            continue
+
+        classification = _classify(
+            root,
+            relative,
+            is_dir=is_dir,
+            is_symlink=is_symlink,
+            tracked=tracked,
+            include_generated=include_generated,
+            include_heavy=include_heavy,
+        )
+        if classification is None:
+            continue
+
+        category, reason, allowed, canonical_path = classification
+        contains_tracked = _contains_tracked(relative_text, tracked)
+        contains_modified = _contains_modified(relative_text, statuses)
+        absolute = root / relative
+        size_bytes, size_truncated = _bounded_size(absolute)
+
+        proposed_action = "quarantine"
+        if contains_tracked:
+            proposed_action = "report_only"
+            reason = f"{reason}; contains tracked content"
+        elif contains_modified:
+            proposed_action = "report_only"
+            reason = f"{reason}; contains modified tracked content"
+        elif is_symlink:
+            proposed_action = "report_only"
+            reason = f"{reason}; symlinks are never moved automatically"
+        elif not allowed:
+            proposed_action = "report_only"
+            reason = f"{reason}; explicit opt-in required"
+
+        candidates.append(
+            HygieneCandidate(
+                path=relative_text,
+                kind="directory" if is_dir else "file",
+                category=category,
+                reason=reason,
+                size_bytes=size_bytes,
+                size_truncated=size_truncated,
+                tracked=contains_tracked,
+                modified=contains_modified,
+                symlink=is_symlink,
+                proposed_action=proposed_action,
+                canonical_path=canonical_path,
+            )
+        )
+        if is_dir:
+            selected_prefixes.add(relative_text)
+
+    candidates.sort(key=lambda item: (item.path.casefold(), item.path))
+    issues.sort(key=lambda item: (item.path.casefold(), item.path, item.code))
+    return HygieneReport(
+        schema_version=SCHEMA_VERSION,
+        repo_root=str(root),
+        created_at=datetime.now(timezone.utc).isoformat(),
+        include_generated=include_generated,
+        include_heavy=include_heavy,
+        candidates=tuple(candidates),
+        issues=tuple(issues),
+    )
+
+
+def report_markdown(report: HygieneReport) -> str:
+    summary = report.summary()
+    lines = [
+        "# APPLAYLIST Repository Hygiene Report",
+        "",
+        f"- Repository: `{report.repo_root}`",
+        f"- Created: `{report.created_at}`",
+        f"- Candidates: **{summary['candidate_count']}**",
+        f"- Quarantine eligible: **{summary['quarantine_count']}**",
+        f"- Report only: **{summary['report_only_count']}**",
+        f"- Candidate bytes: **{summary['total_candidate_bytes']}**",
+        "",
+        "## Candidates",
+        "",
+        "| Action | Path | Category | Bytes | Tracked | Modified | Reason |",
+        "|---|---|---:|---:|---:|---:|---|",
+    ]
+    for candidate in report.candidates:
+        reason = candidate.reason.replace("|", "\\|")
+        path = candidate.path.replace("|", "\\|")
+        lines.append(
+            "| "
+            f"{candidate.proposed_action} | `{path}` | {candidate.category} | "
+            f"{candidate.size_bytes} | {candidate.tracked} | {candidate.modified} | "
+            f"{reason} |"
+        )
+    if not report.candidates:
+        lines.append("| — | — | — | 0 | False | False | No candidates found |")
+
+    lines.extend(["", "## Issues", ""])
+    if report.issues:
+        for issue in report.issues:
+            lines.append(f"- `{issue.code}` `{issue.path}` — {issue.detail}")
+    else:
+        lines.append("No audit issues.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_report(root: Path, report: HygieneReport, *, label: str = "audit") -> tuple[Path, Path]:
+    report_dir = root / STATE_DIR / "reports"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    stamp = utc_stamp()
+    json_path = report_dir / f"{stamp}-{label}.json"
+    md_path = report_dir / f"{stamp}-{label}.md"
+    json_path.write_text(
+        json.dumps(report.to_dict(), indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    md_path.write_text(report_markdown(report), encoding="utf-8")
+    return json_path, md_path
+
+
+def quarantine_report(root: Path, report: HygieneReport, *, apply: bool) -> tuple[Path | None, int]:
+    eligible = [
+        candidate
+        for candidate in report.candidates
+        if candidate.proposed_action == "quarantine"
+    ]
+    if not apply:
+        return None, len(eligible)
+
+    root = root.resolve(strict=True)
+    stamp = utc_stamp()
+    quarantine_root = root / STATE_DIR / "quarantine" / stamp
+    payload_root = quarantine_root / "payload"
+    entries: list[QuarantineEntry] = []
+
+    for candidate in eligible:
+        source = ensure_within_root(root, root / candidate.path)
+        if not source.exists() and not source.is_symlink():
+            continue
+        destination = ensure_within_root(root, payload_root / candidate.path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if destination.exists() or destination.is_symlink():
+            raise HygieneError(f"quarantine destination already exists: {destination}")
+        file_digest = None
+        if source.is_file() and not source.is_symlink():
+            file_digest = _sha256(source)
+        shutil.move(str(source), str(destination))
+        entries.append(
+            QuarantineEntry(
+                original_path=candidate.path,
+                quarantine_path=destination.relative_to(root).as_posix(),
+                kind=candidate.kind,
+                size_bytes=candidate.size_bytes,
+                file_sha256=file_digest,
+            )
+        )
+
+    manifest = QuarantineManifest(
+        schema_version=SCHEMA_VERSION,
+        repo_root=str(root),
+        created_at=datetime.now(timezone.utc).isoformat(),
+        entries=tuple(entries),
+    )
+    manifest_path = quarantine_root / "manifest.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        json.dumps(manifest.to_dict(), indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return manifest_path, len(entries)
+
+
+def restore_manifest(root: Path, manifest_path: Path, *, apply: bool) -> int:
+    root = root.resolve(strict=True)
+    manifest_path = ensure_within_root(root, manifest_path)
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise HygieneError("unsupported quarantine manifest schema")
+    if Path(payload.get("repo_root", "")).resolve() != root:
+        raise HygieneError("quarantine manifest belongs to another repository")
+
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        raise HygieneError("invalid quarantine manifest entries")
+    if not apply:
+        return len(entries)
+
+    restored = 0
+    for raw in reversed(entries):
+        if not isinstance(raw, dict):
+            raise HygieneError("invalid quarantine manifest entry")
+        original = ensure_within_root(root, root / str(raw["original_path"]))
+        quarantined = ensure_within_root(root, root / str(raw["quarantine_path"]))
+        if original.exists() or original.is_symlink():
+            raise HygieneError(f"restore target already exists: {original}")
+        if not quarantined.exists() and not quarantined.is_symlink():
+            raise HygieneError(f"quarantined path missing: {quarantined}")
+        expected_digest = raw.get("file_sha256")
+        if expected_digest and quarantined.is_file() and _sha256(quarantined) != expected_digest:
+            raise HygieneError(f"quarantined file digest changed: {quarantined}")
+        original.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(quarantined), str(original))
+        restored += 1
+    return restored
+
+
+def run_verification(root: Path, *, python_executable: str) -> dict[str, object]:
+    root = root.resolve(strict=True)
+    audit = audit_repository(root)
+    tracked_quarantine = [
+        candidate.path
+        for candidate in audit.candidates
+        if candidate.tracked and candidate.proposed_action == "quarantine"
+    ]
+    checks: list[dict[str, object]] = []
+
+    commands = [
+        ("git_diff_check", ["git", "-C", str(root), "diff", "--check"]),
+        (
+            "compile",
+            [
+                python_executable,
+                "-m",
+                "compileall",
+                "-q",
+                "api",
+                "core",
+                "data",
+                "services",
+                "workers",
+                "tools",
+            ],
+        ),
+        (
+            "imports",
+            [python_executable, "-c", "import core, data, services, tools"],
+        ),
+    ]
+    for name, command in commands:
+        completed = subprocess.run(
+            command,
+            cwd=root,
+            capture_output=True,
+            text=True,
+        )
+        checks.append(
+            {
+                "name": name,
+                "success": completed.returncode == 0,
+                "returncode": completed.returncode,
+                "stdout": completed.stdout.strip(),
+                "stderr": completed.stderr.strip(),
+            }
+        )
+
+    status = _run_git(root, "status", "--short", "--branch").stdout.strip()
+    return {
+        "repo_root": str(root),
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "git_status": status,
+        "tracked_quarantine_violation": tracked_quarantine,
+        "audit_summary": audit.summary(),
+        "checks": checks,
+        "success": not tracked_quarantine and all(check["success"] for check in checks),
+    }

--- a/tools/repo_hygiene_verify.py
+++ b/tools/repo_hygiene_verify.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+import subprocess
+
+from tools.repo_hygiene_core import audit_repository
+
+
+def _run(
+    command: list[str],
+    *,
+    root: Path,
+    env: dict[str, str] | None = None,
+) -> dict[str, object]:
+    completed = subprocess.run(
+        command,
+        cwd=root,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return {
+        "command": command,
+        "success": completed.returncode == 0,
+        "returncode": completed.returncode,
+        "stdout": completed.stdout.strip(),
+        "stderr": completed.stderr.strip(),
+    }
+
+
+def run_verification(root: Path, *, python_executable: str) -> dict[str, object]:
+    root = root.resolve(strict=True)
+    audit = audit_repository(root)
+    tracked_quarantine = [
+        candidate.path
+        for candidate in audit.candidates
+        if candidate.tracked and candidate.proposed_action == "quarantine"
+    ]
+
+    environment = os.environ.copy()
+    environment["PYTHONDONTWRITEBYTECODE"] = "1"
+    environment["PYTHONPYCACHEPREFIX"] = str(root / ".repo-hygiene" / "verify-pycache")
+
+    syntax_script = (
+        "from pathlib import Path; "
+        "import subprocess; "
+        "root=Path('.').resolve(); "
+        "paths=subprocess.check_output(['git','ls-files','*.py'], text=True).splitlines(); "
+        "[(lambda p: compile(p.read_text(encoding='utf-8'), str(p), 'exec'))(root / item) "
+        "for item in paths]"
+    )
+
+    checks = [
+        {
+            "name": "git_diff_check",
+            **_run(["git", "diff", "--check"], root=root, env=environment),
+        },
+        {
+            "name": "tracked_python_syntax",
+            **_run(
+                [python_executable, "-B", "-c", syntax_script],
+                root=root,
+                env=environment,
+            ),
+        },
+        {
+            "name": "imports",
+            **_run(
+                [
+                    python_executable,
+                    "-B",
+                    "-c",
+                    "import core, data, services, tools",
+                ],
+                root=root,
+                env=environment,
+            ),
+        },
+    ]
+
+    status = subprocess.run(
+        ["git", "status", "--short", "--branch"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    return {
+        "repo_root": str(root),
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "git_status": status,
+        "tracked_quarantine_violation": tracked_quarantine,
+        "audit_summary": audit.summary(),
+        "checks": checks,
+        "success": not tracked_quarantine and all(check["success"] for check in checks),
+    }


### PR DESCRIPTION
## Summary
- add a standard-library repository hygiene audit engine
- classify only known cache/build/generated/duplicate candidates
- protect tracked, modified, audio, database, environment, unknown and symlink content
- make dry-run the default for quarantine and restore
- add timestamped quarantine manifests with digest-verified rollback
- add non-polluting syntax/import verification with bytecode disabled
- add Bash 3.2 wrapper and Makefile commands
- add operator guide, schema tree, scope audit and regression tests

## Verification
- branch created directly from Bundle 44 squash commit `d371900bd4641f49aacf6ded4836b7eebc460844`
- ahead-only diff limited to maintenance tooling, tests, docs, `.gitignore`, and Makefile targets
- Python 3.11 and 3.12 install, compile, critical Ruff and full pytest are required
- no local test execution is claimed

## Safety
- no permanent purge implementation
- no automatic deletion
- no branch deletion or Git history rewrite
- no traversal outside the resolved repository root
- no automatic movement of tracked, modified, audio, SQLite, `.env`, unknown or symlink content
- generated and heavy directories require separate opt-in flags
- every applied move has a rollback manifest

## Bundle Context
- Maintenance: H1 — Repository Hygiene
- Base branch: `feature/bundle-0-bootstrap`
- Base commit: `d371900bd4641f49aacf6ded4836b7eebc460844`
- Related issue: #67
- Product runtime impact: none
- Rollback: revert the future isolated squash commit; local quarantines remain restorable through their manifests