### PR TITLE
Add default-off canonical shadow writer runtime integration

### DIFF
--- a/core/analysis/canonical_writer_feature_flags.py
+++ b/core/analysis/canonical_writer_feature_flags.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+_TRUE_VALUES = {"1", "true", "yes", "on", "enabled"}
+_FALSE_VALUES = {"0", "false", "no", "off", "disabled", ""}
+
+
+def canonical_writer_enabled(
+    env: Mapping[str, str] | None = None,
+) -> bool:
+    """Return whether the non-authoritative canonical writer is enabled.
+
+    Missing, false-like, or invalid values fail closed to disabled.
+    """
+
+    source = os.environ if env is None else env
+    value = source.get(
+        "APPLAYLIST_CANONICAL_WRITER_ENABLED",
+        "0",
+    ).strip().lower()
+
+    if value in _TRUE_VALUES:
+        return True
+
+    if value in _FALSE_VALUES:
+        return False
+
+    return False

--- a/services/analysis/provider_analysis_service.py
+++ b/services/analysis/provider_analysis_service.py
@@ -1,18 +1,48 @@
 from __future__ import annotations
 
+import logging
+from collections.abc import Iterable, Mapping
 from pathlib import Path
-from typing import Iterable
+from typing import Protocol
 
+from core.analysis.canonical_writer_feature_flags import (
+    canonical_writer_enabled,
+)
 from core.analysis.provider_contracts import ProviderOutput
 from core.analysis.provider_orchestrator import analyze_with_provider_selection
