### PR TITLE
Canonical versus legacy comparison receipts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,8 @@ JWT_ALGORITHM=HS256
 # environment together with an explicit JSONL receipt path.
 APPLAYLIST_CANONICAL_WRITER_ENABLED=0
 APPLAYLIST_CANONICAL_WRITER_RECEIPTS_PATH=
+
+# Optional comparison evidence. This remains OFF unless the bounded non-live
+# canonical writer profile is enabled and both values below are explicit.
+APPLAYLIST_CANONICAL_COMPARISON_ENABLED=0
+APPLAYLIST_CANONICAL_COMPARISON_RECEIPTS_PATH=

--- a/core/analysis/canonical_legacy_comparison.py
+++ b/core/analysis/canonical_legacy_comparison.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from data.models.analysis_record import AnalysisRecord
+from data.models.canonical_analysis_record import (
+    CanonicalAnalysisPersistenceRecord,
+)
+
+BPM_ABSOLUTE_TOLERANCE = 1.0
+ENERGY_ABSOLUTE_TOLERANCE = 0.05
+DURATION_SECONDS_TOLERANCE = 0.05
+COMPARISON_SCHEMA_VERSION = "canonical-legacy-comparison-v1"
+
+
+class FieldComparisonStatus(StrEnum):
+    EXACT_MATCH = "exact_match"
+    WITHIN_TOLERANCE = "within_tolerance"
+    MISMATCH = "mismatch"
+    MISSING_LEGACY = "missing_legacy"
+    MISSING_CANONICAL = "missing_canonical"
+    NOT_COMPARABLE = "not_comparable"
+
+
+@dataclass(frozen=True, slots=True)
+class FieldComparison:
+    field: str
+    status: FieldComparisonStatus
+    legacy_value: str | float | None
+    canonical_value: str | float | None
+    absolute_delta: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalLegacyComparison:
+    track_id: str
+    provider: str
+    legacy_analysis_version: str
+    canonical_analysis_version: str
+    comparison_schema_version: str
+    fields: tuple[FieldComparison, ...]
+
+    @property
+    def mismatched_fields(self) -> tuple[str, ...]:
+        mismatch_statuses = {
+            FieldComparisonStatus.MISMATCH,
+            FieldComparisonStatus.MISSING_LEGACY,
+            FieldComparisonStatus.MISSING_CANONICAL,
+        }
+        return tuple(
+            item.field
+            for item in self.fields
+            if item.status in mismatch_statuses
+        )
+
+    @property
+    def matched_fields(self) -> tuple[str, ...]:
+        match_statuses = {
+            FieldComparisonStatus.EXACT_MATCH,
+            FieldComparisonStatus.WITHIN_TOLERANCE,
+        }
+        return tuple(
+            item.field
+            for item in self.fields
+            if item.status in match_statuses
+        )
+
+    @property
+    def outcome(self) -> str:
+        return "mismatch" if self.mismatched_fields else "succeeded"
+
+
+_CAMELOT_TO_KEY = {
+    "1A": "G# minor",
+    "2A": "D# minor",
+    "3A": "A# minor",
+    "4A": "F minor",
+    "5A": "C minor",
+    "6A": "G minor",
+    "7A": "D minor",
+    "8A": "A minor",
+    "9A": "E minor",
+    "10A": "B minor",
+    "11A": "F# minor",
+    "12A": "C# minor",
+    "1B": "B major",
+    "2B": "F# major",
+    "3B": "C# major",
+    "4B": "G# major",
+    "5B": "D# major",
+    "6B": "A# major",
+    "7B": "F major",
+    "8B": "C major",
+    "9B": "G major",
+    "10B": "D major",
+    "11B": "A major",
+    "12B": "E major",
+}
+
+_NOTE_ALIASES = {
+    "ab": "G#",
+    "a#": "A#",
+    "bb": "A#",
+    "c#": "C#",
+    "db": "C#",
+    "d#": "D#",
+    "eb": "D#",
+    "f#": "F#",
+    "gb": "F#",
+    "g#": "G#",
+}
+
+
+def _normalize_note(value: str) -> str:
+    stripped = value.strip()
+    if not stripped:
+        return ""
+    first = stripped[0].upper()
+    accidental = stripped[1:2]
+    raw_note = first + accidental
+    return _NOTE_ALIASES.get(raw_note.lower(), raw_note)
+
+
+def normalize_key(
+    key: str | None,
+    *,
+    scale: str | None = None,
+    camelot: str | None = None,
+) -> str | None:
+    if camelot:
+        mapped = _CAMELOT_TO_KEY.get(camelot.strip().upper())
+        if mapped is not None:
+            return mapped
+
+    if key is None or not key.strip():
+        return None
+
+    value = key.strip()
+    lowered = value.lower()
+    inferred_scale = scale.strip().lower() if scale else None
+
+    if lowered.endswith(" minor"):
+        inferred_scale = "minor"
+        value = value[:-6].strip()
+    elif lowered.endswith(" major"):
+        inferred_scale = "major"
+        value = value[:-6].strip()
+    elif lowered.endswith("min"):
+        inferred_scale = "minor"
+        value = value[:-3].strip()
+    elif lowered.endswith("maj"):
+        inferred_scale = "major"
+        value = value[:-3].strip()
+    elif lowered.endswith("m") and len(value) > 1:
+        inferred_scale = "minor"
+        value = value[:-1].strip()
+
+    note = _normalize_note(value)
+    if not note:
+        return None
+
+    mode = inferred_scale if inferred_scale in {"major", "minor"} else None
+    return f"{note} {mode}" if mode else note
+
+
+def _compare_numeric(
+    field: str,
+    legacy: float | None,
+    canonical: float | None,
+    tolerance: float,
+) -> FieldComparison:
+    if legacy is None and canonical is None:
+        return FieldComparison(
+            field=field,
+            status=FieldComparisonStatus.NOT_COMPARABLE,
+            legacy_value=None,
+            canonical_value=None,
+        )
+    if legacy is None:
+        return FieldComparison(
+            field=field,
+            status=FieldComparisonStatus.MISSING_LEGACY,
+            legacy_value=None,
+            canonical_value=canonical,
+        )
+    if canonical is None:
+        return FieldComparison(
+            field=field,
+            status=FieldComparisonStatus.MISSING_CANONICAL,
+            legacy_value=legacy,
+            canonical_value=None,
+        )
+
+    delta = abs(float(legacy) - float(canonical))
+    if delta == 0:
+        status = FieldComparisonStatus.EXACT_MATCH
+    elif delta <= tolerance:
+        status = FieldComparisonStatus.WITHIN_TOLERANCE
+    else:
+        status = FieldComparisonStatus.MISMATCH
+
+    return FieldComparison(
+        field=field,
+        status=status,
+        legacy_value=legacy,
+        canonical_value=canonical,
+        absolute_delta=delta,
+    )
+
+
+def _compare_key(
+    legacy: AnalysisRecord,
+    canonical: CanonicalAnalysisPersistenceRecord,
+) -> FieldComparison:
+    legacy_key = normalize_key(
+        legacy.key,
+        scale=legacy.scale,
+        camelot=legacy.camelot,
+    )
+    canonical_key = normalize_key(canonical.key)
+
+    if legacy_key is None and canonical_key is None:
+        status = FieldComparisonStatus.NOT_COMPARABLE
+    elif legacy_key is None:
+        status = FieldComparisonStatus.MISSING_LEGACY
+    elif canonical_key is None:
+        status = FieldComparisonStatus.MISSING_CANONICAL
+    elif legacy_key == canonical_key:
+        status = FieldComparisonStatus.EXACT_MATCH
+    else:
+        status = FieldComparisonStatus.MISMATCH
+
+    return FieldComparison(
+        field="key",
+        status=status,
+        legacy_value=legacy_key,
+        canonical_value=canonical_key,
+    )
+
+
+def compare_canonical_to_legacy(
+    legacy: AnalysisRecord,
+    canonical: CanonicalAnalysisPersistenceRecord,
+) -> CanonicalLegacyComparison:
+    if legacy.track_id != canonical.track_id:
+        raise ValueError("legacy and canonical track_id must match")
+
+    fields = (
+        _compare_numeric(
+            "bpm",
+            legacy.bpm,
+            canonical.bpm,
+            BPM_ABSOLUTE_TOLERANCE,
+        ),
+        _compare_numeric(
+            "bpm_confidence",
+            legacy.bpm_confidence,
+            canonical.bpm_confidence,
+            0.05,
+        ),
+        _compare_key(legacy, canonical),
+        _compare_numeric(
+            "energy",
+            legacy.energy,
+            canonical.energy,
+            ENERGY_ABSOLUTE_TOLERANCE,
+        ),
+        _compare_numeric(
+            "loudness_db",
+            legacy.loudness_db,
+            canonical.loudness_db,
+            0.5,
+        ),
+        _compare_numeric(
+            "duration_seconds",
+            legacy.duration_seconds,
+            canonical.duration_seconds,
+            DURATION_SECONDS_TOLERANCE,
+        ),
+    )
+
+    return CanonicalLegacyComparison(
+        track_id=legacy.track_id,
+        provider=canonical.provider,
+        legacy_analysis_version=legacy.analysis_version,
+        canonical_analysis_version=canonical.canonical_analysis_version,
+        comparison_schema_version=COMPARISON_SCHEMA_VERSION,
+        fields=fields,
+    )

