### PR TITLE
feat(analysis): add default-off canonical shadow reader core

### DIFF
--- a/core/analysis/canonical_shadow_read_receipts.py
+++ b/core/analysis/canonical_shadow_read_receipts.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol
+from uuid import uuid4
+
+from core.analysis.canonical_legacy_comparison import (
+    COMPARISON_SCHEMA_VERSION,
+    CanonicalLegacyComparison,
+)
+
+_MAX_CORRELATION_ID_LENGTH = 128
+
+
+def _bounded_correlation_id(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    return normalized[:_MAX_CORRELATION_ID_LENGTH]
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalShadowReadReceipt:
+    event_name: str
+    attempt_id: str
+    correlation_id: str | None
+    outcome: str
+    track_id: str
+    provider: str | None
+    legacy_analysis_version: str
+    canonical_analysis_version: str | None
+    comparison_schema_version: str
+    matched_fields: tuple[str, ...]
+    mismatched_fields: tuple[str, ...]
+    duration_ms: float
+    error_type: str | None
+    recorded_at: str
+
+    @classmethod
+    def from_comparison(
+        cls,
+        comparison: CanonicalLegacyComparison,
+        *,
+        duration_ms: float,
+        correlation_id: str | None = None,
+    ) -> CanonicalShadowReadReceipt:
+        return cls(
+            event_name=f"canonical_shadow_read_{comparison.outcome}",
+            attempt_id=str(uuid4()),
+            correlation_id=_bounded_correlation_id(correlation_id),
+            outcome=comparison.outcome,
+            track_id=comparison.track_id,
+            provider=comparison.provider,
+            legacy_analysis_version=comparison.legacy_analysis_version,
+            canonical_analysis_version=comparison.canonical_analysis_version,
+            comparison_schema_version=comparison.comparison_schema_version,
+            matched_fields=comparison.matched_fields,
+            mismatched_fields=comparison.mismatched_fields,
+            duration_ms=round(max(0.0, duration_ms), 3),
+            error_type=None,
+            recorded_at=datetime.now(UTC).isoformat(),
+        )
+
+    @classmethod
+    def canonical_missing(
+        cls,
+        *,
+        track_id: str,
+        legacy_analysis_version: str,
+        duration_ms: float,
+        correlation_id: str | None = None,
+    ) -> CanonicalShadowReadReceipt:
+        return cls(
+            event_name="canonical_shadow_read_canonical_missing",
+            attempt_id=str(uuid4()),
+            correlation_id=_bounded_correlation_id(correlation_id),
+            outcome="canonical_missing",
+            track_id=track_id,
+            provider=None,
+            legacy_analysis_version=legacy_analysis_version,
+            canonical_analysis_version=None,
+            comparison_schema_version=COMPARISON_SCHEMA_VERSION,
+            matched_fields=(),
+            mismatched_fields=(),
+            duration_ms=round(max(0.0, duration_ms), 3),
+            error_type=None,
+            recorded_at=datetime.now(UTC).isoformat(),
+        )
+
+    @classmethod
+    def failed(
+        cls,
+        *,
+        track_id: str,
+        legacy_analysis_version: str,
+        duration_ms: float,
+        error_type: str,
+        correlation_id: str | None = None,
+    ) -> CanonicalShadowReadReceipt:
+        return cls(
+            event_name="canonical_shadow_read_failed",
+            attempt_id=str(uuid4()),
+            correlation_id=_bounded_correlation_id(correlation_id),
+            outcome="failed",
+            track_id=track_id,
+            provider=None,
+            legacy_analysis_version=legacy_analysis_version,
+            canonical_analysis_version=None,
+            comparison_schema_version=COMPARISON_SCHEMA_VERSION,
+            matched_fields=(),
+            mismatched_fields=(),
+            duration_ms=round(max(0.0, duration_ms), 3),
+            error_type=error_type,
+            recorded_at=datetime.now(UTC).isoformat(),
+        )
+
+
+class CanonicalShadowReadReceiptSink(Protocol):
+    def write(self, receipt: CanonicalShadowReadReceipt) -> None:
+        ...
+
+
+class JsonlCanonicalShadowReadReceiptSink:
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path).expanduser()
+
+    def write(self, receipt: CanonicalShadowReadReceipt) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(
+            asdict(receipt),
+            sort_keys=True,
+            separators=(",", ":"),
+        ) + "\n"
+        descriptor = os.open(
+            self._path,
+            os.O_APPEND | os.O_CREAT | os.O_WRONLY,
+            0o600,
+        )
+        try:
+            os.write(descriptor, payload.encode("utf-8"))
+        finally:
+            os.close(descriptor)

