### PR TITLE
Bundle 48: authenticated Python sidecar proof

### DIFF
--- a/.github/workflows/desktop-sidecar-proof.yml
+++ b/.github/workflows/desktop-sidecar-proof.yml
@@ -1,0 +1,88 @@
+name: Desktop Sidecar Proof
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/desktop-sidecar-proof.yml"
+      - "services/desktop/**"
+      - "scripts/applaylist_sidecar_entry.py"
+      - "scripts/build_desktop_sidecar.py"
+      - "scripts/smoke_desktop_sidecar.py"
+      - "tests/test_desktop_readiness_sidecar.py"
+      - "pyproject.toml"
+  push:
+    branches:
+      - "feature/bundle-48a-*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: desktop-sidecar-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  package-proof:
+    name: ${{ matrix.os }} / Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install project and pinned packager
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev,desktop-build]"
+
+      - name: Sidecar unit and process tests
+        run: python -m pytest -q tests/test_desktop_readiness_sidecar.py
+
+      - name: Build target-native sidecar
+        run: python scripts/build_desktop_sidecar.py
+
+      - name: Smoke packaged sidecar
+        run: |
+          python scripts/smoke_desktop_sidecar.py \
+            artifacts/desktop-sidecar/package-manifest.json \
+            | tee artifacts/desktop-sidecar/smoke-evidence.json
+
+      - name: Verify package manifest
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          manifest = json.loads(
+              Path("artifacts/desktop-sidecar/package-manifest.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          assert manifest["schema_version"] == "applaylist-sidecar-package-v1"
+          assert manifest["mode"] == "onedir"
+          assert manifest["size_bytes"] > 0
+          executable = Path(manifest["executable"])
+          assert executable.is_file(), executable
+          print(json.dumps(manifest, sort_keys=True))
+          PY
+
+      - name: Upload packaged proof
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-sidecar-${{ runner.os }}-${{ matrix.python-version }}
+          path: artifacts/desktop-sidecar/
+          if-no-files-found: error
+          retention-days: 14

--- a/docs/operations/DESKTOP_SIDECAR_PROOF_GUIDE.md
+++ b/docs/operations/DESKTOP_SIDECAR_PROOF_GUIDE.md
@@ -1,0 +1,134 @@
+# APPLAYLIST Desktop Sidecar Proof Guide
+
+## Status
+
+Bundle 48A proves only the Python sidecar boundary required by the canonical Bundle 48 Tauri proof.
+
+It does not create the renderer, Tauri core, folder capability registry, updater, product UI or signed release.
+
+## Schema Tree
+
+```text
+future Tauri supervisor
+  -> spawn packaged executable
+  -> write one private JSON line to stdin
+      ├── protocol
+      ├── per-session secret
+      └── readiness nonce
+  -> Python readiness sidecar
+      ├── validate exact envelope
+      ├── bind 127.0.0.1:0
+      ├── emit ready event
+      │   ├── protocol
+      │   ├── loopback host
+      │   ├── ephemeral port
+      │   ├── nonce SHA-256
+      │   └── process ID
+      ├── authenticated GET /v1/health
+      ├── authenticated POST /v1/shutdown
+      └── graceful process exit
+```
+
+## Security Contract
+
+- Secret and nonce are supplied through stdin, never command-line arguments.
+- The startup envelope is read exactly once and is bounded to 8192 bytes.
+- Only the exact `protocol`, `secret` and `nonce` fields are accepted.
+- Secret and nonce must be distinct printable ASCII values between 32 and 256 characters.
+- The service binds only to `127.0.0.1` and requests an ephemeral port from the OS.
+- The raw nonce is not printed. Readiness exposes only its SHA-256 digest.
+- The raw secret is never returned or logged.
+- Health and shutdown require both secret and nonce headers.
+- Missing or incorrect credentials return the same generic unauthorized response.
+- Unknown routes and unsupported methods return controlled JSON responses.
+- Shutdown accepts no request body.
+- The renderer must never learn the sidecar URL, secret or nonce in Bundle 48B.
+
+## Startup Envelope
+
+The future Rust supervisor writes one newline-terminated JSON object:
+
+```json
+{"protocol":"applaylist-sidecar-v1","secret":"<session-secret>","nonce":"<readiness-nonce>"}
+```
+
+Do not pass the envelope in argv, environment variables, logs or renderer events.
+
+## Readiness Event
+
+The sidecar prints one JSON line to stdout:
+
+```json
+{
+  "event": "ready",
+  "host": "127.0.0.1",
+  "nonce_sha256": "<digest>",
+  "port": 49152,
+  "process_id": 12345,
+  "protocol": "applaylist-sidecar-v1"
+}
+```
+
+The supervisor must verify:
+
+1. event is `ready`,
+2. protocol matches,
+3. host is exactly `127.0.0.1`,
+4. port is in the valid TCP range,
+5. nonce digest matches its startup nonce,
+6. the child process is still alive,
+7. authenticated health succeeds.
+
+## Local Source Test
+
+```bash
+python -m pytest -q tests/test_desktop_readiness_sidecar.py
+```
+
+## Packaging Proof
+
+Install the explicitly separated packaging dependency:
+
+```bash
+python -m pip install -e ".[dev,desktop-build]"
+```
+
+Build a target-native PyInstaller `onedir` package:
+
+```bash
+python scripts/build_desktop_sidecar.py
+```
+
+Smoke-test the package:
+
+```bash
+python scripts/smoke_desktop_sidecar.py \
+  artifacts/desktop-sidecar/package-manifest.json
+```
+
+PyInstaller is not a cross-compiler. Build each target on its target operating system.
+
+## Why `onedir` First
+
+The proof intentionally uses `onedir` because package contents and missing native libraries are easier to inspect. Bundle 48B may stage a target-triple sidecar executable for Tauri only after packaged lifecycle tests are stable.
+
+A single-file format must not be treated as automatically superior: it extracts at startup and can complicate startup time, diagnostics and macOS signing behavior.
+
+## Evidence
+
+CI uploads:
+
+```text
+artifacts/desktop-sidecar/
+├── dist/
+├── package-manifest.json
+├── smoke-evidence.json
+├── spec/
+└── work/
+```
+
+The package manifest records target platform, Python version and package size. It is proof evidence, not a distributable signed release.
+
+## Rollback
+
+Revert the isolated Bundle 48A squash commit. No data, schema or product-runtime rollback is required.

--- a/docs/status/BUNDLE_48A_AUTHENTICATED_PYTHON_SIDECAR.md
+++ b/docs/status/BUNDLE_48A_AUTHENTICATED_PYTHON_SIDECAR.md
@@ -1,0 +1,95 @@
+# Bundle 48A — Authenticated Python Readiness Sidecar
+
+## Status
+
+Implemented on an isolated feature branch. Not yet merged.
+
+## Product Value
+
+Bundle 48A proves that the future Tauri desktop core can supervise a packaged Python process without exposing arbitrary shell, filesystem or sidecar network authority to the renderer.
+
+## Schema Tree
+
+```text
+APPLAYLIST Desktop Proof
+└── Bundle 48A: Python sidecar boundary
+    ├── private stdin startup envelope
+    │   ├── protocol version
+    │   ├── per-session secret
+    │   └── readiness nonce
+    ├── loopback ephemeral listener
+    ├── machine-readable readiness evidence
+    ├── authenticated health
+    ├── authenticated shutdown
+    ├── signal-aware graceful exit
+    ├── PyInstaller onedir package proof
+    └── Linux/macOS packaged smoke workflow
+
+Future Bundle 48B
+└── Tauri 2 + React supervisor proof
+    ├── typed commands
+    ├── renderer isolation
+    ├── secret ownership in Rust
+    ├── sidecar lifecycle
+    └── opaque folder capability ID
+```
+
+## Changed Boundary
+
+```text
+Rust supervisor contract (documented, not implemented)
+  -> services.desktop.sidecar
+  -> packaged process artifact
+```
+
+## Security Invariants
+
+- No secret or nonce in argv.
+- No secret or raw nonce in readiness output or errors.
+- No environment-variable credential transport.
+- Exact startup schema and protocol version.
+- Loopback-only bind.
+- OS-selected ephemeral port.
+- Constant-time secret and nonce comparison.
+- Generic unauthorized response.
+- No generic RPC, shell, filesystem, database or product API.
+- Renderer remains unable to connect directly.
+
+## Packaging Decision
+
+- `PyInstaller==6.21.0` is isolated under the `desktop-build` optional dependency.
+- First proof uses `onedir` for inspectability.
+- Each OS builds its own target-native artifact.
+- CI artifacts are proof evidence, not signed releases.
+
+## Out of Scope
+
+- React/Vite workspace,
+- Rust/Tauri core,
+- native folder dialog,
+- opaque capability registry,
+- library import UI,
+- MIR or composition UI,
+- updater,
+- code signing/notarization,
+- production distribution.
+
+## Acceptance
+
+- Python 3.11 and 3.12 process tests pass.
+- Missing/wrong secret and nonce fail closed.
+- Correct health handshake succeeds.
+- Body-bearing shutdown is rejected.
+- Correct shutdown terminates within timeout.
+- Credentials do not appear in process args or captured output.
+- PyInstaller package builds on Linux and macOS.
+- Packaged executable passes negative-auth, health and shutdown smoke checks.
+- Existing full Python regression suite remains green.
+
+## Rollback
+
+Revert one isolated squash commit. No database or product-runtime migration is involved.
+
+## Next Dependency
+
+Bundle 48B adds the minimal React/Tauri supervisor and proves that the renderer cannot access the sidecar endpoint or private startup credentials.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dev = [
   "httpx>=0.27,<1.0",
   "ruff>=0.6,<1.0",
 ]
+desktop-build = [
+  "pyinstaller==6.21.0",
+]
 
 [tool.setuptools]
 include-package-data = true

--- a/scripts/applaylist_sidecar_entry.py
+++ b/scripts/applaylist_sidecar_entry.py
@@ -1,0 +1,5 @@
+from services.desktop.sidecar import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_desktop_sidecar.py
+++ b/scripts/build_desktop_sidecar.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+
+SIDECAR_NAME = "applaylist-sidecar"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build the APPLAYLIST Python readiness sidecar")
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=Path("artifacts/desktop-sidecar"),
+        help="Build output root relative to the repository or as an absolute path",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    repository_root = Path(__file__).resolve().parents[1]
+    output_root = args.output_root
+    if not output_root.is_absolute():
+        output_root = (repository_root / output_root).resolve()
+    else:
+        output_root = output_root.resolve()
+
+    if repository_root not in output_root.parents:
+        raise SystemExit("output root must remain inside the repository")
+
+    dist = output_root / "dist"
+    work = output_root / "work"
+    specs = output_root / "spec"
+    if output_root.exists():
+        shutil.rmtree(output_root)
+    dist.mkdir(parents=True)
+    work.mkdir(parents=True)
+    specs.mkdir(parents=True)
+
+    command = [
+        sys.executable,
+        "-m",
+        "PyInstaller",
+        "--noconfirm",
+        "--clean",
+        "--onedir",
+        "--name",
+        SIDECAR_NAME,
+        "--distpath",
+        str(dist),
+        "--workpath",
+        str(work),
+        "--specpath",
+        str(specs),
+        str(repository_root / "scripts" / "applaylist_sidecar_entry.py"),
+    ]
+    completed = subprocess.run(command, cwd=repository_root, check=False)
+    if completed.returncode != 0:
+        return completed.returncode
+
+    executable = dist / SIDECAR_NAME / SIDECAR_NAME
+    if sys.platform == "win32":
+        executable = executable.with_suffix(".exe")
+    if not executable.is_file():
+        raise SystemExit(f"sidecar executable missing: {executable}")
+
+    manifest = {
+        "schema_version": "applaylist-sidecar-package-v1",
+        "mode": "onedir",
+        "executable": str(executable.relative_to(repository_root)),
+        "size_bytes": sum(
+            path.stat().st_size for path in (dist / SIDECAR_NAME).rglob("*") if path.is_file()
+        ),
+        "python": sys.version.split()[0],
+        "platform": sys.platform,
+    }
+    manifest_path = output_root / "package-manifest.json"
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(manifest_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_desktop_sidecar.py
+++ b/scripts/smoke_desktop_sidecar.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+
+PROTOCOL = "applaylist-sidecar-v1"
+SECRET = "package-smoke-secret-0123456789-ABCDEFGH"
+NONCE = "package-smoke-nonce-0123456789-IJKLMNOP"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Smoke-test a packaged APPLAYLIST sidecar")
+    parser.add_argument("manifest", type=Path)
+    args = parser.parse_args()
+
+    repository_root = Path(__file__).resolve().parents[1]
+    manifest_path = args.manifest.resolve(strict=True)
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    executable = (repository_root / payload["executable"]).resolve(strict=True)
+    if repository_root not in executable.parents:
+        raise SystemExit("packaged executable escaped repository root")
+
+    process = subprocess.Popen(
+        [str(executable)],
+        cwd=repository_root,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        bufsize=1,
+    )
+    assert process.stdin is not None
+    assert process.stdout is not None
+    process.stdin.write(
+        json.dumps(
+            {"protocol": PROTOCOL, "secret": SECRET, "nonce": NONCE},
+            separators=(",", ":"),
+        )
+        + "\n"
+    )
+    process.stdin.flush()
+    ready_line = process.stdout.readline()
+    if not ready_line:
+        stderr = process.stderr.read() if process.stderr is not None else ""
+        process.kill()
+        raise SystemExit(f"packaged sidecar did not become ready: {stderr}")
+    ready = json.loads(ready_line)
+    expected_nonce_digest = hashlib.sha256(NONCE.encode("ascii")).hexdigest()
+    if ready.get("host") != "127.0.0.1" or ready.get("nonce_sha256") != expected_nonce_digest:
+        process.kill()
+        raise SystemExit("packaged sidecar readiness evidence is invalid")
+
+    base_url = f"http://127.0.0.1:{ready['port']}"
+    wrong = Request(
+        base_url + "/v1/health",
+        headers={
+            "X-APPLAYLIST-Sidecar-Secret": "X" * 48,
+            "X-APPLAYLIST-Readiness-Nonce": NONCE,
+        },
+    )
+    try:
+        urlopen(wrong, timeout=5)  # noqa: S310 - fixed loopback target
+        process.kill()
+        raise SystemExit("packaged sidecar accepted an invalid secret")
+    except HTTPError as exc:
+        if exc.code != 401:
+            process.kill()
+            raise
+
+    health = Request(
+        base_url + "/v1/health",
+        headers={
+            "X-APPLAYLIST-Sidecar-Secret": SECRET,
+            "X-APPLAYLIST-Readiness-Nonce": NONCE,
+        },
+    )
+    with urlopen(health, timeout=5) as response:  # noqa: S310 - fixed loopback target
+        health_payload = json.loads(response.read().decode("utf-8"))
+    if health_payload.get("status") != "ready":
+        process.kill()
+        raise SystemExit("packaged sidecar health response is invalid")
+
+    shutdown = Request(
+        base_url + "/v1/shutdown",
+        method="POST",
+        data=b"",
+        headers={
+            "X-APPLAYLIST-Sidecar-Secret": SECRET,
+            "X-APPLAYLIST-Readiness-Nonce": NONCE,
+        },
+    )
+    with urlopen(shutdown, timeout=5) as response:  # noqa: S310 - fixed loopback target
+        if response.status != 202:
+            process.kill()
+            raise SystemExit("packaged sidecar shutdown was rejected")
+
+    stdout, stderr = process.communicate(timeout=10)
+    if process.returncode != 0:
+        raise SystemExit(f"packaged sidecar exited with {process.returncode}: {stderr}")
+    combined = ready_line + stdout + stderr
+    if SECRET in combined or NONCE in combined:
+        raise SystemExit("packaged sidecar disclosed private startup credentials")
+
+    print(
+        json.dumps(
+            {
+                "status": "passed",
+                "executable": str(executable),
+                "package_size_bytes": payload["size_bytes"],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/desktop/__init__.py
+++ b/services/desktop/__init__.py
@@ -1,0 +1,5 @@
+"""Desktop host and sidecar boundaries.
+
+Renderer-facing desktop authority belongs to the future Tauri core. This package
+contains only the Python process contract supervised by that core.
+"""

--- a/services/desktop/sidecar.py
+++ b/services/desktop/sidecar.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import secrets
+import signal
+import sys
+import threading
+from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, TextIO
+
+
+PROTOCOL_VERSION = "applaylist-sidecar-v1"
+MAX_STARTUP_BYTES = 8_192
+MAX_HEADER_BYTES = 512
+SECRET_HEADER = "X-APPLAYLIST-Sidecar-Secret"
+NONCE_HEADER = "X-APPLAYLIST-Readiness-Nonce"
+
+
+class SidecarStartupError(ValueError):
+    """Raised when the supervisor startup envelope is malformed or unsafe."""
+
+
+@dataclass(frozen=True, slots=True)
+class SidecarStartup:
+    protocol: str
+    secret: str
+    nonce: str
+
+
+@dataclass(frozen=True, slots=True)
+class SidecarReady:
+    protocol: str
+    host: str
+    port: int
+    nonce_sha256: str
+    process_id: int
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "event": "ready",
+                "protocol": self.protocol,
+                "host": self.host,
+                "port": self.port,
+                "nonce_sha256": self.nonce_sha256,
+                "process_id": self.process_id,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+
+def read_startup_envelope(stream: TextIO) -> SidecarStartup:
+    line = stream.readline(MAX_STARTUP_BYTES + 1)
+    if not line:
+        raise SidecarStartupError("startup envelope is required")
+    if len(line.encode("utf-8")) > MAX_STARTUP_BYTES:
+        raise SidecarStartupError("startup envelope exceeds size limit")
+    if not line.endswith("\n"):
+        raise SidecarStartupError("startup envelope must be newline terminated")
+
+    try:
+        payload = json.loads(line)
+    except json.JSONDecodeError as exc:
+        raise SidecarStartupError("startup envelope must be valid JSON") from exc
+    if not isinstance(payload, dict):
+        raise SidecarStartupError("startup envelope must be an object")
+    if set(payload) != {"protocol", "secret", "nonce"}:
+        raise SidecarStartupError("startup envelope contains unexpected fields")
+
+    protocol = _required_text(payload.get("protocol"), "protocol", minimum=1, maximum=64)
+    secret = _required_text(payload.get("secret"), "secret", minimum=32, maximum=256)
+    nonce = _required_text(payload.get("nonce"), "nonce", minimum=32, maximum=256)
+    if protocol != PROTOCOL_VERSION:
+        raise SidecarStartupError("unsupported sidecar protocol")
+    if hmac.compare_digest(secret, nonce):
+        raise SidecarStartupError("secret and nonce must be distinct")
+    return SidecarStartup(protocol=protocol, secret=secret, nonce=nonce)
+
+
+def _required_text(value: Any, field: str, *, minimum: int, maximum: int) -> str:
+    if not isinstance(value, str):
+        raise SidecarStartupError(f"{field} must be text")
+    if value != value.strip():
+        raise SidecarStartupError(f"{field} must not contain surrounding whitespace")
+    if not minimum <= len(value) <= maximum:
+        raise SidecarStartupError(
+            f"{field} length must be between {minimum} and {maximum} characters"
+        )
+    if any(ord(character) < 33 or ord(character) > 126 for character in value):
+        raise SidecarStartupError(f"{field} must contain printable ASCII without spaces")
+    return value
+
+
+class _SidecarHTTPServer(ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = False
+
+    def __init__(self, startup: SidecarStartup) -> None:
+        self.startup = startup
+        self.shutdown_requested = threading.Event()
+        super().__init__(("127.0.0.1", 0), _SidecarRequestHandler)
+
+
+class _SidecarRequestHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    server_version = "APPLAYLISTSidecar"
+    sys_version = ""
+
+    @property
+    def sidecar_server(self) -> _SidecarHTTPServer:
+        server = self.server
+        if not isinstance(server, _SidecarHTTPServer):
+            raise RuntimeError("invalid sidecar server")
+        return server
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path != "/v1/health":
+            self._write_json(HTTPStatus.NOT_FOUND, {"error": "not_found"})
+            return
+        if not self._authorized():
+            self._write_json(HTTPStatus.UNAUTHORIZED, {"error": "unauthorized"})
+            return
+        self._write_json(
+            HTTPStatus.OK,
+            {
+                "status": "ready",
+                "protocol": PROTOCOL_VERSION,
+                "nonce_sha256": _sha256(self.sidecar_server.startup.nonce),
+            },
+        )
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path != "/v1/shutdown":
+            self._write_json(HTTPStatus.NOT_FOUND, {"error": "not_found"})
+            return
+        if not self._authorized():
+            self._write_json(HTTPStatus.UNAUTHORIZED, {"error": "unauthorized"})
+            return
+        if not self._empty_body():
+            self._write_json(HTTPStatus.BAD_REQUEST, {"error": "body_not_allowed"})
+            return
+
+        self.sidecar_server.shutdown_requested.set()
+        self._write_json(HTTPStatus.ACCEPTED, {"status": "shutting_down"})
+        threading.Thread(
+            target=self.sidecar_server.shutdown,
+            name="applaylist-sidecar-shutdown",
+            daemon=True,
+        ).start()
+
+    def do_PUT(self) -> None:  # noqa: N802
+        self._method_not_allowed()
+
+    def do_DELETE(self) -> None:  # noqa: N802
+        self._method_not_allowed()
+
+    def do_PATCH(self) -> None:  # noqa: N802
+        self._method_not_allowed()
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+    def _authorized(self) -> bool:
+        secret = self.headers.get(SECRET_HEADER)
+        nonce = self.headers.get(NONCE_HEADER)
+        if secret is None or nonce is None:
+            return False
+        if len(secret) > MAX_HEADER_BYTES or len(nonce) > MAX_HEADER_BYTES:
+            return False
+        startup = self.sidecar_server.startup
+        return hmac.compare_digest(secret, startup.secret) and hmac.compare_digest(
+            nonce, startup.nonce
+        )
+
+    def _empty_body(self) -> bool:
+        raw_length = self.headers.get("Content-Length", "0")
+        try:
+            length = int(raw_length)
+        except ValueError:
+            return False
+        if length != 0:
+            if 0 < length <= MAX_STARTUP_BYTES:
+                self.rfile.read(length)
+            return False
+        return True
+
+    def _method_not_allowed(self) -> None:
+        self._write_json(HTTPStatus.METHOD_NOT_ALLOWED, {"error": "method_not_allowed"})
+
+    def _write_json(self, status: HTTPStatus, payload: dict[str, object]) -> None:
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        self.send_response(status.value)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(encoded)
+        self.close_connection = True
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("ascii")).hexdigest()
+
+
+def run_sidecar(
+    *,
+    stdin: TextIO = sys.stdin,
+    stdout: TextIO = sys.stdout,
+    stderr: TextIO = sys.stderr,
+) -> int:
+    try:
+        startup = read_startup_envelope(stdin)
+    except SidecarStartupError as exc:
+        print(
+            json.dumps({"event": "startup_error", "error": str(exc)}, sort_keys=True),
+            file=stderr,
+            flush=True,
+        )
+        return 2
+
+    server = _SidecarHTTPServer(startup)
+    host, port = server.server_address
+    ready = SidecarReady(
+        protocol=PROTOCOL_VERSION,
+        host=str(host),
+        port=int(port),
+        nonce_sha256=_sha256(startup.nonce),
+        process_id=_process_id(),
+    )
+    print(ready.to_json(), file=stdout, flush=True)
+
+    stop_requested = threading.Event()
+
+    def request_stop(_signum: int, _frame: object) -> None:
+        if stop_requested.is_set():
+            return
+        stop_requested.set()
+        threading.Thread(target=server.shutdown, daemon=True).start()
+
+    previous_sigterm = signal.signal(signal.SIGTERM, request_stop)
+    previous_sigint = signal.signal(signal.SIGINT, request_stop)
+    try:
+        server.serve_forever(poll_interval=0.1)
+    finally:
+        server.server_close()
+        signal.signal(signal.SIGTERM, previous_sigterm)
+        signal.signal(signal.SIGINT, previous_sigint)
+    return 0
+
+
+def _process_id() -> int:
+    import os
+
+    return os.getpid()
+
+
+def main() -> int:
+    return run_sidecar()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_desktop_readiness_sidecar.py
+++ b/tests/test_desktop_readiness_sidecar.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+import pytest
+
+from services.desktop.sidecar import PROTOCOL_VERSION, read_startup_envelope
+
+
+SECRET = "S" * 48
+NONCE = "N" * 48
+
+
+def _start_sidecar(*, secret: str = SECRET, nonce: str = NONCE) -> tuple[subprocess.Popen[str], dict]:
+    process = subprocess.Popen(
+        [sys.executable, "-m", "services.desktop.sidecar"],
+        cwd=Path(__file__).resolve().parents[1],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        bufsize=1,
+        env={**os.environ, "PYTHONUNBUFFERED": "1"},
+    )
+    assert process.stdin is not None
+    assert process.stdout is not None
+    process.stdin.write(
+        json.dumps(
+            {"protocol": PROTOCOL_VERSION, "secret": secret, "nonce": nonce},
+            separators=(",", ":"),
+        )
+        + "\n"
+    )
+    process.stdin.flush()
+    ready_line = process.stdout.readline()
+    if not ready_line:
+        stderr = process.stderr.read() if process.stderr is not None else ""
+        raise AssertionError(f"sidecar did not become ready: {stderr}")
+    return process, json.loads(ready_line)
+
+
+def _request(
+    ready: dict,
+    *,
+    method: str,
+    path: str,
+    secret: str = SECRET,
+    nonce: str = NONCE,
+    body: bytes | None = None,
+) -> tuple[int, dict]:
+    request = Request(
+        f"http://127.0.0.1:{ready['port']}{path}",
+        data=body,
+        method=method,
+        headers={
+            "X-APPLAYLIST-Sidecar-Secret": secret,
+            "X-APPLAYLIST-Readiness-Nonce": nonce,
+        },
+    )
+    try:
+        with urlopen(request, timeout=3) as response:  # noqa: S310 - fixed loopback URL
+            return response.status, json.loads(response.read().decode("utf-8"))
+    except HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode("utf-8"))
+
+
+def _finish(process: subprocess.Popen[str], *, timeout: float = 5.0) -> tuple[str, str]:
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        stdout, stderr = process.communicate(timeout=timeout)
+        raise AssertionError("sidecar did not terminate within timeout")
+    return stdout, stderr
+
+
+def test_startup_envelope_is_strict_and_does_not_accept_extra_fields() -> None:
+    from io import StringIO
+
+    valid = read_startup_envelope(
+        StringIO(
+            json.dumps(
+                {"protocol": PROTOCOL_VERSION, "secret": SECRET, "nonce": NONCE}
+            )
+            + "\n"
+        )
+    )
+    assert valid.secret == SECRET
+
+    with pytest.raises(ValueError, match="unexpected fields"):
+        read_startup_envelope(
+            StringIO(
+                json.dumps(
+                    {
+                        "protocol": PROTOCOL_VERSION,
+                        "secret": SECRET,
+                        "nonce": NONCE,
+                        "port": 8000,
+                    }
+                )
+                + "\n"
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    ("secret", "nonce"),
+    [
+        ("short", NONCE),
+        (SECRET, "short"),
+        (SECRET, SECRET),
+        (SECRET + " ", NONCE),
+    ],
+)
+def test_invalid_startup_fails_without_disclosing_credentials(secret: str, nonce: str) -> None:
+    process = subprocess.run(
+        [sys.executable, "-m", "services.desktop.sidecar"],
+        cwd=Path(__file__).resolve().parents[1],
+        input=json.dumps(
+            {"protocol": PROTOCOL_VERSION, "secret": secret, "nonce": nonce}
+        )
+        + "\n",
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=5,
+        check=False,
+    )
+
+    assert process.returncode == 2
+    assert '"event": "startup_error"' in process.stderr
+    assert secret not in process.stderr
+    assert nonce not in process.stderr
+
+
+def test_sidecar_authentication_health_and_shutdown_are_fail_closed() -> None:
+    process, ready = _start_sidecar()
+    try:
+        assert ready["event"] == "ready"
+        assert ready["protocol"] == PROTOCOL_VERSION
+        assert ready["host"] == "127.0.0.1"
+        assert isinstance(ready["port"], int) and ready["port"] > 0
+        assert ready["nonce_sha256"] == hashlib.sha256(NONCE.encode("ascii")).hexdigest()
+        assert SECRET not in json.dumps(ready)
+        assert NONCE not in json.dumps(ready)
+        assert SECRET not in " ".join(process.args)
+        assert NONCE not in " ".join(process.args)
+
+        status, payload = _request(
+            ready,
+            method="GET",
+            path="/v1/health",
+            secret="X" * 48,
+        )
+        assert status == 401
+        assert payload == {"error": "unauthorized"}
+
+        status, payload = _request(
+            ready,
+            method="GET",
+            path="/v1/health",
+            nonce="Y" * 48,
+        )
+        assert status == 401
+        assert payload == {"error": "unauthorized"}
+
+        status, payload = _request(ready, method="GET", path="/v1/health")
+        assert status == 200
+        assert payload == {
+            "nonce_sha256": hashlib.sha256(NONCE.encode("ascii")).hexdigest(),
+            "protocol": PROTOCOL_VERSION,
+            "status": "ready",
+        }
+
+        status, payload = _request(
+            ready,
+            method="POST",
+            path="/v1/shutdown",
+            body=b"not-allowed",
+        )
+        assert status == 400
+        assert payload == {"error": "body_not_allowed"}
+        assert process.poll() is None
+
+        status, payload = _request(ready, method="POST", path="/v1/shutdown")
+        assert status == 202
+        assert payload == {"status": "shutting_down"}
+
+        stdout, stderr = _finish(process)
+        assert process.returncode == 0
+        assert SECRET not in stdout + stderr
+        assert NONCE not in stdout + stderr
+    finally:
+        if process.poll() is None:
+            process.kill()
+            _finish(process)
+
+
+def test_unknown_route_and_method_do_not_expose_server_details() -> None:
+    process, ready = _start_sidecar()
+    try:
+        status, payload = _request(ready, method="GET", path="/unknown")
+        assert status == 404
+        assert payload == {"error": "not_found"}
+
+        status, payload = _request(ready, method="PUT", path="/v1/health")
+        assert status == 405
+        assert payload == {"error": "method_not_allowed"}
+
+        status, _ = _request(ready, method="POST", path="/v1/shutdown")
+        assert status == 202
+        deadline = time.monotonic() + 5
+        while process.poll() is None and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert process.poll() == 0
+    finally:
+        if process.poll() is None:
+            process.kill()
+            _finish(process)


### PR DESCRIPTION
## Summary
- add a strict standard-library Python readiness sidecar for the future Tauri supervisor
- accept one bounded startup envelope through stdin only
- bind exclusively to `127.0.0.1` on an OS-selected ephemeral port
- expose only authenticated health and shutdown operations
- keep raw secret and nonce out of argv, readiness output and captured logs
- add negative-auth, malformed-startup, health and graceful-shutdown process tests
- pin PyInstaller 6.21.0 under an isolated desktop-build optional dependency
- add target-native Linux/macOS onedir package build and smoke proof
- add operator guide, schema tree and rollback evidence

## Verification
- branch content created directly from canonical head `e498e93db2873723ad26dba3ea686db5f3a4a930`
- ahead-only diff limited to sidecar code, tests, packaging workflow/scripts, one optional dependency and documentation
- full Python 3.11/3.12 CI, PR Guard and Linux/macOS packaged sidecar proof are required

## Isolation
- no React, Tauri or Rust runtime yet
- no renderer-to-sidecar networking
- no arbitrary shell/filesystem authority
- no product API, DB, MIR, composition or export activation
- no code-signing or production-distribution claim

## Bundle Context
- Bundle: 48 — authenticated Python sidecar proof (first isolated implementation slice)
- Parent issue: #78
- Implementation issue: #81
- Base commit: `e498e93db2873723ad26dba3ea686db5f3a4a930`
- Next: minimal Tauri/React supervisor, typed commands and opaque native folder capability
- Rollback: revert one isolated squash commit