--- a/core/analysis/canonical_legacy_comparison_profile.py
+++ b/core/analysis/canonical_legacy_comparison_profile.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+from core.analysis.canonical_writer_runtime_profile import (
+    CanonicalWriterRuntimeProfile,
+)
+
+_TRUE_VALUES = {"1", "true", "yes", "on", "enabled"}
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalLegacyComparisonProfile:
+    enabled: bool
+    receipts_path: Path | None
+    reason: str
+
+
+def resolve_canonical_legacy_comparison_profile(
+    writer_profile: CanonicalWriterRuntimeProfile,
+    env: Mapping[str, str] | None = None,
+) -> CanonicalLegacyComparisonProfile:
+    source = {} if env is None else env
+    requested = (
+        source.get(
+            "APPLAYLIST_CANONICAL_COMPARISON_ENABLED",
+            "0",
+        )
+        .strip()
+        .lower()
+        in _TRUE_VALUES
+    )
+    raw_path = source.get(
+        "APPLAYLIST_CANONICAL_COMPARISON_RECEIPTS_PATH",
+        "",
+    ).strip()
+
+    if not writer_profile.enabled:
+        return CanonicalLegacyComparisonProfile(
+            enabled=False,
+            receipts_path=None,
+            reason="writer_profile_not_enabled",
+        )
+    if not requested:
+        return CanonicalLegacyComparisonProfile(
+            enabled=False,
+            receipts_path=None,
+            reason="comparison_not_requested",
+        )
+    if not raw_path:
+        return CanonicalLegacyComparisonProfile(
+            enabled=False,
+            receipts_path=None,
+            reason="comparison_receipts_path_required",
+        )
+    return CanonicalLegacyComparisonProfile(
+        enabled=True,
+        receipts_path=Path(raw_path).expanduser(),
+        reason="bounded_nonlive_comparison_enabled",
+    )