--- a/core/analysis/canonical_shadow_reader_profile.py
+++ b/core/analysis/canonical_shadow_reader_profile.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+_ALLOWED_NONLIVE_ENVS = {"development", "test", "staging", "nonlive"}
+_PRODUCTION_ENVS = {"prod", "production"}
+_TRUE_VALUES = {"1", "true", "yes", "on", "enabled"}
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalShadowReaderProfile:
+    enabled: bool
+    app_env: str
+    receipts_path: Path | None
+    reason: str
+
+
+def resolve_canonical_shadow_reader_profile(
+    env: Mapping[str, str] | None = None,
+) -> CanonicalShadowReaderProfile:
+    source = {} if env is None else env
+    app_env = source.get("APP_ENV", "development").strip().lower()
+    requested = (
+        source.get("APPLAYLIST_CANONICAL_SHADOW_READER_ENABLED", "0")
+        .strip()
+        .lower()
+        in _TRUE_VALUES
+    )
+    raw_receipts_path = source.get(
+        "APPLAYLIST_CANONICAL_SHADOW_READER_RECEIPTS_PATH",
+        "",
+    ).strip()
+
+    if app_env in _PRODUCTION_ENVS:
+        return CanonicalShadowReaderProfile(
+            enabled=False,
+            app_env=app_env,
+            receipts_path=None,
+            reason="production_fail_closed",
+        )
+    if not requested:
+        return CanonicalShadowReaderProfile(
+            enabled=False,
+            app_env=app_env,
+            receipts_path=None,
+            reason="reader_not_requested",
+        )
+    if app_env not in _ALLOWED_NONLIVE_ENVS:
+        return CanonicalShadowReaderProfile(
+            enabled=False,
+            app_env=app_env,
+            receipts_path=None,
+            reason="environment_not_allowlisted",
+        )
+    if not raw_receipts_path:
+        return CanonicalShadowReaderProfile(
+            enabled=False,
+            app_env=app_env,
+            receipts_path=None,
+            reason="receipts_path_required",
+        )
+
+    return CanonicalShadowReaderProfile(
+        enabled=True,
+        app_env=app_env,
+        receipts_path=Path(raw_receipts_path).expanduser(),
+        reason="bounded_nonlive_shadow_reader_enabled",
+    )

--- a/docs/architecture/APPLAYLIST_CANONICAL_SHADOW_READER_V1.md
+++ b/docs/architecture/APPLAYLIST_CANONICAL_SHADOW_READER_V1.md
@@ -1,0 +1,78 @@
+# APPLAYLIST Canonical Shadow Reader V1
+
+## Status
+
+```text
+WB004E_IMPLEMENTATION=ISOLATED_CORE_SLICE
+CANONICAL_READER_PRODUCT_PATH=NONE
+CANONICAL_READER_ACTIVATION=NONE_BY_DEFAULT
+LEGACY_ANALYSIS_AUTHORITY=ACTIVE
+RUNTIME_AUTHORITY_SWITCH=NONE
+PUBLIC_API_CHANGE=NONE
+BACKFILL=NONE
+WB004F_START=NONE
+WB006D=HOLD
+```
+
+This document describes an internal, default-off WB004E component. It does not
+declare a product-path integration or an authority cutover.
+
+## Purpose
+
+The canonical shadow reader is a bounded observer for future non-live parity
+verification. Given an already-authoritative legacy `AnalysisRecord`, it may:
+
+1. read the corresponding canonical persistence record by `track_id`;
+2. reuse the WB004D canonical-to-legacy comparator;
+3. write a bounded receipt for match, mismatch, canonical absence, or failure;
+4. return the original legacy object unchanged.
+
+## Components
+
+- `CanonicalShadowReaderProfile`
+  - defaults to disabled;
+  - fails closed in `prod` and `production`;
+  - requires an allowlisted non-live environment and an explicit receipt path.
+
+- `CanonicalShadowReader`
+  - accepts injected reader and receipt-sink protocols;
+  - catches canonical read/comparison failures;
+  - catches receipt-write failures;
+  - never replaces or mutates the authoritative legacy result.
+
+- `CanonicalShadowReadReceipt`
+  - records stable identifiers, schema versions, comparison outcome, bounded
+    correlation ID, matched fields, mismatched fields, duration, and error type;
+  - excludes source paths and raw analysis payloads;
+  - JSONL files are created with mode `0600`.
+
+## Configuration contract
+
+The component is not wired into an application or product request path.
+
+A future explicitly authorized non-live caller may resolve:
+
+```text
+APP_ENV=development|test|staging|nonlive
+APPLAYLIST_CANONICAL_SHADOW_READER_ENABLED=1
+APPLAYLIST_CANONICAL_SHADOW_READER_RECEIPTS_PATH=<explicit non-live path>
+```
+
+Production environments always resolve the profile as disabled, even when the
+enable flag is present.
+
+## Failure behaviour
+
+Canonical absence, canonical repository failure, identity mismatch, comparison
+failure, and receipt-sink failure do not change the returned legacy object.
+No canonical value becomes authoritative.
+
+## Deferred work
+
+The following remain outside this isolated slice:
+
+- connection to `AnalysisRepository.get_by_track_id()` or another product seam;
+- runtime activation in any caller;
+- parity campaign execution;
+- product endpoint, composer, ranking, or transition changes;
+- WB004F and WB004G.