+from data.models.canonical_analysis_record import (
+    CanonicalAnalysisMappingError,
+    CanonicalAnalysisPersistenceRecord,
+    map_canonical_analysis_to_persistence,
+)
+from data.repositories.canonical_analysis_repository import (
+    CanonicalAnalysisRepository,
+    CanonicalAnalysisRepositoryError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CanonicalAnalysisWriter(Protocol):
+    def upsert(self, record: CanonicalAnalysisPersistenceRecord) -> None:
+        ...
 
 
 class ProviderAnalysisService:
-    """Optional provider-based analysis service.
+    """Optional provider analysis with a non-authoritative shadow writer."""
 
-    This service is a sidecar path.
-    It does not replace the existing AudioAnalyzer or API behavior yet.
-    """
+    def __init__(
+        self,
+        *,
+        canonical_writer: CanonicalAnalysisWriter | None = None,
+        canonical_writer_is_enabled: bool = False,
+    ) -> None:
+        if canonical_writer_is_enabled and canonical_writer is None:
+            raise ValueError(
+                "canonical_writer is required when canonical writer is enabled"
+            )
+        self._canonical_writer = canonical_writer
+        self._canonical_writer_is_enabled = canonical_writer_is_enabled
 
     def analyze(
         self,
@@ -24,7 +54,7 @@ class ProviderAnalysisService:
         safe_baseline: str = "baseline",
         provider_names: Iterable[str] | None = None,
     ) -> ProviderOutput:
-        return analyze_with_provider_selection(
+        output = analyze_with_provider_selection(
             track_id=track_id,
             path=path,
             requested_provider=requested_provider,
@@ -33,6 +63,48 @@ class ProviderAnalysisService:
             provider_names=provider_names,
         )
 
+        if self._canonical_writer_is_enabled:
+            self._write_canonical_result(output)
 
-def create_provider_analysis_service() -> ProviderAnalysisService:
-    return ProviderAnalysisService()
+        return output
+
+    def _write_canonical_result(self, output: ProviderOutput) -> None:
+        writer = self._canonical_writer
+        if writer is None:
+            raise RuntimeError("enabled canonical writer dependency is missing")
+
+        try:
+            record = map_canonical_analysis_to_persistence(
+                output.normalized,
+            )
+            writer.upsert(record)
+        except (
+            CanonicalAnalysisMappingError,
+            CanonicalAnalysisRepositoryError,
+        ) as exc:
+            logger.warning(
+                "canonical_writer_shadow_write_failed",
+                extra={
+                    "event_name": "canonical_writer_shadow_write_failed",
+                    "provider": output.provider,
+                    "track_id": output.normalized.track_id,
+                    "error_type": type(exc).__name__,
+                },
+            )
+
+
+def create_provider_analysis_service(
+    *,
+    env: Mapping[str, str] | None = None,
+    canonical_writer: CanonicalAnalysisWriter | None = None,
+) -> ProviderAnalysisService:
+    enabled = canonical_writer_enabled(env)
+    writer = canonical_writer
+
+    if enabled and writer is None:
+        writer = CanonicalAnalysisRepository()
+
+    return ProviderAnalysisService(
+        canonical_writer=writer,
+        canonical_writer_is_enabled=enabled,
+    )

--- a/services/analysis/routed_analysis_service.py
+++ b/services/analysis/routed_analysis_service.py
@@ -41,7 +41,9 @@ class RoutedAnalysisService:
         mode = provider_analysis_mode(env)
 
         if mode == "provider":
-            output = create_provider_analysis_service().analyze(
+            output = create_provider_analysis_service(
+                env=env,
+            ).analyze(
                 track_id=track_id,
                 path=path,
                 requested_provider=requested_provider,

--- a/tests/unit/test_canonical_writer_feature_flags.py
+++ b/tests/unit/test_canonical_writer_feature_flags.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from core.analysis.canonical_writer_feature_flags import (
+    canonical_writer_enabled,
+)
+
+
+def test_canonical_writer_defaults_disabled() -> None:
+    assert canonical_writer_enabled({}) is False
+
+
+def test_canonical_writer_enables_only_explicit_true_value() -> None:
+    assert canonical_writer_enabled(
+        {"APPLAYLIST_CANONICAL_WRITER_ENABLED": "1"}
+    ) is True
+
+
+def test_canonical_writer_invalid_value_fails_closed() -> None:
+    assert canonical_writer_enabled(
+        {"APPLAYLIST_CANONICAL_WRITER_ENABLED": "maybe"}
+    ) is False

--- a/tests/unit/test_provider_analysis_service.py
+++ b/tests/unit/test_provider_analysis_service.py
@@ -64,3 +64,81 @@ def test_provider_analysis_service_returns_controlled_error_when_no_provider_ava
         )
 
     assert exc_info.value.details.code == "provider_unavailable"
+
+
+class _RecordingCanonicalWriter:
+    def __init__(self) -> None:
+        self.records = []
+
+    def upsert(self, record) -> None:
+        self.records.append(record)
+
+
+class _FailingCanonicalWriter:
+    def upsert(self, record) -> None:
+        from data.repositories.canonical_analysis_repository import (
+            CanonicalAnalysisRepositoryError,
+        )
+
+        raise CanonicalAnalysisRepositoryError(
+            "upsert",
+            "injected test failure",
+        )
+
+
+def test_canonical_writer_disabled_does_not_write(tmp_path: Path) -> None:
+    audio_path = tmp_path / "writer-disabled.wav"
+    _write_test_tone(audio_path)
+    writer = _RecordingCanonicalWriter()
+
+    output = create_provider_analysis_service(
+        env={},
+        canonical_writer=writer,
+    ).analyze(
+        track_id="writer-disabled",
+        path=audio_path,
+        provider_names=["baseline"],
+    )
+
+    assert output.normalized.track_id == "writer-disabled"
+    assert writer.records == []
+
+
+def test_canonical_writer_enabled_writes_once(tmp_path: Path) -> None:
+    audio_path = tmp_path / "writer-enabled.wav"
+    _write_test_tone(audio_path)
+    writer = _RecordingCanonicalWriter()
+
+    output = create_provider_analysis_service(
+        env={"APPLAYLIST_CANONICAL_WRITER_ENABLED": "1"},
+        canonical_writer=writer,
+    ).analyze(
+        track_id="writer-enabled",
+        path=audio_path,
+        provider_names=["baseline"],
+    )
+
+    assert output.normalized.track_id == "writer-enabled"
+    assert len(writer.records) == 1
+    assert writer.records[0].track_id == "writer-enabled"
+
+
+def test_canonical_writer_failure_is_non_authoritative(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    audio_path = tmp_path / "writer-failure.wav"
+    _write_test_tone(audio_path)
+
+    with caplog.at_level("WARNING"):
+        output = create_provider_analysis_service(
+            env={"APPLAYLIST_CANONICAL_WRITER_ENABLED": "1"},
+            canonical_writer=_FailingCanonicalWriter(),
+        ).analyze(
+            track_id="writer-failure",
+            path=audio_path,
+            provider_names=["baseline"],
+        )
+
+    assert output.normalized.track_id == "writer-failure"
+    assert "canonical_writer_shadow_write_failed" in caplog.messages

--- a/tests/unit/test_routed_analysis_service.py
+++ b/tests/unit/test_routed_analysis_service.py
@@ -84,3 +84,20 @@ def test_invalid_flag_fails_closed_to_legacy(
 
     assert result.mode == "legacy"
     assert result.provider == "legacy"
+
+
+def test_routed_provider_mode_keeps_writer_disabled_by_default(
+    tmp_path: Path,
+) -> None:
+    audio_path = tmp_path / "provider-writer-default-off.wav"
+    _write_test_tone(audio_path)
+
+    result = create_routed_analysis_service().analyze(
+        track_id="provider-writer-default-off",
+        path=audio_path,
+        env={"APPLAYLIST_PROVIDER_ANALYSIS_ENABLED": "1"},
+        provider_names=["baseline"],
+    )
+
+    assert result.mode == "provider"
+    assert result.track_id == "provider-writer-default-off"

--- a/tools/quality/ruff-baseline.txt
+++ b/tools/quality/ruff-baseline.txt
@@ -1,5 +1,5 @@
-Found 151 errors.
-[*] 112 fixable with the `--fix` option (2 hidden fixes can be enabled with the `--unsafe-fixes` option).
+Found 150 errors.
+[*] 111 fixable with the `--fix` option (2 hidden fixes can be enabled with the `--unsafe-fixes` option).
 api/core/logging.py:1:1: I001 [*] Import block is un-sorted or un-formatted
 api/core/logging_setup.py:1:1: I001 [*] Import block is un-sorted or un-formatted
 api/middleware/rate_limit.py:16:21: UP006 [*] Use `collections.defaultdict` instead of `DefaultDict` for type annotation
@@ -118,7 +118,6 @@ services/analysis/analyzer.py:43:98: UP045 [*] Use `X | None` for type annotatio
 services/analysis/analyzer.py:48:101: E501 Line too long (107 > 100)
 services/analysis/analyzer.py:49:101: E501 Line too long (107 > 100)
 services/analysis/analyzer.py:88:9: F841 Local variable `zcr_mean` is assigned to but never used
-services/analysis/provider_analysis_service.py:4:1: UP035 [*] Import from `collections.abc` instead: `Iterable`
 services/export/exporter.py:58:101: E501 Line too long (102 > 100)
 services/export/exporter.py:59:101: E501 Line too long (102 > 100)
 services/export/exporter.py:5:1: UP035 [*] Import from `collections.abc` instead: `Iterable`


### PR DESCRIPTION
## Scope

WB004A adds one feature-flagged canonical writer call site to the provider analysis path.

- adds `APPLAYLIST_CANONICAL_WRITER_ENABLED`
- defaults OFF
- invalid values fail closed to disabled
- persists only newly completed provider analyses when explicitly enabled
- uses a single production writer call site
- keeps canonical persistence non-authoritative
- logs `canonical_writer_shadow_write_failed` on mapping/repository failure
- updates the Ruff differential baseline by removing one proven historical `UP035` finding

## Verified locally

- exact AST writer call-site count: 1
- production canonical reader call sites: 0
- targeted WB004A tests: 14 passed
- full regression: 191 passed
- doctor gate: PASS
- differential Ruff gate: PASS
- differential mypy gate: PASS
- security gate: PASS
- backup/restore smoke: PASS
- clean post-commit `make verify`: PASS
- live database SHA unchanged
- clean worktree

## Commit

`ca8592bae4934cff1a0166ae239c634b8eea07d1`

## Explicit non-goals

- no backfill
- no canonical reader activation
- no runtime authority switch
- no public API change
- no Transition Intelligence activation
- WB006D remains on hold

## Runtime state

- `CANONICAL_WRITER_DEFAULT=OFF`
- `CANONICAL_READER_ACTIVATION=NONE`
- `RUNTIME_AUTHORITY=NONE`
- `TRANSITION_INTELLIGENCE_ACTIVATION=NONE`
- `WB006D=HOLD`