--- a/core/analysis/canonical_legacy_comparison_receipts.py
+++ b/core/analysis/canonical_legacy_comparison_receipts.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol
+from uuid import uuid4
+
+from core.analysis.canonical_legacy_comparison import (
+    CanonicalLegacyComparison,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalLegacyComparisonReceipt:
+    event_name: str
+    attempt_id: str
+    outcome: str
+    track_id: str
+    provider: str
+    legacy_analysis_version: str | None
+    canonical_analysis_version: str
+    comparison_schema_version: str
+    matched_fields: tuple[str, ...]
+    mismatched_fields: tuple[str, ...]
+    duration_ms: float
+    error_type: str | None
+    recorded_at: str
+
+    @classmethod
+    def from_comparison(
+        cls,
+        comparison: CanonicalLegacyComparison,
+        *,
+        duration_ms: float,
+    ) -> CanonicalLegacyComparisonReceipt:
+        return cls(
+            event_name=(
+                f"canonical_legacy_comparison_{comparison.outcome}"
+            ),
+            attempt_id=str(uuid4()),
+            outcome=comparison.outcome,
+            track_id=comparison.track_id,
+            provider=comparison.provider,
+            legacy_analysis_version=comparison.legacy_analysis_version,
+            canonical_analysis_version=(
+                comparison.canonical_analysis_version
+            ),
+            comparison_schema_version=(
+                comparison.comparison_schema_version
+            ),
+            matched_fields=comparison.matched_fields,
+            mismatched_fields=comparison.mismatched_fields,
+            duration_ms=round(max(0.0, duration_ms), 3),
+            error_type=None,
+            recorded_at=datetime.now(UTC).isoformat(),
+        )
+
+    @classmethod
+    def skipped(
+        cls,
+        *,
+        track_id: str,
+        provider: str,
+        canonical_analysis_version: str,
+        comparison_schema_version: str,
+        duration_ms: float,
+    ) -> CanonicalLegacyComparisonReceipt:
+        return cls(
+            event_name="canonical_legacy_comparison_skipped",
+            attempt_id=str(uuid4()),
+            outcome="skipped",
+            track_id=track_id,
+            provider=provider,
+            legacy_analysis_version=None,
+            canonical_analysis_version=canonical_analysis_version,
+            comparison_schema_version=comparison_schema_version,
+            matched_fields=(),
+            mismatched_fields=(),
+            duration_ms=round(max(0.0, duration_ms), 3),
+            error_type=None,
+            recorded_at=datetime.now(UTC).isoformat(),
+        )
+
+    @classmethod
+    def failed(
+        cls,
+        *,
+        track_id: str,
+        provider: str,
+        canonical_analysis_version: str,
+        comparison_schema_version: str,
+        duration_ms: float,
+        error_type: str,
+    ) -> CanonicalLegacyComparisonReceipt:
+        return cls(
+            event_name="canonical_legacy_comparison_failed",
+            attempt_id=str(uuid4()),
+            outcome="failed",
+            track_id=track_id,
+            provider=provider,
+            legacy_analysis_version=None,
+            canonical_analysis_version=canonical_analysis_version,
+            comparison_schema_version=comparison_schema_version,
+            matched_fields=(),
+            mismatched_fields=(),
+            duration_ms=round(max(0.0, duration_ms), 3),
+            error_type=error_type,
+            recorded_at=datetime.now(UTC).isoformat(),
+        )
+
+
+class CanonicalLegacyComparisonReceiptSink(Protocol):
+    def write(self, receipt: CanonicalLegacyComparisonReceipt) -> None:
+        ...
+
+
+class JsonlCanonicalLegacyComparisonReceiptSink:
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path).expanduser()
+
+    def write(self, receipt: CanonicalLegacyComparisonReceipt) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(
+            asdict(receipt),
+            sort_keys=True,
+            separators=(",", ":"),
+        ) + "\n"
+        descriptor = os.open(
+            self._path,
+            os.O_APPEND | os.O_CREAT | os.O_WRONLY,
+            0o600,
+        )
+        try:
+            os.write(descriptor, payload.encode("utf-8"))
+        finally:
+            os.close(descriptor)

