### PR TITLE
Add inactive canonical analysis persistence repository

### DIFF
--- a/data/models/canonical_analysis_record.py
+++ b/data/models/canonical_analysis_record.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from core.analysis.contracts import CanonicalAnalysisResult
+
+
+class CanonicalAnalysisMappingError(ValueError):
+    """The canonical result cannot be persisted without inventing data."""
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalAnalysisPersistenceRecord:
+    track_id: str
+    provider: str
+    provider_version: str | None
+    canonical_analysis_version: str
+    source_analysis_version: str | None
+    bpm: float | None
+    bpm_confidence: float | None
+    key: str | None
+    key_confidence: float | None
+    key_system: str | None
+    energy: float | None
+    energy_confidence: float | None
+    loudness_db: float | None
+    loudness_integrated_lufs: float | None
+    duration_seconds: float | None
+    sample_rate_hz: int | None
+    channels: int | None
+    genre_hint: str | None
+    analysis_status: str
+    analyzed_at: str | None
+    warnings_json: str
+    persisted_at: str | None = None
+
+    def warnings(self) -> tuple[str, ...]:
+        value = json.loads(self.warnings_json)
+        if not isinstance(value, list) or not all(
+            isinstance(item, str) for item in value
+        ):
+            raise CanonicalAnalysisMappingError(
+                "warnings_json must contain a JSON string array"
+            )
+        return tuple(value)
+
+
+def _required_text(value: Any, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise CanonicalAnalysisMappingError(
+            f"{field_name} must be a non-empty string"
+        )
+    return value
+
+
+def map_canonical_analysis_to_persistence(
+    result: CanonicalAnalysisResult,
+) -> CanonicalAnalysisPersistenceRecord:
+    if not isinstance(result, CanonicalAnalysisResult):
+        raise TypeError("result must be CanonicalAnalysisResult")
+
+    warnings = tuple(result.warnings)
+    if not all(isinstance(item, str) for item in warnings):
+        raise CanonicalAnalysisMappingError(
+            "warnings must contain only strings"
+        )
+
+    return CanonicalAnalysisPersistenceRecord(
+        track_id=_required_text(result.track_id, "track_id"),
+        provider=_required_text(result.provider, "provider"),
+        provider_version=result.provider_version,
+        canonical_analysis_version=_required_text(
+            result.analysis_version,
+            "analysis_version",
+        ),
+        source_analysis_version=result.source_analysis_version,
+        bpm=result.bpm,
+        bpm_confidence=result.bpm_confidence,
+        key=result.key,
+        key_confidence=result.key_confidence,
+        key_system=result.key_system,
+        energy=result.energy,
+        energy_confidence=result.energy_confidence,
+        loudness_db=result.loudness_db,
+        loudness_integrated_lufs=result.loudness_integrated_lufs,
+        duration_seconds=result.duration_seconds,
+        sample_rate_hz=result.sample_rate_hz,
+        channels=result.channels,
+        genre_hint=result.genre_hint,
+        analysis_status=_required_text(
+            result.analysis_status,
+            "analysis_status",
+        ),
+        analyzed_at=result.analyzed_at,
+        warnings_json=json.dumps(
+            warnings,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ),
+    )

--- a/data/repositories/__init__.py
+++ b/data/repositories/__init__.py
@@ -1,0 +1,11 @@
+from data.repositories.canonical_analysis_repository import (
+    CanonicalAnalysisRepository as CanonicalAnalysisRepository,
+)
+from data.repositories.canonical_analysis_repository import (
+    CanonicalAnalysisRepositoryError as CanonicalAnalysisRepositoryError,
+)
+
+__all__ = [
+    "CanonicalAnalysisRepository",
+    "CanonicalAnalysisRepositoryError",
+]

--- a/data/repositories/canonical_analysis_repository.py
+++ b/data/repositories/canonical_analysis_repository.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from dataclasses import fields
+from typing import Any
+
+from data.connection import get_sqlite_connection
+from data.models.canonical_analysis_record import (
+    CanonicalAnalysisPersistenceRecord,
+)
+
+ConnectionFactory = Callable[[], sqlite3.Connection]
+
+
+class CanonicalAnalysisRepositoryError(RuntimeError):
+    def __init__(self, operation: str, message: str) -> None:
+        self.operation = operation
+        super().__init__(f"canonical analysis {operation} failed: {message}")
+
+
+class CanonicalAnalysisRepository:
+    def __init__(
+        self,
+        connection_factory: ConnectionFactory = get_sqlite_connection,
+    ) -> None:
+        self._connection_factory = connection_factory
+
+    def upsert(self, record: CanonicalAnalysisPersistenceRecord) -> None:
+        if not isinstance(record, CanonicalAnalysisPersistenceRecord):
+            raise TypeError(
+                "record must be CanonicalAnalysisPersistenceRecord"
+            )
+
+        conn = self._connection_factory()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """
+                INSERT INTO canonical_analyses (
+                    track_id,
+                    provider,
+                    provider_version,
+                    canonical_analysis_version,
+                    source_analysis_version,
+                    bpm,
+                    bpm_confidence,
+                    key,
+                    key_confidence,
+                    key_system,
+                    energy,
+                    energy_confidence,
+                    loudness_db,
+                    loudness_integrated_lufs,
+                    duration_seconds,
+                    sample_rate_hz,
+                    channels,
+                    genre_hint,
+                    analysis_status,
+                    analyzed_at,
+                    warnings_json
+                ) VALUES (
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+                )
+                ON CONFLICT(track_id) DO UPDATE SET
+                    provider = excluded.provider,
+                    provider_version = excluded.provider_version,
+                    canonical_analysis_version =
+                        excluded.canonical_analysis_version,
+                    source_analysis_version =
+                        excluded.source_analysis_version,
+                    bpm = excluded.bpm,
+                    bpm_confidence = excluded.bpm_confidence,
+                    key = excluded.key,
+                    key_confidence = excluded.key_confidence,
+                    key_system = excluded.key_system,
+                    energy = excluded.energy,
+                    energy_confidence = excluded.energy_confidence,
+                    loudness_db = excluded.loudness_db,
+                    loudness_integrated_lufs =
+                        excluded.loudness_integrated_lufs,
+                    duration_seconds = excluded.duration_seconds,
+                    sample_rate_hz = excluded.sample_rate_hz,
+                    channels = excluded.channels,
+                    genre_hint = excluded.genre_hint,
+                    analysis_status = excluded.analysis_status,
+                    analyzed_at = excluded.analyzed_at,
+                    warnings_json = excluded.warnings_json,
+                    persisted_at = CURRENT_TIMESTAMP
+                """,
+                (
+                    record.track_id,
+                    record.provider,
+                    record.provider_version,
+                    record.canonical_analysis_version,
+                    record.source_analysis_version,
+                    record.bpm,
+                    record.bpm_confidence,
+                    record.key,
+                    record.key_confidence,
+                    record.key_system,
+                    record.energy,
+                    record.energy_confidence,
+                    record.loudness_db,
+                    record.loudness_integrated_lufs,
+                    record.duration_seconds,
+                    record.sample_rate_hz,
+                    record.channels,
+                    record.genre_hint,
+                    record.analysis_status,
+                    record.analyzed_at,
+                    record.warnings_json,
+                ),
+            )
+            conn.commit()
+        except Exception as exc:
+            try:
+                conn.rollback()
+            except sqlite3.Error:
+                pass
+            raise CanonicalAnalysisRepositoryError(
+                "upsert",
+                str(exc),
+            ) from exc
+        finally:
+            conn.close()
+
+    def get(
+        self,
+        track_id: str,
+    ) -> CanonicalAnalysisPersistenceRecord | None:
+        conn = self._connection_factory()
+        try:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                """
+                SELECT
+                    track_id,
+                    provider,
+                    provider_version,
+                    canonical_analysis_version,
+                    source_analysis_version,
+                    bpm,
+                    bpm_confidence,
+                    key,
+                    key_confidence,
+                    key_system,
+                    energy,
+                    energy_confidence,
+                    loudness_db,
+                    loudness_integrated_lufs,
+                    duration_seconds,
+                    sample_rate_hz,
+                    channels,
+                    genre_hint,
+                    analysis_status,
+                    analyzed_at,
+                    warnings_json,
+                    persisted_at
+                FROM canonical_analyses
+                WHERE track_id = ?
+                """,
+                (track_id,),
+            ).fetchone()
+        except Exception as exc:
+            raise CanonicalAnalysisRepositoryError(
+                "get",
+                str(exc),
+            ) from exc
+        finally:
+            conn.close()
+
+        if row is None:
+            return None
+
+        allowed = {
+            field.name
+            for field in fields(CanonicalAnalysisPersistenceRecord)
+        }
+        payload: dict[str, Any] = {
+            key: row[key]
+            for key in row.keys()
+            if key in allowed
+        }
+        return CanonicalAnalysisPersistenceRecord(**payload)
+
+    def exists(self, track_id: str) -> bool:
+        conn = self._connection_factory()
+        try:
+            row = conn.execute(
+                """
+                SELECT 1
+                FROM canonical_analyses
+                WHERE track_id = ?
+                """,
+                (track_id,),
+            ).fetchone()
+        except Exception as exc:
+            raise CanonicalAnalysisRepositoryError(
+                "exists",
+                str(exc),
+            ) from exc
+        finally:
+            conn.close()
+
+        return row is not None