--- a/services/analysis/canonical_shadow_reader.py
+++ b/services/analysis/canonical_shadow_reader.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable, Mapping
+from typing import Protocol
+
+from core.analysis.canonical_legacy_comparison import compare_canonical_to_legacy
+from core.analysis.canonical_shadow_read_receipts import (
+    CanonicalShadowReadReceipt,
+    CanonicalShadowReadReceiptSink,
+    JsonlCanonicalShadowReadReceiptSink,
+)
+from core.analysis.canonical_shadow_reader_profile import (
+    resolve_canonical_shadow_reader_profile,
+)
+from data.models.analysis_record import AnalysisRecord
+from data.models.canonical_analysis_record import (
+    CanonicalAnalysisPersistenceRecord,
+)
+from data.repositories.canonical_analysis_repository import (
+    CanonicalAnalysisRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CanonicalAnalysisReader(Protocol):
+    def get(
+        self,
+        track_id: str,
+    ) -> CanonicalAnalysisPersistenceRecord | None:
+        ...
+
+
+class CanonicalShadowReader:
+    """Default-off observer that never replaces the authoritative legacy result."""
+
+    def __init__(
+        self,
+        *,
+        canonical_reader: CanonicalAnalysisReader | None = None,
+        enabled: bool = False,
+        receipt_sink: CanonicalShadowReadReceiptSink | None = None,
+        monotonic_ns: Callable[[], int] = time.monotonic_ns,
+    ) -> None:
+        if enabled and canonical_reader is None:
+            raise ValueError(
+                "canonical_reader is required when shadow reader is enabled"
+            )
+        if enabled and receipt_sink is None:
+            raise ValueError(
+                "receipt_sink is required when shadow reader is enabled"
+            )
+        self._canonical_reader = canonical_reader
+        self._enabled = enabled
+        self._receipt_sink = receipt_sink
+        self._monotonic_ns = monotonic_ns
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def observe_authoritative_legacy_read(
+        self,
+        legacy: AnalysisRecord,
+        *,
+        correlation_id: str | None = None,
+    ) -> AnalysisRecord:
+        if not isinstance(legacy, AnalysisRecord):
+            raise TypeError("legacy must be AnalysisRecord")
+        if not self._enabled:
+            return legacy
+
+        reader = self._canonical_reader
+        sink = self._receipt_sink
+        if reader is None or sink is None:
+            raise RuntimeError("enabled shadow reader dependency is missing")
+
+        started_ns = self._monotonic_ns()
+        try:
+            canonical = reader.get(legacy.track_id)
+            elapsed_ms = (self._monotonic_ns() - started_ns) / 1_000_000
+            if canonical is None:
+                receipt = CanonicalShadowReadReceipt.canonical_missing(
+                    track_id=legacy.track_id,
+                    legacy_analysis_version=legacy.analysis_version,
+                    duration_ms=elapsed_ms,
+                    correlation_id=correlation_id,
+                )
+            else:
+                comparison = compare_canonical_to_legacy(legacy, canonical)
+                receipt = CanonicalShadowReadReceipt.from_comparison(
+                    comparison,
+                    duration_ms=elapsed_ms,
+                    correlation_id=correlation_id,
+                )
+        except Exception as exc:
+            elapsed_ms = (self._monotonic_ns() - started_ns) / 1_000_000
+            receipt = CanonicalShadowReadReceipt.failed(
+                track_id=legacy.track_id,
+                legacy_analysis_version=legacy.analysis_version,
+                duration_ms=elapsed_ms,
+                error_type=type(exc).__name__,
+                correlation_id=correlation_id,
+            )
+
+        self._write_receipt(sink, receipt)
+        self._log_receipt(receipt)
+        return legacy
+
+    @staticmethod
+    def _write_receipt(
+        sink: CanonicalShadowReadReceiptSink,
+        receipt: CanonicalShadowReadReceipt,
+    ) -> None:
+        try:
+            sink.write(receipt)
+        except Exception as exc:
+            logger.warning(
+                "canonical_shadow_read_receipt_write_failed",
+                extra={
+                    "event_name": "canonical_shadow_read_receipt_write_failed",
+                    "track_id": receipt.track_id,
+                    "error_type": type(exc).__name__,
+                },
+            )
+
+    @staticmethod
+    def _log_receipt(receipt: CanonicalShadowReadReceipt) -> None:
+        log = logger.warning if receipt.outcome == "failed" else logger.info
+        log(
+            receipt.event_name,
+            extra={
+                "event_name": receipt.event_name,
+                "track_id": receipt.track_id,
+                "provider": receipt.provider,
+                "outcome": receipt.outcome,
+                "mismatched_fields": receipt.mismatched_fields,
+            },
+        )
+
+
+def create_canonical_shadow_reader(
+    *,
+    env: Mapping[str, str] | None = None,
+    canonical_reader: CanonicalAnalysisReader | None = None,
+    receipt_sink: CanonicalShadowReadReceiptSink | None = None,
+) -> CanonicalShadowReader:
+    profile = resolve_canonical_shadow_reader_profile(env)
+    reader = canonical_reader
+    sink = receipt_sink
+
+    if profile.enabled:
+        if reader is None:
+            reader = CanonicalAnalysisRepository()
+        if sink is None:
+            if profile.receipts_path is None:
+                raise RuntimeError(
+                    "enabled shadow reader profile is missing receipts path"
+                )
+            sink = JsonlCanonicalShadowReadReceiptSink(
+                profile.receipts_path
+            )
+
+    return CanonicalShadowReader(
+        canonical_reader=reader,
+        enabled=profile.enabled,
+        receipt_sink=sink,
+    )

--- a/tests/unit/test_canonical_shadow_read_receipts.py
+++ b/tests/unit/test_canonical_shadow_read_receipts.py
@@ -1,0 +1,66 @@
+import json
+import stat
+from pathlib import Path
+
+from core.analysis.canonical_legacy_comparison import (
+    COMPARISON_SCHEMA_VERSION,
+    CanonicalLegacyComparison,
+)
+from core.analysis.canonical_shadow_read_receipts import (
+    CanonicalShadowReadReceipt,
+    JsonlCanonicalShadowReadReceiptSink,
+)
+
+
+def test_jsonl_receipt_is_bounded_and_excludes_payloads(tmp_path: Path) -> None:
+    comparison = CanonicalLegacyComparison(
+        track_id="track-1",
+        provider="baseline",
+        legacy_analysis_version="legacy-v1",
+        canonical_analysis_version="canonical-v1",
+        comparison_schema_version=COMPARISON_SCHEMA_VERSION,
+        fields=(),
+    )
+    receipt = CanonicalShadowReadReceipt.from_comparison(
+        comparison,
+        duration_ms=1.23456,
+        correlation_id=" request-1 ",
+    )
+    path = tmp_path / "nested" / "receipts.jsonl"
+
+    JsonlCanonicalShadowReadReceiptSink(path).write(receipt)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["event_name"] == "canonical_shadow_read_succeeded"
+    assert payload["duration_ms"] == 1.235
+    assert payload["correlation_id"] == "request-1"
+    assert "path" not in payload
+    assert "raw" not in payload
+    assert "payload" not in payload
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_correlation_id_is_bounded() -> None:
+    receipt = CanonicalShadowReadReceipt.canonical_missing(
+        track_id="track-1",
+        legacy_analysis_version="legacy-v1",
+        duration_ms=0.0,
+        correlation_id="x" * 256,
+    )
+
+    assert receipt.correlation_id == "x" * 128
+
+
+def test_failed_receipt_contains_only_error_type() -> None:
+    receipt = CanonicalShadowReadReceipt.failed(
+        track_id="track-1",
+        legacy_analysis_version="legacy-v1",
+        duration_ms=-1.0,
+        error_type="RuntimeError",
+    )
+
+    assert receipt.outcome == "failed"
+    assert receipt.duration_ms == 0.0
+    assert receipt.error_type == "RuntimeError"
+    assert receipt.provider is None
+    assert receipt.canonical_analysis_version is None

--- a/tests/unit/test_canonical_shadow_reader.py
+++ b/tests/unit/test_canonical_shadow_reader.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import pytest
+
+from core.analysis.canonical_shadow_read_receipts import (
+    CanonicalShadowReadReceipt,
+)
+from data.models.analysis_record import AnalysisRecord
+from data.models.canonical_analysis_record import (
+    CanonicalAnalysisPersistenceRecord,
+)
+from services.analysis.canonical_shadow_reader import (
+    CanonicalShadowReader,
+    create_canonical_shadow_reader,
+)
+
+
+class RecordingCanonicalReader:
+    def __init__(
+        self,
+        record: CanonicalAnalysisPersistenceRecord | None,
+    ) -> None:
+        self.record = record
+        self.calls: list[str] = []
+
+    def get(
+        self,
+        track_id: str,
+    ) -> CanonicalAnalysisPersistenceRecord | None:
+        self.calls.append(track_id)
+        return self.record
+
+
+class FailingCanonicalReader:
+    def get(
+        self,
+        track_id: str,
+    ) -> CanonicalAnalysisPersistenceRecord | None:
+        raise RuntimeError(f"canonical read failed for {track_id}")
+
+
+class RecordingSink:
+    def __init__(self) -> None:
+        self.receipts: list[CanonicalShadowReadReceipt] = []
+
+    def write(self, receipt: CanonicalShadowReadReceipt) -> None:
+        self.receipts.append(receipt)
+
+
+class FailingSink:
+    def write(self, receipt: CanonicalShadowReadReceipt) -> None:
+        raise OSError(f"receipt unavailable for {receipt.track_id}")
+
+
+def _legacy(*, bpm: float = 120.0) -> AnalysisRecord:
+    return AnalysisRecord(
+        track_id="track-1",
+        analysis_version="legacy-v1",
+        features_version="legacy-features-v1",
+        extractor_backend="librosa",
+        extractor_name="baseline",
+        bpm=bpm,
+        bpm_confidence=0.8,
+        key="A",
+        scale="minor",
+        camelot="8A",
+        energy=0.5,
+        loudness_db=-12.0,
+        duration_seconds=180.0,
+    )
+
+
+def _canonical(
+    *,
+    bpm: float = 120.0,
+    track_id: str = "track-1",
+) -> CanonicalAnalysisPersistenceRecord:
+    return CanonicalAnalysisPersistenceRecord(
+        track_id=track_id,
+        provider="baseline",
+        provider_version="1",
+        canonical_analysis_version="canonical-v1",
+        source_analysis_version="legacy-v1",
+        bpm=bpm,
+        bpm_confidence=0.8,
+        key="A minor",
+        key_confidence=None,
+        key_system=None,
+        energy=0.5,
+        energy_confidence=None,
+        loudness_db=-12.0,
+        loudness_integrated_lufs=None,
+        duration_seconds=180.0,
+        sample_rate_hz=None,
+        channels=None,
+        genre_hint=None,
+        analysis_status="complete",
+        analyzed_at=None,
+        warnings_json="[]",
+    )
+
+
+def test_disabled_observer_returns_same_legacy_object_without_dependencies() -> None:
+    legacy = _legacy()
+    observer = CanonicalShadowReader()
+
+    returned = observer.observe_authoritative_legacy_read(legacy)
+
+    assert returned is legacy
+    assert observer.enabled is False
+
+
+def test_enabled_observer_requires_canonical_reader() -> None:
+    with pytest.raises(ValueError, match="canonical_reader"):
+        CanonicalShadowReader(
+            enabled=True,
+            receipt_sink=RecordingSink(),
+        )
+
+
+def test_enabled_observer_requires_receipt_sink() -> None:
+    with pytest.raises(ValueError, match="receipt_sink"):
+        CanonicalShadowReader(
+            enabled=True,
+            canonical_reader=RecordingCanonicalReader(_canonical()),
+        )
+
+
+def test_matching_canonical_record_emits_succeeded_receipt() -> None:
+    legacy = _legacy()
+    reader = RecordingCanonicalReader(_canonical())
+    sink = RecordingSink()
+    ticks = iter((1_000_000, 2_500_000))
+    observer = CanonicalShadowReader(
+        canonical_reader=reader,
+        enabled=True,
+        receipt_sink=sink,
+        monotonic_ns=lambda: next(ticks),
+    )
+
+    returned = observer.observe_authoritative_legacy_read(
+        legacy,
+        correlation_id="request-1",
+    )
+
+    assert returned is legacy
+    assert reader.calls == ["track-1"]
+    assert len(sink.receipts) == 1
+    receipt = sink.receipts[0]
+    assert receipt.outcome == "succeeded"
+    assert receipt.duration_ms == 1.5
+    assert receipt.correlation_id == "request-1"
+
+
+def test_missing_canonical_record_emits_bounded_missing_receipt() -> None:
+    legacy = _legacy()
+    sink = RecordingSink()
+    observer = CanonicalShadowReader(
+        canonical_reader=RecordingCanonicalReader(None),
+        enabled=True,
+        receipt_sink=sink,
+    )
+
+    returned = observer.observe_authoritative_legacy_read(legacy)
+
+    assert returned is legacy
+    receipt = sink.receipts[0]
+    assert receipt.outcome == "canonical_missing"
+    assert receipt.provider is None
+    assert receipt.matched_fields == ()
+    assert receipt.mismatched_fields == ()
+
+
+def test_divergent_canonical_record_emits_mismatch_receipt() -> None:
+    legacy = _legacy()
+    sink = RecordingSink()
+    observer = CanonicalShadowReader(
+        canonical_reader=RecordingCanonicalReader(_canonical(bpm=130.0)),
+        enabled=True,
+        receipt_sink=sink,
+    )
+
+    returned = observer.observe_authoritative_legacy_read(legacy)
+
+    assert returned is legacy
+    receipt = sink.receipts[0]
+    assert receipt.outcome == "mismatch"
+    assert "bpm" in receipt.mismatched_fields
+
+
+def test_canonical_read_failure_does_not_change_legacy_result() -> None:
+    legacy = _legacy()
+    sink = RecordingSink()
+    observer = CanonicalShadowReader(
+        canonical_reader=FailingCanonicalReader(),
+        enabled=True,
+        receipt_sink=sink,
+    )
+
+    returned = observer.observe_authoritative_legacy_read(legacy)
+
+    assert returned is legacy
+    receipt = sink.receipts[0]
+    assert receipt.outcome == "failed"
+    assert receipt.error_type == "RuntimeError"
+
+
+def test_identity_mismatch_is_observed_as_failure() -> None:
+    legacy = _legacy()
+    sink = RecordingSink()
+    observer = CanonicalShadowReader(
+        canonical_reader=RecordingCanonicalReader(
+            _canonical(track_id="different-track")
+        ),
+        enabled=True,
+        receipt_sink=sink,
+    )
+
+    returned = observer.observe_authoritative_legacy_read(legacy)
+
+    assert returned is legacy
+    receipt = sink.receipts[0]
+    assert receipt.outcome == "failed"
+    assert receipt.error_type == "ValueError"
+
+
+def test_receipt_write_failure_does_not_change_legacy_result() -> None:
+    legacy = _legacy()
+    observer = CanonicalShadowReader(
+        canonical_reader=RecordingCanonicalReader(_canonical()),
+        enabled=True,
+        receipt_sink=FailingSink(),
+    )
+
+    returned = observer.observe_authoritative_legacy_read(legacy)
+
+    assert returned is legacy
+
+
+def test_factory_is_default_off_and_does_not_create_product_read_path() -> None:
+    observer = create_canonical_shadow_reader()
+    legacy = _legacy()
+
+    returned = observer.observe_authoritative_legacy_read(legacy)
+
+    assert observer.enabled is False
+    assert returned is legacy

--- a/tests/unit/test_canonical_shadow_reader_profile.py
+++ b/tests/unit/test_canonical_shadow_reader_profile.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+from core.analysis.canonical_shadow_reader_profile import (
+    resolve_canonical_shadow_reader_profile,
+)
+
+
+def test_shadow_reader_is_disabled_by_default() -> None:
+    profile = resolve_canonical_shadow_reader_profile()
+
+    assert profile.enabled is False
+    assert profile.receipts_path is None
+    assert profile.reason == "reader_not_requested"
+
+
+def test_shadow_reader_fails_closed_in_production(tmp_path: Path) -> None:
+    profile = resolve_canonical_shadow_reader_profile(
+        {
+            "APP_ENV": "production",
+            "APPLAYLIST_CANONICAL_SHADOW_READER_ENABLED": "1",
+            "APPLAYLIST_CANONICAL_SHADOW_READER_RECEIPTS_PATH": str(
+                tmp_path / "receipts.jsonl"
+            ),
+        }
+    )
+
+    assert profile.enabled is False
+    assert profile.receipts_path is None
+    assert profile.reason == "production_fail_closed"
+
+
+def test_shadow_reader_requires_allowlisted_environment(tmp_path: Path) -> None:
+    profile = resolve_canonical_shadow_reader_profile(
+        {
+            "APP_ENV": "qa",
+            "APPLAYLIST_CANONICAL_SHADOW_READER_ENABLED": "1",
+            "APPLAYLIST_CANONICAL_SHADOW_READER_RECEIPTS_PATH": str(
+                tmp_path / "receipts.jsonl"
+            ),
+        }
+    )
+
+    assert profile.enabled is False
+    assert profile.reason == "environment_not_allowlisted"
+
+
+def test_shadow_reader_requires_receipts_path() -> None:
+    profile = resolve_canonical_shadow_reader_profile(
+        {
+            "APP_ENV": "test",
+            "APPLAYLIST_CANONICAL_SHADOW_READER_ENABLED": "true",
+        }
+    )
+
+    assert profile.enabled is False
+    assert profile.reason == "receipts_path_required"
+
+
+def test_shadow_reader_can_be_enabled_only_for_bounded_nonlive_use(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "receipts.jsonl"
+    profile = resolve_canonical_shadow_reader_profile(
+        {
+            "APP_ENV": "nonlive",
+            "APPLAYLIST_CANONICAL_SHADOW_READER_ENABLED": "enabled",
+            "APPLAYLIST_CANONICAL_SHADOW_READER_RECEIPTS_PATH": str(path),
+        }
+    )
+
+    assert profile.enabled is True
+    assert profile.receipts_path == path
+    assert profile.reason == "bounded_nonlive_shadow_reader_enabled"


### PR DESCRIPTION
## Scope

WB004E isolated canonical shadow-reader **core only**.

This pull request adds seven new files and does not connect the shadow reader to
an existing product, API, repository, composer, provider-service or runtime request path.

### Added components

- default-off and production-fail-closed runtime profile;
- internal canonical reader protocol and observer;
- reuse of the WB004D canonical/legacy comparator;
- bounded JSONL observation receipts;
- unit tests for disabled, missing, match, mismatch and failure paths;
- architecture boundary contract.

### Verified locally

- exact seven-file all-added commit;
- focused Ruff: PASS;
- focused mypy: PASS;
- focused tests: 18 passed;
- full regression: 226 passed;
- security gate: PASS;
- clean-worktree restore smoke: PASS;
- live database remained byte-identical.

### Explicit boundaries

```text
EXISTING_PRODUCT_FILES_MODIFIED=0
CANONICAL_READER_PRODUCT_PATH=NONE
CANONICAL_READER_ACTIVATION=NONE
LEGACY_ANALYSIS_AUTHORITY=ACTIVE
RUNTIME_AUTHORITY_SWITCH=NONE
PUBLIC_API_CHANGE=NONE
BACKFILL=NONE
WB004F_START=NONE
TRANSITION_INTELLIGENCE_ACTIVATION=NONE
WB006D=HOLD
```

### Non-goals

- no product-path integration;
- no runtime enablement;
- no authority switch;
- no canonical fallback response;
- no API or persistence schema change;
- no backfill;
- no WB004F campaign.

## Review requirement

Review the default-off profile, exception isolation, receipt contents, file permissions,
exact seven-file scope and the guarantee that the observer returns the original
authoritative legacy object.