--- a/docs/ops/CANONICAL_LEGACY_COMPARISON_RUNBOOK.md
+++ b/docs/ops/CANONICAL_LEGACY_COMPARISON_RUNBOOK.md
@@ -1,0 +1,62 @@
+# Canonical versus Legacy Comparison Receipts
+
+## Authority boundary
+
+Comparison is observational only. Legacy analysis remains authoritative.
+Canonical persistence remains non-authoritative.
+
+The comparison path:
+
+- runs only after a successful canonical shadow write;
+- uses the already-mapped canonical persistence record;
+- reads the existing legacy analysis for the same `track_id`;
+- emits a separate JSONL comparison receipt;
+- does not return canonical data to the product path;
+- does not backfill or perform a second audio analysis.
+
+## Bounded non-live configuration
+
+```text
+APP_ENV=staging
+APPLAYLIST_CANONICAL_WRITER_ENABLED=1
+APPLAYLIST_CANONICAL_WRITER_RECEIPTS_PATH=./artifacts/writer.jsonl
+APPLAYLIST_CANONICAL_COMPARISON_ENABLED=1
+APPLAYLIST_CANONICAL_COMPARISON_RECEIPTS_PATH=./artifacts/comparison.jsonl
+DATABASE_URL=sqlite:///./artifacts/nonlive-applaylist.sqlite3
+```
+
+Production remains fail-closed because comparison cannot enable unless the
+bounded canonical writer profile itself is enabled.
+
+## Events
+
+```text
+canonical_legacy_comparison_succeeded
+canonical_legacy_comparison_mismatch
+canonical_legacy_comparison_skipped
+canonical_legacy_comparison_failed
+canonical_legacy_comparison_receipt_write_failed
+```
+
+## Initial deterministic tolerances
+
+```text
+BPM_ABSOLUTE_TOLERANCE=1.0
+ENERGY_ABSOLUTE_TOLERANCE=0.05
+DURATION_SECONDS_TOLERANCE=0.05
+```
+
+Missing values are classified explicitly. They are never coerced to zero.
+Audio paths and raw provider payloads are excluded from receipts.
+
+## Non-goals
+
+```text
+BACKFILL=NONE
+CANONICAL_READER_ACTIVATION=NONE
+RUNTIME_AUTHORITY=NONE
+PRODUCTION_DEFAULT_CHANGE=NONE
+PUBLIC_API_CHANGE=NONE
+TRANSITION_INTELLIGENCE_ACTIVATION=NONE
+WB006D=HOLD
+```

--- a/services/analysis/provider_analysis_service.py
+++ b/services/analysis/provider_analysis_service.py
@@ -6,6 +6,18 @@ from collections.abc import Callable, Iterable, Mapping
 from pathlib import Path
 from typing import Protocol
 
+from core.analysis.canonical_legacy_comparison import (
+    COMPARISON_SCHEMA_VERSION,
+    compare_canonical_to_legacy,
+)
+from core.analysis.canonical_legacy_comparison_profile import (
+    resolve_canonical_legacy_comparison_profile,
+)
+from core.analysis.canonical_legacy_comparison_receipts import (
+    CanonicalLegacyComparisonReceipt,
+    CanonicalLegacyComparisonReceiptSink,
+    JsonlCanonicalLegacyComparisonReceiptSink,
+)
 from core.analysis.canonical_writer_receipts import (
     CanonicalWriterReceipt,
     CanonicalWriterReceiptSink,
@@ -16,11 +28,13 @@ from core.analysis.canonical_writer_runtime_profile import (
 )
 from core.analysis.provider_contracts import ProviderOutput
 from core.analysis.provider_orchestrator import analyze_with_provider_selection
+from data.models.analysis_record import AnalysisRecord
 from data.models.canonical_analysis_record import (
     CanonicalAnalysisMappingError,
     CanonicalAnalysisPersistenceRecord,
     map_canonical_analysis_to_persistence,
 )
+from data.repositories.analysis_repository import AnalysisRepository
 from data.repositories.canonical_analysis_repository import (
     CanonicalAnalysisRepository,
     CanonicalAnalysisRepositoryError,
@@ -34,8 +48,13 @@ class CanonicalAnalysisWriter(Protocol):
         ...
 
 
+class LegacyAnalysisReader(Protocol):
+    def get_by_track_id(self, track_id: str) -> AnalysisRecord | None:
+        ...
+
+
 class ProviderAnalysisService:
-    """Provider analysis with an optional non-authoritative shadow writer."""
+    """Provider analysis with optional non-authoritative evidence paths."""
 
     def __init__(
         self,
@@ -43,6 +62,11 @@ class ProviderAnalysisService:
         canonical_writer: CanonicalAnalysisWriter | None = None,
         canonical_writer_is_enabled: bool = False,
         receipt_sink: CanonicalWriterReceiptSink | None = None,
+        comparison_is_enabled: bool = False,
+        legacy_analysis_reader: LegacyAnalysisReader | None = None,
+        comparison_receipt_sink: (
+            CanonicalLegacyComparisonReceiptSink | None
+        ) = None,
         monotonic_ns: Callable[[], int] = time.monotonic_ns,
     ) -> None:
         if canonical_writer_is_enabled and canonical_writer is None:
@@ -53,9 +77,24 @@ class ProviderAnalysisService:
             raise ValueError(
                 "receipt_sink is required when canonical writer is enabled"
             )
+        if comparison_is_enabled and not canonical_writer_is_enabled:
+            raise ValueError(
+                "comparison requires the canonical writer to be enabled"
+            )
+        if comparison_is_enabled and legacy_analysis_reader is None:
+            raise ValueError(
+                "legacy_analysis_reader is required when comparison is enabled"
+            )
+        if comparison_is_enabled and comparison_receipt_sink is None:
+            raise ValueError(
+                "comparison_receipt_sink is required when comparison is enabled"
+            )
         self._canonical_writer = canonical_writer
         self._canonical_writer_is_enabled = canonical_writer_is_enabled
         self._receipt_sink = receipt_sink
+        self._comparison_is_enabled = comparison_is_enabled
+        self._legacy_analysis_reader = legacy_analysis_reader
+        self._comparison_receipt_sink = comparison_receipt_sink
         self._monotonic_ns = monotonic_ns
 
     def analyze(
@@ -118,6 +157,90 @@ class ProviderAnalysisService:
                     ),
                 },
             )