--- a/tests/unit/test_canonical_analysis_persistence_mapper.py
+++ b/tests/unit/test_canonical_analysis_persistence_mapper.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pytest
+
+from core.analysis.contracts import CanonicalAnalysisResult
+from data.models.canonical_analysis_record import (
+    CanonicalAnalysisMappingError,
+    map_canonical_analysis_to_persistence,
+)
+
+
+def _canonical_result() -> CanonicalAnalysisResult:
+    return CanonicalAnalysisResult(
+        path="/private/audio/track.wav",
+        provider="essentia",
+        bpm=128.0,
+        bpm_confidence=None,
+        key="Am",
+        key_confidence=0.91,
+        key_system="traditional",
+        energy=0.72,
+        energy_confidence=None,
+        loudness_db=-9.5,
+        loudness_integrated_lufs=-10.1,
+        duration_seconds=245.5,
+        sample_rate_hz=44100,
+        channels=2,
+        genre_hint="techno",
+        analysis_status="complete",
+        analysis_version="canonical-mir-v1",
+        source_analysis_version="essentia-profile-v1",
+        provider_version="2.1",
+        analyzed_at="2026-08-01T20:00:00+00:00",
+        track_id="track-1",
+        warnings=("zeta", "alpha"),
+        raw_provider_fields={"provider_only": 123},
+    )
+
+
+def test_mapper_preserves_every_supported_persistence_field() -> None:
+    record = map_canonical_analysis_to_persistence(_canonical_result())
+
+    assert record.track_id == "track-1"
+    assert record.provider == "essentia"
+    assert record.provider_version == "2.1"
+    assert record.canonical_analysis_version == "canonical-mir-v1"
+    assert record.source_analysis_version == "essentia-profile-v1"
+    assert record.bpm == 128.0
+    assert record.bpm_confidence is None
+    assert record.key == "Am"
+    assert record.key_confidence == 0.91
+    assert record.key_system == "traditional"
+    assert record.energy == 0.72
+    assert record.energy_confidence is None
+    assert record.loudness_db == -9.5
+    assert record.loudness_integrated_lufs == -10.1
+    assert record.duration_seconds == 245.5
+    assert record.sample_rate_hz == 44100
+    assert record.channels == 2
+    assert record.genre_hint == "techno"
+    assert record.analysis_status == "complete"
+    assert record.analyzed_at == "2026-08-01T20:00:00+00:00"
+
+
+def test_mapper_preserves_missing_confidence_as_none() -> None:
+    record = map_canonical_analysis_to_persistence(_canonical_result())
+
+    assert record.bpm_confidence is None
+    assert record.energy_confidence is None
+
+
+def test_warnings_json_is_deterministic_and_round_trips() -> None:
+    first = map_canonical_analysis_to_persistence(_canonical_result())
+    second = map_canonical_analysis_to_persistence(_canonical_result())
+
+    assert first.warnings_json == second.warnings_json
+    assert first.warnings_json == '["zeta","alpha"]'
+    assert json.loads(first.warnings_json) == ["zeta", "alpha"]
+    assert first.warnings() == ("zeta", "alpha")
+
+
+def test_mapper_rejects_missing_track_id() -> None:
+    result = replace(_canonical_result(), track_id=None)
+
+    with pytest.raises(
+        CanonicalAnalysisMappingError,
+        match="track_id",
+    ):
+        map_canonical_analysis_to_persistence(result)
+
+
+def test_mapper_rejects_untyped_payload() -> None:
+    with pytest.raises(TypeError):
+        map_canonical_analysis_to_persistence(  # type: ignore[arg-type]
+            {"track_id": "wrong"}
+        )

