### PR TITLE
Bundle 45: baseline Librosa MIR provider

### DIFF
--- a/core/analysis/provider_contract.py
+++ b/core/analysis/provider_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import re
 from dataclasses import asdict, dataclass
 from typing import Any, Mapping
 
@@ -49,6 +50,15 @@ class CanonicalAnalysisResult:
     genre_hint: str | None
     analysis_status: str = "ok"
     analysis_version: str = "canonical-mir-v1"
+    key_tonic: str | None = None
+    key_scale: str | None = None
+    camelot: str | None = None
+    beat_stability: float | None = None
+    harmonic_ratio: float | None = None
+    percussive_ratio: float | None = None
+    provider_version: str | None = None
+    algorithm_version: str | None = None
+    warnings: tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -111,7 +121,13 @@ def _bounded(
     return value
 
 
-def _optional_text(value: Any, field: str, provider: str) -> str | None:
+def _optional_text(
+    value: Any,
+    field: str,
+    provider: str,
+    *,
+    maximum_length: int = 128,
+) -> str | None:
     if value is None:
         return None
     if not isinstance(value, str):
@@ -122,12 +138,46 @@ def _optional_text(value: Any, field: str, provider: str) -> str | None:
     normalized = value.strip()
     if not normalized:
         return None
-    if len(normalized) > 128:
+    if len(normalized) > maximum_length:
         raise ProviderOutputInvalid(
             f"Provider field '{field}' is too long",
             provider=provider,
         )
     return normalized
+
+
+def _optional_camelot(value: Any, provider: str) -> str | None:
+    normalized = _optional_text(value, "camelot", provider, maximum_length=3)
+    if normalized is None:
+        return None
+    normalized = normalized.upper()
+    if re.fullmatch(r"(?:[1-9]|1[0-2])[AB]", normalized) is None:
+        raise ProviderOutputInvalid(
+            "Provider field 'camelot' must be between 1A and 12B",
+            provider=provider,
+        )
+    return normalized
+
+
+def _warnings(value: Any, provider: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, (list, tuple)):
+        raise ProviderOutputInvalid(
+            "Provider field 'warnings' must be an array",
+            provider=provider,
+        )
+    if len(value) > 32:
+        raise ProviderOutputInvalid(
+            "Provider field 'warnings' contains too many entries",
+            provider=provider,
+        )
+    normalized: list[str] = []
+    for item in value:
+        text = _optional_text(item, "warnings", provider, maximum_length=256)
+        if text is not None and text not in normalized:
+            normalized.append(text)
+    return tuple(normalized)
 
 
 def normalize_provider_result(
@@ -169,6 +219,7 @@ def normalize_provider_result(
     beat = _as_mapping(raw_result.get("beat"), "beat", provider)
     metrics = _as_mapping(raw_result.get("metrics"), "metrics", provider)
     tags = _as_mapping(raw_result.get("tags"), "tags", provider)
+    provenance = _as_mapping(raw_result.get("provenance"), "provenance", provider)
 
     raw_key = raw_result.get("key")
     key_block = _as_mapping(raw_key, "key", provider) if not isinstance(raw_key, str) else {}
@@ -178,15 +229,30 @@ def normalize_provider_result(
         raw_result.get("bpm_confidence"),
         beat.get("confidence"),
     )
+    beat_stability_raw = _first_not_none(
+        raw_result.get("beat_stability"),
+        beat.get("stability"),
+    )
 
     if isinstance(raw_key, Mapping):
-        key_raw = _first_not_none(raw_key.get("camelot"), raw_key.get("key"))
+        key_raw = _first_not_none(
+            raw_key.get("camelot"),
+            raw_key.get("key"),
+            raw_key.get("tonic"),
+        )
     else:
         key_raw = raw_key
     key_confidence_raw = _first_not_none(
         raw_result.get("key_confidence"),
         key_block.get("confidence"),
     )
+    tonic_raw = _first_not_none(raw_result.get("key_tonic"), key_block.get("tonic"))
+    scale_raw = _first_not_none(raw_result.get("key_scale"), key_block.get("scale"))
+    camelot_raw = _first_not_none(raw_result.get("camelot"), key_block.get("camelot"))
+    if camelot_raw is None and isinstance(raw_key, str):
+        candidate = raw_key.strip().upper()
+        if re.fullmatch(r"(?:[1-9]|1[0-2])[AB]", candidate):
+            camelot_raw = candidate
 
     energy_raw = _first_not_none(
         raw_result.get("energy"),
@@ -200,6 +266,14 @@ def normalize_provider_result(
         raw_result.get("duration_seconds"),
         raw_result.get("duration_sec"),
         metrics.get("duration_seconds"),
+    )
+    harmonic_ratio_raw = _first_not_none(
+        raw_result.get("harmonic_ratio"),
+        metrics.get("harmonic_ratio"),
+    )
+    percussive_ratio_raw = _first_not_none(
+        raw_result.get("percussive_ratio"),
+        metrics.get("percussive_ratio"),
     )
     genre_raw = _first_not_none(
         raw_result.get("genre_hint"),
@@ -221,6 +295,13 @@ def normalize_provider_result(
         minimum=0.0,
         maximum=1.0,
     )
+    beat_stability = _bounded(
+        _as_optional_float(beat_stability_raw, "beat_stability", provider),
+        "beat_stability",
+        provider,
+        minimum=0.0,
+        maximum=1.0,
+    )
     key_confidence = _bounded(
         _as_optional_float(key_confidence_raw, "key_confidence", provider),
         "key_confidence",
@@ -231,6 +312,20 @@ def normalize_provider_result(
     energy = _bounded(
         _as_optional_float(energy_raw, "energy", provider),
         "energy",
+        provider,
+        minimum=0.0,
+        maximum=1.0,
+    )
+    harmonic_ratio = _bounded(
+        _as_optional_float(harmonic_ratio_raw, "harmonic_ratio", provider),
+        "harmonic_ratio",
+        provider,
+        minimum=0.0,
+        maximum=1.0,
+    )
+    percussive_ratio = _bounded(
+        _as_optional_float(percussive_ratio_raw, "percussive_ratio", provider),
+        "percussive_ratio",
         provider,
         minimum=0.0,
         maximum=1.0,
@@ -246,15 +341,42 @@ def normalize_provider_result(
             provider=provider,
         )
 
+    camelot = _optional_camelot(camelot_raw, provider)
+    key = _optional_text(key_raw, "key", provider)
+    if camelot is not None:
+        key = camelot
+
     return CanonicalAnalysisResult(
         path=path.strip(),
         provider=provider,
         bpm=bpm,
         bpm_confidence=bpm_confidence,
-        key=_optional_text(key_raw, "key", provider),
+        key=key,
         key_confidence=key_confidence,
         energy=energy,
         loudness_db=_as_optional_float(loudness_raw, "loudness_db", provider),
         duration_seconds=duration_seconds,
         genre_hint=_optional_text(genre_raw, "genre_hint", provider),
+        key_tonic=_optional_text(tonic_raw, "key_tonic", provider, maximum_length=8),
+        key_scale=_optional_text(scale_raw, "key_scale", provider, maximum_length=16),
+        camelot=camelot,
+        beat_stability=beat_stability,
+        harmonic_ratio=harmonic_ratio,
+        percussive_ratio=percussive_ratio,
+        provider_version=_optional_text(
+            _first_not_none(raw_result.get("provider_version"), provenance.get("provider_version")),
+            "provider_version",
+            provider,
+            maximum_length=64,
+        ),
+        algorithm_version=_optional_text(
+            _first_not_none(
+                raw_result.get("algorithm_version"),
+                provenance.get("algorithm_version"),
+            ),
+            "algorithm_version",
+            provider,
+            maximum_length=128,
+        ),
+        warnings=_warnings(raw_result.get("warnings"), provider),
     )

--- a/core/analysis/providers.py
+++ b/core/analysis/providers.py
@@ -6,7 +6,9 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 from core.analysis.provider_contract import (
+    ProviderContractError,
     ProviderDependencyMissingError,
+    ProviderRuntimeFailure,
     ProviderUnavailableError,
     UnknownProviderError,
 )
@@ -49,11 +51,17 @@ class LibrosaAnalyzerProvider(BaseAnalyzerProvider):
         return AnalyzerProviderInfo(name=cls.name, available=True, reason="ok")
 
     def analyze(self, path: str) -> Dict[str, Any]:
-        return {
-            "provider": self.name,
-            "path": path,
-            "status": "stub",
-        }
+        try:
+            from services.analysis.librosa_baseline import BaselineLibrosaMIR
+
+            return BaselineLibrosaMIR().analyze(path)
+        except ProviderContractError:
+            raise
+        except Exception as exc:
+            raise ProviderRuntimeFailure(
+                "Librosa baseline analysis failed",
+                provider=self.name,
+            ) from exc
 
 
 class EssentiaAnalyzerProvider(BaseAnalyzerProvider):

--- a/docs/compliance/APPLAYLIST_LICENSE_DECISION_REGISTER_V1.md
+++ b/docs/compliance/APPLAYLIST_LICENSE_DECISION_REGISTER_V1.md
@@ -24,7 +24,7 @@ This document is an engineering control, not legal advice. Final commercial dist
 | NumPy | numerical baseline | approved_dev | verify binary-wheel notices in packaged app |
 | SciPy | signal-processing baseline | approved_dev | verify binary-wheel notices in packaged app |
 | SoundFile | audio decode boundary | approved_dev | audit bundled native `libsndfile` obligations |
-| Librosa | baseline MIR candidate | approved_dev | benchmark; move behind lazy provider boundary |
+| Librosa | lazy baseline MIR candidate | approved_dev | benchmark quality/runtime; retain provenance; do not approve as production default before Bundle 46 decision gate |
 | TinyTag 2.2.1 | read-only audio metadata | approved_dev | retain MIT notice; verify exact resolved version and packaged SBOM before distribution |
 
 `approved_dev` does not automatically mean approved for a signed commercial installer.
@@ -42,10 +42,21 @@ Product preference is the smallest read-only metadata dependency that satisfies 
 
 | Component | Candidate use | State | Decision notes |
 |---|---|---|---|
+| Librosa + NumPy/SciPy/SoundFile | local baseline BPM/key/energy evaluation | approved_dev | implemented behind lazy provider boundary; no provider-side persistence; confidence and energy remain internal/uncalibrated until benchmark; exact resolved versions and native-library notices required for distribution |
 | Essentia | advanced BPM/key/energy benchmark | experiment_only | commercial distribution requires explicit licensing decision; model licenses must be evaluated individually |
 | Essentia pretrained models | optional ML descriptors | review_required | no model may be downloaded or shipped without per-model license record |
 | madmom | beat/downbeat research | review_required | release age, compatibility and model-data restrictions require review; not an MVP dependency |
 | remote audio-analysis API | analysis provider | rejected for MVP | conflicts with local-first privacy and reproducibility goals unless separately approved |
+
+### Bundle 45 Librosa baseline decision
+
+- approved only for development, CI and controlled local benchmark evaluation,
+- not approved as the production-authoritative provider,
+- no claim of parity with Mixed In Key or another commercial analyzer,
+- provider imports remain lazy so mandatory API/config imports do not load audio backends,
+- analysis stays local and performs no network upload,
+- provider emits dependency and algorithm provenance,
+- the packaged-app decision remains blocked on Bundle 46 quality/runtime evidence and native dependency review.
 
 ## Desktop candidates
 

--- a/docs/status/BUNDLE_45_BASELINE_LIBROSA_MIR_PROVIDER.md
+++ b/docs/status/BUNDLE_45_BASELINE_LIBROSA_MIR_PROVIDER.md
@@ -1,0 +1,175 @@
+# Bundle 45 — Baseline Librosa MIR Provider
+
+## Status
+
+Implemented on an isolated feature branch. Not yet merged or production-authoritative.
+
+## Product Goal
+
+Replace the Librosa stub with a real local baseline analyzer that produces versioned BPM, key/Camelot, energy and confidence evidence suitable for Bundle 46 benchmarking.
+
+This bundle proves a working analysis path. It does not prove commercial-analyzer parity or production accuracy.
+
+## Schema Tree
+
+```text
+APPLAYLIST
+└── Track intelligence
+    ├── RoutedAnalysisService
+    │   ├── provider selection
+    │   ├── controlled provider failure mapping
+    │   └── canonical result normalization
+    │
+    └── LibrosaAnalyzerProvider
+        ├── lazy BaselineLibrosaMIR import
+        ├── no database write
+        └── BaselineLibrosaMIR
+            ├── absolute regular-file validation
+            ├── local mono decode @ 22 050 Hz
+            ├── finite/duration/silence guards
+            ├── harmonic-percussive separation
+            ├── onset envelope + beat tracking
+            ├── BPM
+            ├── beat stability
+            ├── internal BPM confidence
+            ├── CQT chroma
+            │   └── STFT fallback with warning
+            ├── 24 tonic/mode profile scoring
+            ├── tonic + scale + Camelot
+            ├── internal tonal confidence
+            ├── RMS dBFS
+            ├── harmonic/percussive ratios
+            ├── relative energy components
+            ├── provider + algorithm provenance
+            └── warnings
+                ↓
+        normalize_provider_result
+                ↓
+        CanonicalAnalysisResult
+```
+
+## Runtime Flow
+
+```text
+absolute local audio path
+  → explicit provider selection
+  → lazy Librosa import
+  → local decode
+  → deterministic feature extraction
+  → raw provider evidence
+  → fail-closed canonical normalization
+  → CanonicalAnalysisResult
+```
+
+No API route, worker, database repository or composition authority is switched to this provider by Bundle 45.
+
+## Canonical Evidence
+
+The canonical result preserves current compatibility and adds explicit evidence:
+
+```text
+key                 existing composition-compatible value
+key_tonic           tonic, for example C
+key_scale           major or minor
+camelot             for example 8B
+key_confidence      bounded internal tonal confidence
+bpm                 estimated tempo
+bpm_confidence      bounded internal beat confidence
+beat_stability      interval-consistency evidence
+energy              provider-relative 0..1 score
+loudness_db         RMS dBFS evidence
+harmonic_ratio      normalized harmonic power share
+percussive_ratio    normalized percussive power share
+provider_version    resolved Librosa version
+algorithm_version   baseline-librosa-mir-v1
+warnings             controlled limitations/fallback evidence
+```
+
+## Algorithm Decisions
+
+### Tempo
+
+- Beat tracking runs on the percussive component and onset envelope.
+- Confidence combines beat-interval stability, expected-beat coverage and onset strength.
+- Half/double-tempo ambiguity is not silently corrected in this bundle; Bundle 46 evaluates it against reference data.
+
+### Key
+
+- Harmonic chroma is preferred.
+- CQT chroma is used for normal-length audio.
+- STFT chroma is the controlled fallback.
+- Twenty-four major/minor key hypotheses are scored with tonal profiles.
+- Camelot is derived from tonic and mode.
+- Confidence is an internal relative measure based on absolute fit and winner margin.
+
+### Energy
+
+Energy is a relative provider-specific score combining:
+
+- RMS loudness component,
+- percussive power ratio,
+- onset activity,
+- spectral brightness,
+- RMS dynamics.
+
+It is not a universal physical energy value. Bundle 46 must measure ranking usefulness against DJ annotations.
+
+## Safety Boundaries
+
+- Input must be an absolute path to an existing regular file.
+- Analysis is local and performs no network upload.
+- Optional audio dependencies remain off mandatory boot paths.
+- Empty, silent, non-finite or undecodable audio fails in a controlled provider boundary.
+- Provider output is normalized and bounded before acceptance.
+- Provider code performs no database write.
+- No quality or production-default claim is made before benchmark review.
+
+## Verification Scope
+
+Synthetic-audio tests prove:
+
+- real WAV decoding,
+- tempo evidence including half/double-compatible tolerance,
+- duration,
+- key/scale/Camelot output,
+- bounded confidence and energy,
+- loudness and harmonic/percussive evidence,
+- deterministic repeated output,
+- silence rejection,
+- lazy import,
+- malformed Camelot/warning payload rejection.
+
+Synthetic tests prove software behavior, not accuracy on real DJ music.
+
+## Explicitly Out of Scope
+
+- provider persistence,
+- API or desktop activation,
+- worker/job wiring,
+- production-default selection,
+- automatic beatgrid correction,
+- downbeat, phrase, section or cue-point detection,
+- genre classification,
+- embeddings or pretrained models,
+- Essentia activation,
+- claims of parity with Mixed In Key, Rekordbox or other commercial analyzers.
+
+## Rollback
+
+Before merge, close the pull request without changing the canonical branch.
+
+After an isolated squash merge, revert that one merge commit. No data rollback is required because Bundle 45 introduces no database writes or migration.
+
+## Next Slice
+
+```text
+Bundle 46 — MIR Benchmark Harness
+  ├── licensed dataset manifests
+  ├── decode reliability
+  ├── BPM exact + half/double metrics
+  ├── exact and Camelot-compatible key metrics
+  ├── energy rank correlation
+  ├── runtime and memory evidence
+  ├── human DJ review
+  └── provider decision report
+```

--- a/services/analysis/librosa_baseline.py
+++ b/services/analysis/librosa_baseline.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any
+
+
+NOTE_NAMES = ("C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B")
+
+CAMELOT_BY_PITCH_CLASS = {
+    "major": (
+        "8B", "3B", "10B", "5B", "12B", "7B", "2B", "9B", "4B", "11B", "6B", "1B"
+    ),
+    "minor": (
+        "5A", "12A", "7A", "2A", "9A", "4A", "11A", "6A", "1A", "8A", "3A", "10A"
+    ),
+}
+
+MAJOR_PROFILE = (6.35, 2.23, 3.48, 2.33, 4.38, 4.09, 2.52, 5.19, 2.39, 3.66, 2.29, 2.88)
+MINOR_PROFILE = (6.33, 2.68, 3.52, 5.38, 2.60, 3.53, 2.54, 4.75, 3.98, 2.69, 3.34, 3.17)
+
+
+class BaselineLibrosaMIR:
+    """Deterministic local baseline for benchmark evaluation, not production approval."""
+
+    provider_name = "librosa"
+    algorithm_version = "baseline-librosa-mir-v1"
+    sample_rate = 22_050
+    hop_length = 512
+
+    def analyze(self, path: str) -> dict[str, Any]:
+        source = self._validated_source(path)
+
+        import librosa
+        import numpy as np
+
+        waveform, sample_rate = librosa.load(
+            str(source),
+            sr=self.sample_rate,
+            mono=True,
+            dtype=np.float32,
+        )
+        waveform = np.asarray(waveform, dtype=np.float32)
+        if waveform.ndim != 1 or waveform.size == 0:
+            raise ValueError("decoded audio is empty or not mono")
+        if not np.all(np.isfinite(waveform)):
+            raise ValueError("decoded audio contains non-finite samples")
+
+        duration = float(librosa.get_duration(y=waveform, sr=sample_rate))
+        if not math.isfinite(duration) or duration <= 0.0:
+            raise ValueError("decoded audio has invalid duration")
+        if float(np.max(np.abs(waveform))) < 1e-7:
+            raise ValueError("decoded audio is silent")
+
+        warnings = [
+            "baseline provider output is not benchmark-approved",
+            "confidence values are internal and not benchmark-calibrated",
+            "energy score is relative and provider-specific",
+        ]
+        if duration < 3.0:
+            warnings.append("short audio may reduce tempo and key reliability")
+
+        harmonic, percussive = librosa.effects.hpss(waveform)
+        harmonic = np.asarray(harmonic, dtype=np.float32)
+        percussive = np.asarray(percussive, dtype=np.float32)
+
+        onset_envelope = librosa.onset.onset_strength(
+            y=percussive,
+            sr=sample_rate,
+            hop_length=self.hop_length,
+            aggregate=np.median,
+        )
+        tempo_raw, beat_frames = librosa.beat.beat_track(
+            onset_envelope=onset_envelope,
+            sr=sample_rate,
+            hop_length=self.hop_length,
+        )
+        tempo = self._first_scalar(tempo_raw, np)
+        beat_frames = np.asarray(beat_frames, dtype=int)
+        bpm, bpm_confidence, beat_stability = self._beat_evidence(
+            tempo=tempo,
+            beat_frames=beat_frames,
+            onset_envelope=np.asarray(onset_envelope, dtype=float),
+            duration=duration,
+            sample_rate=sample_rate,
+            librosa=librosa,
+            np=np,
+        )
+        if bpm is None:
+            warnings.append("tempo could not be estimated reliably")
+
+        chroma = self._chroma(
+            harmonic=harmonic,
+            sample_rate=sample_rate,
+            duration=duration,
+            librosa=librosa,
+            np=np,
+            warnings=warnings,
+        )
+        tonic, scale, camelot, key_confidence = self._key_evidence(chroma, np=np)
+        if camelot is None:
+            warnings.append("tonal key could not be estimated reliably")
+
+        rms = librosa.feature.rms(
+            y=waveform,
+            frame_length=2048,
+            hop_length=self.hop_length,
+        )[0]
+        centroid = librosa.feature.spectral_centroid(
+            y=waveform,
+            sr=sample_rate,
+            hop_length=self.hop_length,
+        )[0]
+        onset_frames = librosa.onset.onset_detect(
+            onset_envelope=onset_envelope,
+            sr=sample_rate,
+            hop_length=self.hop_length,
+            units="frames",
+        )
+
+        harmonic_power = float(np.sum(np.square(harmonic, dtype=np.float64)))
+        percussive_power = float(np.sum(np.square(percussive, dtype=np.float64)))
+        total_power = harmonic_power + percussive_power
+        if total_power <= 1e-20:
+            harmonic_ratio = 0.5
+            percussive_ratio = 0.5
+        else:
+            harmonic_ratio = self._clip(harmonic_power / total_power)
+            percussive_ratio = self._clip(percussive_power / total_power)
+
+        loudness_db, energy = self._energy_evidence(
+            rms=np.asarray(rms, dtype=float),
+            centroid=np.asarray(centroid, dtype=float),
+            onset_count=int(len(onset_frames)),
+            duration=duration,
+            sample_rate=sample_rate,
+            percussive_ratio=percussive_ratio,
+            np=np,
+        )
+
+        return {
+            "provider": self.provider_name,
+            "provider_version": str(librosa.__version__),
+            "algorithm_version": self.algorithm_version,
+            "status": "ok",
+            "beat": {
+                "bpm": bpm,
+                "confidence": bpm_confidence,
+                "stability": beat_stability,
+                "beat_count": int(len(beat_frames)),
+            },
+            "key": {
+                "tonic": tonic,
+                "scale": scale,
+                "camelot": camelot,
+                "confidence": key_confidence,
+            },
+            "metrics": {
+                "energy_score": energy,
+                "loudness_db": loudness_db,
+                "duration_seconds": duration,
+                "harmonic_ratio": harmonic_ratio,
+                "percussive_ratio": percussive_ratio,
+            },
+            "provenance": {
+                "provider_version": str(librosa.__version__),
+                "algorithm_version": self.algorithm_version,
+                "sample_rate": sample_rate,
+                "hop_length": self.hop_length,
+            },
+            "warnings": warnings,
+        }
+
+    @staticmethod
+    def _validated_source(path: str) -> Path:
+        if not isinstance(path, str) or not path.strip():
+            raise ValueError("analysis path must be a non-empty string")
+        source = Path(path)
+        if not source.is_absolute():
+            raise ValueError("analysis path must be absolute")
+        try:
+            resolved = source.resolve(strict=True)
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(f"audio file not found: {source}") from exc
+        if not resolved.is_file():
+            raise ValueError("analysis path must reference a regular file")
+        return resolved
+
+    @staticmethod
+    def _first_scalar(value: Any, np: Any) -> float | None:
+        values = np.asarray(value, dtype=float).reshape(-1)
+        if values.size == 0:
+            return None
+        scalar = float(values[0])
+        return scalar if math.isfinite(scalar) else None
+
+    def _beat_evidence(
+        self,
+        *,
+        tempo: float | None,
+        beat_frames: Any,
+        onset_envelope: Any,
+        duration: float,
+        sample_rate: int,
+        librosa: Any,
+        np: Any,
+    ) -> tuple[float | None, float | None, float | None]:
+        if tempo is None or not 20.0 <= tempo <= 400.0 or len(beat_frames) < 2:
+            return None, 0.0, 0.0
+
+        beat_times = librosa.frames_to_time(
+            beat_frames,
+            sr=sample_rate,
+            hop_length=self.hop_length,
+        )
+        intervals = np.diff(np.asarray(beat_times, dtype=float))
+        intervals = intervals[np.isfinite(intervals) & (intervals > 0.0)]
+        if intervals.size == 0:
+            return float(tempo), 0.0, 0.0
+
+        median_interval = float(np.median(intervals))
+        median_deviation = float(np.median(np.abs(intervals - median_interval)))
+        relative_deviation = median_deviation / max(median_interval, 1e-12)
+        stability = self._clip(1.0 - (relative_deviation * 8.0))
+
+        expected_beats = max(1.0, duration * float(tempo) / 60.0)
+        coverage = self._clip(len(beat_frames) / expected_beats)
+
+        valid_frames = beat_frames[(beat_frames >= 0) & (beat_frames < len(onset_envelope))]
+        if len(valid_frames) and float(np.max(onset_envelope)) > 0.0:
+            reference = float(np.percentile(onset_envelope, 95))
+            strength = self._clip(
+                float(np.mean(onset_envelope[valid_frames])) / max(reference, 1e-12)
+            )
+        else:
+            strength = 0.0
+
+        confidence = self._clip((0.50 * stability) + (0.30 * coverage) + (0.20 * strength))
+        return float(tempo), confidence, stability
+
+    def _chroma(
+        self,
+        *,
+        harmonic: Any,
+        sample_rate: int,
+        duration: float,
+        librosa: Any,
+        np: Any,
+        warnings: list[str],
+    ) -> Any:
+        if duration >= 3.0:
+            try:
+                chroma = librosa.feature.chroma_cqt(
+                    y=harmonic,
+                    sr=sample_rate,
+                    hop_length=self.hop_length,
+                    bins_per_octave=36,
+                )
+                if np.asarray(chroma).shape[0] == 12:
+                    return np.asarray(chroma, dtype=float)
+            except Exception:
+                warnings.append("CQT chroma failed; STFT chroma fallback used")
+        else:
+            warnings.append("STFT chroma used for short audio")
+
+        return np.asarray(
+            librosa.feature.chroma_stft(
+                y=harmonic,
+                sr=sample_rate,
+                hop_length=self.hop_length,
+            ),
+            dtype=float,
+        )
+
+    def _key_evidence(self, chroma: Any, *, np: Any) -> tuple[str | None, str | None, str | None, float]:
+        matrix = np.asarray(chroma, dtype=float)
+        if matrix.ndim != 2 or matrix.shape[0] != 12 or matrix.shape[1] == 0:
+            return None, None, None, 0.0
+        if not np.all(np.isfinite(matrix)):
+            return None, None, None, 0.0
+
+        chroma_mean = np.median(matrix, axis=1)
+        if float(np.sum(np.abs(chroma_mean))) <= 1e-12:
+            return None, None, None, 0.0
+
+        def normalized(vector: Any) -> Any:
+            centered = np.asarray(vector, dtype=float) - float(np.mean(vector))
+            norm = float(np.linalg.norm(centered))
+            return centered / max(norm, 1e-12)
+
+        candidates: list[tuple[float, int, str]] = []
+        for scale, profile in (("major", MAJOR_PROFILE), ("minor", MINOR_PROFILE)):
+            profile_vector = normalized(profile)
+            for tonic_index in range(12):
+                rotated = np.roll(chroma_mean, -tonic_index)
+                score = float(np.dot(normalized(rotated), profile_vector))
+                candidates.append((score, tonic_index, scale))
+
+        candidates.sort(key=lambda item: item[0], reverse=True)
+        best_score, tonic_index, scale = candidates[0]
+        second_score = candidates[1][0]
+        absolute = self._clip((best_score + 1.0) / 2.0)
+        margin = self._clip((best_score - second_score) / 0.20)
+        confidence = self._clip((0.70 * absolute) + (0.30 * margin))
+        if best_score < 0.05:
+            return None, None, None, confidence
+
+        tonic = NOTE_NAMES[tonic_index]
+        camelot = CAMELOT_BY_PITCH_CLASS[scale][tonic_index]
+        return tonic, scale, camelot, confidence
+
+    def _energy_evidence(
+        self,
+        *,
+        rms: Any,
+        centroid: Any,
+        onset_count: int,
+        duration: float,
+        sample_rate: int,
+        percussive_ratio: float,
+        np: Any,
+    ) -> tuple[float, float]:
+        finite_rms = rms[np.isfinite(rms) & (rms >= 0.0)]
+        if finite_rms.size == 0:
+            raise ValueError("RMS analysis produced no finite values")
+
+        rms_mean = float(np.mean(finite_rms))
+        loudness_db = 20.0 * math.log10(max(rms_mean, 1e-12))
+        loudness_component = self._clip((loudness_db + 35.0) / 29.0)
+
+        finite_centroid = centroid[np.isfinite(centroid) & (centroid >= 0.0)]
+        centroid_mean = float(np.mean(finite_centroid)) if finite_centroid.size else 0.0
+        brightness = self._clip(centroid_mean / min(6_000.0, sample_rate / 2.0))
+        onset_activity = self._clip((onset_count / max(duration, 1e-12)) / 4.0)
+
+        p10 = float(np.percentile(finite_rms, 10))
+        p90 = float(np.percentile(finite_rms, 90))
+        dynamics = self._clip((p90 - p10) / max(p90, 1e-12))
+
+        energy = self._clip(
+            (0.40 * loudness_component)
+            + (0.25 * percussive_ratio)
+            + (0.20 * onset_activity)
+            + (0.10 * brightness)
+            + (0.05 * dynamics)
+        )
+        return loudness_db, energy
+
+    @staticmethod
+    def _clip(value: float) -> float:
+        if not math.isfinite(value):
+            return 0.0
+        return max(0.0, min(1.0, float(value)))

--- a/tests/test_librosa_baseline_provider.py
+++ b/tests/test_librosa_baseline_provider.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from core.analysis.provider_contract import ProviderOutputInvalid, ProviderRuntimeFailure
+from core.analysis.provider_service import RoutedAnalysisService
+from core.analysis.providers import LibrosaAnalyzerProvider
+from services.analysis.librosa_baseline import BaselineLibrosaMIR, MAJOR_PROFILE
+
+
+SAMPLE_RATE = 22_050
+
+
+def _write_synthetic_track(
+    path: Path,
+    *,
+    duration: float = 12.0,
+    bpm: float = 120.0,
+    amplitude: float = 0.45,
+) -> None:
+    sample_count = int(SAMPLE_RATE * duration)
+    times = np.arange(sample_count, dtype=np.float64) / SAMPLE_RATE
+
+    chord = (
+        np.sin(2.0 * np.pi * 261.6256 * times)
+        + np.sin(2.0 * np.pi * 329.6276 * times)
+        + np.sin(2.0 * np.pi * 391.9954 * times)
+    ) / 3.0
+    chord *= amplitude * 0.55
+
+    clicks = np.zeros(sample_count, dtype=np.float64)
+    pulse_length = max(32, int(SAMPLE_RATE * 0.035))
+    rng = np.random.default_rng(45)
+    pulse = rng.normal(0.0, 1.0, pulse_length) * np.hanning(pulse_length)
+    pulse /= max(float(np.max(np.abs(pulse))), 1e-12)
+    pulse *= amplitude * 0.75
+    period = int(round(SAMPLE_RATE * 60.0 / bpm))
+    for start in range(0, sample_count, period):
+        end = min(sample_count, start + pulse_length)
+        clicks[start:end] += pulse[: end - start]
+
+    signal = np.clip(chord + clicks, -0.98, 0.98).astype(np.float32)
+    sf.write(path, signal, SAMPLE_RATE, subtype="FLOAT")
+
+
+def test_provider_modules_remain_lazy_on_import() -> None:
+    code = """
+import sys
+import core.analysis.providers
+import core.analysis.provider_service
+assert 'librosa' not in sys.modules
+assert 'soundfile' not in sys.modules
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_real_synthetic_audio_returns_canonical_mir_evidence(tmp_path: Path) -> None:
+    source = tmp_path / "c-major-120.wav"
+    _write_synthetic_track(source)
+
+    result = RoutedAnalysisService().analyze_path(
+        str(source.resolve()),
+        preferred_provider="librosa",
+    )
+
+    assert result.provider == "librosa"
+    assert result.provider_version
+    assert result.algorithm_version == "baseline-librosa-mir-v1"
+    assert result.duration_seconds == pytest.approx(12.0, abs=0.05)
+    assert result.bpm is not None
+    assert min(abs(result.bpm - candidate) for candidate in (60.0, 120.0, 240.0)) < 5.0
+    assert result.bpm_confidence is not None
+    assert 0.0 <= result.bpm_confidence <= 1.0
+    assert result.beat_stability is not None
+    assert 0.0 <= result.beat_stability <= 1.0
+    assert result.key_tonic is not None
+    assert result.key_scale in {"major", "minor"}
+    assert result.camelot is not None
+    assert result.key == result.camelot
+    assert result.key_confidence is not None
+    assert 0.0 <= result.key_confidence <= 1.0
+    assert result.energy is not None
+    assert 0.0 <= result.energy <= 1.0
+    assert result.loudness_db is not None
+    assert result.harmonic_ratio is not None
+    assert result.percussive_ratio is not None
+    assert result.harmonic_ratio + result.percussive_ratio == pytest.approx(1.0, abs=1e-6)
+    assert "baseline provider output is not benchmark-approved" in result.warnings
+
+
+def test_ideal_c_major_profile_maps_to_camelot_8b() -> None:
+    chroma = np.repeat(np.asarray(MAJOR_PROFILE, dtype=float)[:, None], 8, axis=1)
+
+    tonic, scale, camelot, confidence = BaselineLibrosaMIR()._key_evidence(
+        chroma,
+        np=np,
+    )
+
+    assert tonic == "C"
+    assert scale == "major"
+    assert camelot == "8B"
+    assert 0.0 < confidence <= 1.0
+
+
+def test_fixed_audio_produces_deterministic_raw_result(tmp_path: Path) -> None:
+    source = tmp_path / "deterministic.wav"
+    _write_synthetic_track(source, duration=6.0)
+    provider = LibrosaAnalyzerProvider()
+
+    first = provider.analyze(str(source.resolve()))
+    second = provider.analyze(str(source.resolve()))
+
+    assert first == second
+
+
+def test_silent_audio_is_a_controlled_provider_failure(tmp_path: Path) -> None:
+    source = tmp_path / "silence.wav"
+    sf.write(source, np.zeros(SAMPLE_RATE * 2, dtype=np.float32), SAMPLE_RATE)
+
+    with pytest.raises(ProviderRuntimeFailure) as exc_info:
+        RoutedAnalysisService().analyze_path(
+            str(source.resolve()),
+            preferred_provider="librosa",
+        )
+
+    assert exc_info.value.provider == "librosa"
+    assert exc_info.value.code == "provider_runtime_error"
+
+
+def test_contract_rejects_invalid_camelot_and_warning_shape() -> None:
+    service = RoutedAnalysisService(
+        selector=lambda _preferred: type(
+            "InvalidProvider",
+            (),
+            {
+                "name": "invalid",
+                "analyze": lambda self, _path: {
+                    "provider": "invalid",
+                    "status": "ok",
+                    "key": {"camelot": "13A"},
+                    "warnings": "not-an-array",
+                },
+            },
+        )()
+    )
+
+    with pytest.raises(ProviderOutputInvalid):
+        service.analyze_path(str(Path("/tmp/demo.wav")))


### PR DESCRIPTION
## Summary
- replace the Librosa stub with a real lazy local MIR provider
- add BPM, beat stability and internal confidence evidence
- add tonic, scale, Camelot and internal tonal confidence
- add provider-relative energy, RMS dBFS and harmonic/percussive ratios
- extend the canonical result with provenance and warnings while preserving `key`
- add real synthetic-WAV tests, silence rejection and deterministic-repeat evidence
- add schema-tree documentation and update the license decision register

## Verification
- branch created directly from canonical commit `9fc9d4f0d6e3ca30b41192e63c31e9da9e96490c`
- ahead-only diff limited to provider contracts/implementation, tests and documentation
- Python 3.11 and 3.12 install, compile, critical Ruff and full pytest are required
- real synthetic audio is analyzed in CI; no local test execution is claimed

## Isolation
- no database write or migration
- no API route, worker or pipeline activation
- no production-default provider decision
- no network access or remote audio upload
- Essentia remains disabled/stubbed
- no claim of Mixed In Key parity before Bundle 46 benchmark evidence

## Bundle Context
- Bundle: 45 — Baseline Librosa MIR Provider
- Base branch: `feature/bundle-0-bootstrap`
- Base commit: `9fc9d4f0d6e3ca30b41192e63c31e9da9e96490c`
- Related issue: #72
- Next: Bundle 46 MIR benchmark harness and provider decision report
- Rollback: revert the future isolated squash commit; no data rollback required