+            if self._comparison_is_enabled:
+                self._compare_with_legacy(record)
+
+    def _compare_with_legacy(
+        self,
+        canonical: CanonicalAnalysisPersistenceRecord,
+    ) -> None:
+        reader = self._legacy_analysis_reader
+        sink = self._comparison_receipt_sink
+        if reader is None or sink is None:
+            raise RuntimeError("enabled comparison dependency is missing")
+
+        started_ns = self._monotonic_ns()
+        try:
+            legacy = reader.get_by_track_id(canonical.track_id)
+            elapsed_ms = (self._monotonic_ns() - started_ns) / 1_000_000
+            if legacy is None:
+                receipt = CanonicalLegacyComparisonReceipt.skipped(
+                    track_id=canonical.track_id,
+                    provider=canonical.provider,
+                    canonical_analysis_version=(
+                        canonical.canonical_analysis_version
+                    ),
+                    comparison_schema_version=COMPARISON_SCHEMA_VERSION,
+                    duration_ms=elapsed_ms,
+                )
+            else:
+                comparison = compare_canonical_to_legacy(legacy, canonical)
+                receipt = CanonicalLegacyComparisonReceipt.from_comparison(
+                    comparison,
+                    duration_ms=elapsed_ms,
+                )
+            self._write_comparison_receipt(sink, receipt)
+            logger.info(
+                receipt.event_name,
+                extra={
+                    "event_name": receipt.event_name,
+                    "track_id": receipt.track_id,
+                    "provider": receipt.provider,
+                    "mismatched_fields": receipt.mismatched_fields,
+                },
+            )
+        except Exception as exc:
+            elapsed_ms = (self._monotonic_ns() - started_ns) / 1_000_000
+            receipt = CanonicalLegacyComparisonReceipt.failed(
+                track_id=canonical.track_id,
+                provider=canonical.provider,
+                canonical_analysis_version=(
+                    canonical.canonical_analysis_version
+                ),
+                comparison_schema_version=COMPARISON_SCHEMA_VERSION,
+                duration_ms=elapsed_ms,
+                error_type=type(exc).__name__,
+            )
+            self._write_comparison_receipt(sink, receipt)
+            logger.warning(
+                "canonical_legacy_comparison_failed",
+                extra={
+                    "event_name": "canonical_legacy_comparison_failed",
+                    "track_id": canonical.track_id,
+                    "provider": canonical.provider,
+                    "error_type": type(exc).__name__,
+                },
+            )
+
+    @staticmethod
+    def _write_comparison_receipt(
+        sink: CanonicalLegacyComparisonReceiptSink,
+        receipt: CanonicalLegacyComparisonReceipt,
+    ) -> None:
+        try:
+            sink.write(receipt)
+        except OSError as exc:
+            logger.warning(
+                "canonical_legacy_comparison_receipt_write_failed",
+                extra={
+                    "event_name": (
+                        "canonical_legacy_comparison_receipt_write_failed"
+                    ),
+                    "track_id": receipt.track_id,
+                    "provider": receipt.provider,
+                    "error_type": type(exc).__name__,
+                },
+            )
 
     def _emit_receipt(
         self,
@@ -157,21 +280,48 @@ def create_provider_analysis_service(
     env: Mapping[str, str] | None = None,
     canonical_writer: CanonicalAnalysisWriter | None = None,
     receipt_sink: CanonicalWriterReceiptSink | None = None,
+    legacy_analysis_reader: LegacyAnalysisReader | None = None,
+    comparison_receipt_sink: (
+        CanonicalLegacyComparisonReceiptSink | None
+    ) = None,
 ) -> ProviderAnalysisService:
-    profile = resolve_canonical_writer_runtime_profile(env)
+    writer_profile = resolve_canonical_writer_runtime_profile(env)
+    comparison_profile = resolve_canonical_legacy_comparison_profile(
+        writer_profile,
+        env,
+    )
     writer = canonical_writer
-    sink = receipt_sink
+    writer_sink = receipt_sink
+    reader = legacy_analysis_reader
+    comparison_sink = comparison_receipt_sink
 
-    if profile.enabled:
+    if writer_profile.enabled:
         if writer is None:
             writer = CanonicalAnalysisRepository()
-        if sink is None:
-            if profile.receipts_path is None:
+        if writer_sink is None:
+            if writer_profile.receipts_path is None:
                 raise RuntimeError("enabled profile is missing receipts path")
-            sink = JsonlCanonicalWriterReceiptSink(profile.receipts_path)
+            writer_sink = JsonlCanonicalWriterReceiptSink(
+                writer_profile.receipts_path
+            )
+
+    if comparison_profile.enabled:
+        if reader is None:
+            reader = AnalysisRepository()
+        if comparison_sink is None:
+            if comparison_profile.receipts_path is None:
+                raise RuntimeError(
+                    "enabled comparison is missing receipts path"
+                )
+            comparison_sink = JsonlCanonicalLegacyComparisonReceiptSink(
+                comparison_profile.receipts_path
+            )
 
     return ProviderAnalysisService(
         canonical_writer=writer,
-        canonical_writer_is_enabled=profile.enabled,
-        receipt_sink=sink,
+        canonical_writer_is_enabled=writer_profile.enabled,
+        receipt_sink=writer_sink,
+        comparison_is_enabled=comparison_profile.enabled,
+        legacy_analysis_reader=reader,
+        comparison_receipt_sink=comparison_sink,
     )

--- a/tests/unit/test_canonical_legacy_comparison.py
+++ b/tests/unit/test_canonical_legacy_comparison.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from core.analysis.canonical_legacy_comparison import (
+    FieldComparisonStatus,
+    compare_canonical_to_legacy,
+    normalize_key,
+)
+from data.models.analysis_record import AnalysisRecord
+from data.models.canonical_analysis_record import (
+    CanonicalAnalysisPersistenceRecord,
+)
+
+
+def _legacy(**overrides: object) -> AnalysisRecord:
+    values: dict[str, object] = {
+        "track_id": "track-1",
+        "analysis_version": "0.1.0",
+        "features_version": "0.1.0",
+        "extractor_backend": "librosa",
+        "extractor_name": "baseline",
+        "bpm": 120.0,
+        "bpm_confidence": 0.8,
+        "key": "A",
+        "scale": "minor",
+        "camelot": "8A",
+        "energy": 0.5,
+        "loudness_db": -12.0,
+        "duration_seconds": 180.0,
+    }
+    values.update(overrides)
+    return AnalysisRecord(**values)
+
+
+def _canonical(
+    **overrides: object,
+) -> CanonicalAnalysisPersistenceRecord:
+    values: dict[str, object] = {
+        "track_id": "track-1",
+        "provider": "baseline",
+        "provider_version": "1",
+        "canonical_analysis_version": "canonical-mir-v1",
+        "source_analysis_version": "0.1.0",
+        "bpm": 120.5,
+        "bpm_confidence": 0.82,
+        "key": "A minor",
+        "key_confidence": 0.7,
+        "key_system": "standard",
+        "energy": 0.52,
+        "energy_confidence": 0.7,
+        "loudness_db": -12.2,
+        "loudness_integrated_lufs": None,
+        "duration_seconds": 180.02,
+        "sample_rate_hz": 44100,
+        "channels": 2,
+        "genre_hint": None,
+        "analysis_status": "complete",
+        "analyzed_at": None,
+        "warnings_json": "[]",
+    }
+    values.update(overrides)
+    return CanonicalAnalysisPersistenceRecord(**values)
+
+
+def test_key_normalization_supports_camelot_and_minor_suffix() -> None:
+    assert normalize_key(None, camelot="8A") == "A minor"
+    assert normalize_key("Am") == "A minor"
+    assert normalize_key("A minor") == "A minor"
+
+
+def test_comparison_classifies_values_within_tolerance() -> None:
+    result = compare_canonical_to_legacy(_legacy(), _canonical())
+
+    assert result.outcome == "succeeded"
+    statuses = {field.field: field.status for field in result.fields}
+    assert statuses["bpm"] is FieldComparisonStatus.WITHIN_TOLERANCE
+    assert statuses["key"] is FieldComparisonStatus.EXACT_MATCH
+    assert statuses["energy"] is FieldComparisonStatus.WITHIN_TOLERANCE
+
+
+def test_comparison_classifies_mismatch_and_missing_value() -> None:
+    result = compare_canonical_to_legacy(
+        _legacy(energy=None),
+        _canonical(bpm=126.0, energy=0.7),
+    )
+
+    assert result.outcome == "mismatch"
+    assert "bpm" in result.mismatched_fields
+    assert "energy" in result.mismatched_fields
+
+
+def test_comparison_rejects_different_track_identity() -> None:
+    try:
+        compare_canonical_to_legacy(
+            _legacy(track_id="legacy"),
+            _canonical(track_id="canonical"),
+        )
+    except ValueError as exc:
+        assert "track_id" in str(exc)
+    else:
+        raise AssertionError("expected track identity mismatch")

--- a/tests/unit/test_canonical_legacy_comparison_profile.py
+++ b/tests/unit/test_canonical_legacy_comparison_profile.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from core.analysis.canonical_legacy_comparison_profile import (
+    resolve_canonical_legacy_comparison_profile,
+)
+from core.analysis.canonical_writer_runtime_profile import (
+    resolve_canonical_writer_runtime_profile,
+)
+
+
+def test_comparison_requires_enabled_writer_profile() -> None:
+    writer = resolve_canonical_writer_runtime_profile({})
+    comparison = resolve_canonical_legacy_comparison_profile(
+        writer,
+        {
+            "APPLAYLIST_CANONICAL_COMPARISON_ENABLED": "1",
+            "APPLAYLIST_CANONICAL_COMPARISON_RECEIPTS_PATH": "receipt.jsonl",
+        },
+    )
+    assert comparison.enabled is False
+    assert comparison.reason == "writer_profile_not_enabled"
+
+
+def test_comparison_requires_explicit_receipt_path() -> None:
+    env = {
+        "APP_ENV": "test",
+        "APPLAYLIST_CANONICAL_WRITER_ENABLED": "1",
+        "APPLAYLIST_CANONICAL_WRITER_RECEIPTS_PATH": "writer.jsonl",
+        "APPLAYLIST_CANONICAL_COMPARISON_ENABLED": "1",
+    }
+    writer = resolve_canonical_writer_runtime_profile(env)
+    comparison = resolve_canonical_legacy_comparison_profile(writer, env)
+    assert comparison.enabled is False
+    assert comparison.reason == "comparison_receipts_path_required"
+
+
+def test_comparison_enables_only_inside_bounded_writer_profile() -> None:
+    env = {
+        "APP_ENV": "staging",
+        "APPLAYLIST_CANONICAL_WRITER_ENABLED": "1",
+        "APPLAYLIST_CANONICAL_WRITER_RECEIPTS_PATH": "writer.jsonl",
+        "APPLAYLIST_CANONICAL_COMPARISON_ENABLED": "1",
+        "APPLAYLIST_CANONICAL_COMPARISON_RECEIPTS_PATH": (
+            "comparison.jsonl"
+        ),
+    }
+    writer = resolve_canonical_writer_runtime_profile(env)
+    comparison = resolve_canonical_legacy_comparison_profile(writer, env)
+    assert comparison.enabled is True
+    assert comparison.reason == "bounded_nonlive_comparison_enabled"

--- a/tests/unit/test_canonical_legacy_comparison_receipts.py
+++ b/tests/unit/test_canonical_legacy_comparison_receipts.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+from core.analysis.canonical_legacy_comparison import (
+    CanonicalLegacyComparison,
+    FieldComparison,
+    FieldComparisonStatus,
+)
+from core.analysis.canonical_legacy_comparison_receipts import (
+    CanonicalLegacyComparisonReceipt,
+    JsonlCanonicalLegacyComparisonReceiptSink,
+)
+
+
+def test_jsonl_receipt_excludes_paths_and_raw_payloads(
+    tmp_path: Path,
+) -> None:
+    comparison = CanonicalLegacyComparison(
+        track_id="track-1",
+        provider="baseline",
+        legacy_analysis_version="0.1.0",
+        canonical_analysis_version="canonical-mir-v1",
+        comparison_schema_version="comparison-v1",
+        fields=(
+            FieldComparison(
+                field="bpm",
+                status=FieldComparisonStatus.EXACT_MATCH,
+                legacy_value=120.0,
+                canonical_value=120.0,
+                absolute_delta=0.0,
+            ),
+        ),
+    )
+    receipt = CanonicalLegacyComparisonReceipt.from_comparison(
+        comparison,
+        duration_ms=1.2345,
+    )
+    path = tmp_path / "comparison.jsonl"
+
+    JsonlCanonicalLegacyComparisonReceiptSink(path).write(receipt)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["event_name"] == (
+        "canonical_legacy_comparison_succeeded"
+    )
+    assert payload["duration_ms"] == 1.234
+    assert "path" not in payload
+    assert "raw" not in payload
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600

--- a/tests/unit/test_provider_analysis_comparison.py
+++ b/tests/unit/test_provider_analysis_comparison.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import services.analysis.provider_analysis_service as service_module
+from core.analysis.contracts import CanonicalAnalysisResult
+from core.analysis.provider_contracts import ProviderOutput
+from data.models.analysis_record import AnalysisRecord
+from data.models.canonical_analysis_record import (
+    CanonicalAnalysisPersistenceRecord,
+)
+from services.analysis.provider_analysis_service import ProviderAnalysisService
+
+
+class RecordingWriter:
+    def __init__(self) -> None:
+        self.records: list[CanonicalAnalysisPersistenceRecord] = []
+
+    def upsert(self, record: CanonicalAnalysisPersistenceRecord) -> None:
+        self.records.append(record)
+
+
+class StaticLegacyReader:
+    def __init__(self, record: AnalysisRecord | None) -> None:
+        self.record = record
+
+    def get_by_track_id(self, track_id: str) -> AnalysisRecord | None:
+        assert track_id == "track-1"
+        return self.record
+
+
+class FailingLegacyReader:
+    def get_by_track_id(self, track_id: str) -> AnalysisRecord | None:
+        raise RuntimeError(f"read failed for {track_id}")
+
+
+class RecordingSink:
+    def __init__(self) -> None:
+        self.receipts: list[object] = []
+
+    def write(self, receipt: object) -> None:
+        self.receipts.append(receipt)
+
+
+def _output() -> ProviderOutput:
+    normalized = CanonicalAnalysisResult(
+        path="/tmp/test.wav",
+        provider="baseline",
+        bpm=120.0,
+        bpm_confidence=0.8,
+        key="A minor",
+        energy=0.5,
+        loudness_db=-12.0,
+        duration_seconds=180.0,
+        analysis_status="complete",
+        analysis_version="canonical-mir-v1",
+        source_analysis_version="0.1.0",
+        provider_version="1",
+        track_id="track-1",
+    )
+    return ProviderOutput(
+        provider="baseline",
+        backend="librosa",
+        raw={},
+        normalized=normalized,
+    )
+
+
+def _legacy() -> AnalysisRecord:
+    return AnalysisRecord(
+        track_id="track-1",
+        analysis_version="0.1.0",
+        features_version="0.1.0",
+        extractor_backend="librosa",
+        extractor_name="baseline",
+        bpm=120.0,
+        bpm_confidence=0.8,
+        key="A",
+        scale="minor",
+        camelot="8A",
+        energy=0.5,
+        loudness_db=-12.0,
+        duration_seconds=180.0,
+    )
+
+
+def test_successful_write_emits_one_comparison_receipt(
+    monkeypatch: object,
+) -> None:
+    output = _output()
+    monkeypatch.setattr(  # type: ignore[attr-defined]
+        service_module,
+        "analyze_with_provider_selection",
+        lambda **_: output,
+    )
+    writer = RecordingWriter()
+    writer_sink = RecordingSink()
+    comparison_sink = RecordingSink()
+    service = ProviderAnalysisService(
+        canonical_writer=writer,
+        canonical_writer_is_enabled=True,
+        receipt_sink=writer_sink,
+        comparison_is_enabled=True,
+        legacy_analysis_reader=StaticLegacyReader(_legacy()),
+        comparison_receipt_sink=comparison_sink,
+    )
+
+    returned = service.analyze(track_id="track-1", path=Path("test.wav"))
+
+    assert returned is output
+    assert len(writer.records) == 1
+    assert len(comparison_sink.receipts) == 1
+    receipt = comparison_sink.receipts[0]
+    assert receipt.outcome == "succeeded"
+
+
+def test_missing_legacy_row_emits_skipped_receipt(
+    monkeypatch: object,
+) -> None:
+    output = _output()
+    monkeypatch.setattr(  # type: ignore[attr-defined]
+        service_module,
+        "analyze_with_provider_selection",
+        lambda **_: output,
+    )
+    comparison_sink = RecordingSink()
+    service = ProviderAnalysisService(
+        canonical_writer=RecordingWriter(),
+        canonical_writer_is_enabled=True,
+        receipt_sink=RecordingSink(),
+        comparison_is_enabled=True,
+        legacy_analysis_reader=StaticLegacyReader(None),
+        comparison_receipt_sink=comparison_sink,
+    )
+
+    returned = service.analyze(track_id="track-1", path=Path("test.wav"))
+
+    assert returned is output
+    assert comparison_sink.receipts[0].outcome == "skipped"
+
+
+def test_comparison_failure_does_not_change_provider_result(
+    monkeypatch: object,
+) -> None:
+    output = _output()
+    monkeypatch.setattr(  # type: ignore[attr-defined]
+        service_module,
+        "analyze_with_provider_selection",
+        lambda **_: output,
+    )
+    comparison_sink = RecordingSink()
+    service = ProviderAnalysisService(
+        canonical_writer=RecordingWriter(),
+        canonical_writer_is_enabled=True,
+        receipt_sink=RecordingSink(),
+        comparison_is_enabled=True,
+        legacy_analysis_reader=FailingLegacyReader(),
+        comparison_receipt_sink=comparison_sink,
+    )
+
+    returned = service.analyze(track_id="track-1", path=Path("test.wav"))
+
+    assert returned is output
+    assert comparison_sink.receipts[0].outcome == "failed"


### PR DESCRIPTION
## Scope

WB004D adds bounded, non-authoritative canonical-versus-legacy comparison evidence.

### Implemented

- deterministic field comparison for BPM, confidence, key, energy, loudness and duration;
- explicit missing-value classification;
- bounded non-live comparison profile, default OFF;
- separate JSONL comparison receipts;
- one comparison call site after successful canonical shadow persistence;
- legacy result remains the returned and authoritative product result.

### Events

```text
canonical_legacy_comparison_succeeded
canonical_legacy_comparison_mismatch
canonical_legacy_comparison_skipped
canonical_legacy_comparison_failed
canonical_legacy_comparison_receipt_write_failed
```

### Verified locally

- targeted Ruff: PASS;
- targeted WB004D tests: PASS;
- full regression: 208 passed;
- doctor: PASS;
- differential Ruff: PASS;
- differential mypy: PASS;
- security gate: PASS;
- clean post-commit `make verify`: PASS;
- restore smoke: PASS;
- live database remained byte-identical.

### Explicit non-goals

```text
BACKFILL=NONE
CANONICAL_READER_ACTIVATION=NONE
RUNTIME_AUTHORITY=NONE
PRODUCTION_DEFAULT_CHANGE=NONE
PUBLIC_API_CHANGE=NONE
TRANSITION_INTELLIGENCE_ACTIVATION=NONE
WB006D=HOLD
```

## Next

After merge, reconcile `STATUS.md`, `ROADMAP.md` and the rollout evidence index, then begin WB004E as a read-only audit/design bundle.