--- a/tests/unit/test_canonical_analysis_repository.py
+++ b/tests/unit/test_canonical_analysis_repository.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from data.migrations.versions.v001_canonical_analyses import (
+    apply_v001_canonical_analyses,
+)
+from data.models.canonical_analysis_record import (
+    CanonicalAnalysisPersistenceRecord,
+)
+from data.repositories.canonical_analysis_repository import (
+    CanonicalAnalysisRepository,
+    CanonicalAnalysisRepositoryError,
+)
+
+
+def _create_v1_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE analyses (
+                track_id TEXT PRIMARY KEY,
+                payload TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO analyses (track_id, payload)
+            VALUES (?, ?)
+            """,
+            ("legacy-1", "unchanged"),
+        )
+        apply_v001_canonical_analyses(conn)
+        conn.execute("PRAGMA user_version = 1")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _factory(path: Path):
+    def connect() -> sqlite3.Connection:
+        return sqlite3.connect(path)
+
+    return connect
+
+
+def _record(
+    *,
+    track_id: str = "track-1",
+    bpm: float | None = 128.0,
+) -> CanonicalAnalysisPersistenceRecord:
+    return CanonicalAnalysisPersistenceRecord(
+        track_id=track_id,
+        provider="essentia",
+        provider_version="2.1",
+        canonical_analysis_version="canonical-mir-v1",
+        source_analysis_version="essentia-profile-v1",
+        bpm=bpm,
+        bpm_confidence=None,
+        key="Am",
+        key_confidence=0.9,
+        key_system="traditional",
+        energy=0.7,
+        energy_confidence=None,
+        loudness_db=-9.0,
+        loudness_integrated_lufs=-10.0,
+        duration_seconds=240.0,
+        sample_rate_hz=44100,
+        channels=2,
+        genre_hint="techno",
+        analysis_status="complete",
+        analyzed_at="2026-08-01T20:00:00+00:00",
+        warnings_json='["warning"]',
+    )
+
+
+def _legacy_payload(path: Path) -> tuple[str, str]:
+    conn = sqlite3.connect(path)
+    try:
+        row = conn.execute(
+            """
+            SELECT track_id, payload
+            FROM analyses
+            ORDER BY track_id
+            """
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None
+    return row
+
+
+def test_insert_get_exists_round_trip_and_legacy_unchanged(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "repo.sqlite3"
+    _create_v1_db(db)
+    legacy_before = _legacy_payload(db)
+
+    repo = CanonicalAnalysisRepository(_factory(db))
+    expected = _record()
+    repo.upsert(expected)
+
+    assert repo.exists("track-1") is True
+    actual = repo.get("track-1")
+    assert actual is not None
+    assert actual.track_id == expected.track_id
+    assert actual.bpm == expected.bpm
+    assert actual.bpm_confidence is None
+    assert actual.warnings_json == expected.warnings_json
+    assert _legacy_payload(db) == legacy_before
+
+
+def test_upsert_updates_same_track_without_duplicate(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "repo.sqlite3"
+    _create_v1_db(db)
+    repo = CanonicalAnalysisRepository(_factory(db))
+
+    repo.upsert(_record(bpm=128.0))
+    repo.upsert(_record(bpm=130.0))
+
+    conn = sqlite3.connect(db)
+    try:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM canonical_analyses"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert count == 1
+    actual = repo.get("track-1")
+    assert actual is not None
+    assert actual.bpm == 130.0
+
+
+def test_repository_rejects_wrong_payload(tmp_path: Path) -> None:
+    db = tmp_path / "repo.sqlite3"
+    _create_v1_db(db)
+    repo = CanonicalAnalysisRepository(_factory(db))
+
+    with pytest.raises(TypeError):
+        repo.upsert({"track_id": "wrong"})  # type: ignore[arg-type]
+
+
+def test_transaction_rolls_back_on_injected_commit_failure(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "repo.sqlite3"
+    _create_v1_db(db)
+
+    class FailingCommitConnection(sqlite3.Connection):
+        def commit(self) -> None:
+            raise sqlite3.OperationalError(
+                "injected commit failure"
+            )
+
+    def failing_factory() -> sqlite3.Connection:
+        return sqlite3.connect(
+            db,
+            factory=FailingCommitConnection,
+        )
+
+    repo = CanonicalAnalysisRepository(failing_factory)
+
+    with pytest.raises(CanonicalAnalysisRepositoryError) as error:
+        repo.upsert(_record())
+
+    assert error.value.operation == "upsert"
+
+    conn = sqlite3.connect(db)
+    try:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM canonical_analyses"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert count == 0


### PR DESCRIPTION
## Scope

Implements WB003C5 as an isolated repository-only canonical persistence layer stacked on WB003C4.

### Added

- canonical persistence DTO
- canonical result → persistence mapper
- canonical repository with `upsert`, `get_by_track_id`, and `exists`
- deterministic warnings JSON handling
- transaction rollback coverage
- focused unit tests

### Verified locally

- targeted persistence tests: 9 passed
- full test suite: 184 passed
- Ruff differential gate: pass
- mypy differential gate: pass
- security gate: pass
- backup/restore smoke: pass
- clean post-commit `make verify`: pass
- worktree clean
- live DB unchanged
- `canonical_analyses` remains empty

### Explicit non-goals

- no runtime call site
- no live DB write
- no backfill
- no canonical writer activation
- no canonical reader activation
- no shadow write activation
- no public API change
- no Transition Intelligence activation
- WB006D remains on hold

## Runtime state

`RUNTIME_AUTHORITY=NONE`

`TRANSITION_INTELLIGENCE_ACTIVATION=NONE`

`WB006D=HOLD`

## Commit

`3f0f3f465b66bbdd58a58cedd336f2feb1d19c39`