### PR TITLE
Bundle 49B: desktop library read model and safe renderer UX

### DIFF
--- a/desktop/host-proof/app.css
+++ b/desktop/host-proof/app.css
@@ -1,0 +1,142 @@
+:root {
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color-scheme: dark;
+  background: #0b0d10;
+  color: #f4f7fb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  background: #0b0d10;
+  color: #f4f7fb;
+}
+
+main {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 32px 0 48px;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+section {
+  margin-top: 24px;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin: 20px 0;
+}
+
+button {
+  border: 1px solid #343a46;
+  border-radius: 8px;
+  background: #171b22;
+  color: inherit;
+  padding: 10px 14px;
+  font: inherit;
+  cursor: pointer;
+}
+
+button:hover:not(:disabled),
+button:focus-visible {
+  border-color: #7f8ba3;
+}
+
+button:focus-visible,
+table:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 3px;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.selected-library,
+.summary-grid {
+  display: grid;
+  grid-template-columns: minmax(120px, auto) 1fr;
+  gap: 8px 16px;
+}
+
+.selected-library dt,
+.summary-grid dt {
+  color: #aab3c2;
+}
+
+.selected-library dd,
+.summary-grid dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.status,
+.empty-state,
+#import-issues {
+  border: 1px solid #2b3039;
+  border-radius: 8px;
+  background: #12161c;
+  padding: 14px 16px;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #10141a;
+}
+
+caption {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+th,
+td {
+  border-bottom: 1px solid #2b3039;
+  padding: 10px 12px;
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  color: #c9d1dd;
+  font-weight: 600;
+}
+
+td {
+  color: #eef2f7;
+}
+
+#import-issues ul {
+  margin-bottom: 0;
+  padding-left: 20px;
+}
+
+[hidden] {
+  display: none !important;
+}

--- a/desktop/host-proof/app.js
+++ b/desktop/host-proof/app.js
@@ -3,6 +3,7 @@
 
   const chooseButton = document.getElementById("choose-library");
   const importButton = document.getElementById("import-library");
+  const importSection = document.getElementById("library-import");
   const selectedLibrary = document.getElementById("selected-library");
   const status = document.getElementById("status");
   const summary = document.getElementById("import-summary");
@@ -12,6 +13,12 @@
   const summaryImported = document.getElementById("summary-imported");
   const summaryPersisted = document.getElementById("summary-persisted");
   const summaryIssues = document.getElementById("summary-issues");
+  const libraryResults = document.getElementById("library-results");
+  const libraryTable = document.getElementById("library-table");
+  const libraryRows = document.getElementById("library-rows");
+  const libraryEmpty = document.getElementById("library-empty");
+  const issuesPanel = document.getElementById("import-issues");
+  const issueList = document.getElementById("issue-list");
 
   const invoke = window.__TAURI__?.core?.invoke;
   let selectedCapability = null;
@@ -25,6 +32,7 @@
     busy = nextBusy;
     chooseButton.disabled = nextBusy;
     importButton.disabled = nextBusy || selectedCapability === null;
+    importSection.setAttribute("aria-busy", nextBusy ? "true" : "false");
   }
 
   function validCapability(value) {
@@ -35,6 +43,44 @@
       value.capability_id.length > 0 &&
       typeof value.display_name === "string" &&
       value.display_name.length > 0
+    );
+  }
+
+  function nullableText(value) {
+    return value === null || typeof value === "string";
+  }
+
+  function validTrack(value) {
+    return (
+      value !== null &&
+      typeof value === "object" &&
+      typeof value.track_id === "string" &&
+      value.track_id.length > 0 &&
+      typeof value.file_name === "string" &&
+      value.file_name.length > 0 &&
+      nullableText(value.title) &&
+      nullableText(value.artist) &&
+      nullableText(value.album) &&
+      nullableText(value.genre) &&
+      (value.duration_seconds === null ||
+        (typeof value.duration_seconds === "number" &&
+          Number.isFinite(value.duration_seconds) &&
+          value.duration_seconds >= 0)) &&
+      typeof value.metadata_origin === "string" &&
+      value.metadata_origin.length > 0 &&
+      typeof value.relinked === "boolean"
+    );
+  }
+
+  function validIssue(value) {
+    return (
+      value !== null &&
+      typeof value === "object" &&
+      typeof value.stage === "string" &&
+      value.stage.length > 0 &&
+      typeof value.code === "string" &&
+      value.code.length > 0 &&
+      (value.file_name === null || typeof value.file_name === "string")
     );
   }
 
@@ -49,7 +95,10 @@
       Number.isInteger(value.counts.accepted) &&
       Number.isInteger(value.counts.imported) &&
       Number.isInteger(value.counts.persisted) &&
+      Array.isArray(value.tracks) &&
+      value.tracks.every(validTrack) &&
       Array.isArray(value.issues) &&
+      value.issues.every(validIssue) &&
       typeof value.complete === "boolean" &&
       typeof value.cancelled === "boolean"
     );
@@ -67,6 +116,30 @@
     return "The desktop host could not complete the request.";
   }
 
+  function displayFormat(fileName) {
+    const dot = fileName.lastIndexOf(".");
+    if (dot <= 0 || dot === fileName.length - 1) {
+      return "Unknown";
+    }
+    return fileName.slice(dot + 1).toUpperCase();
+  }
+
+  function displayDuration(durationSeconds) {
+    if (durationSeconds === null) {
+      return "—";
+    }
+    const totalSeconds = Math.max(0, Math.round(durationSeconds));
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = String(totalSeconds % 60).padStart(2, "0");
+    return `${minutes}:${seconds}`;
+  }
+
+  function appendCell(row, value) {
+    const cell = document.createElement("td");
+    cell.textContent = value;
+    row.appendChild(cell);
+  }
+
   function renderImportSummary(result) {
     summaryLibrary.textContent = result.folder_name;
     summaryDiscovered.textContent = String(result.counts.discovered_entries);
@@ -75,6 +148,57 @@
     summaryPersisted.textContent = String(result.counts.persisted);
     summaryIssues.textContent = String(result.issues.length);
     summary.hidden = false;
+  }
+
+  function renderLibraryTracks(tracks) {
+    libraryRows.replaceChildren();
+    libraryResults.hidden = false;
+
+    if (tracks.length === 0) {
+      libraryTable.hidden = true;
+      libraryEmpty.hidden = false;
+      return;
+    }
+
+    libraryEmpty.hidden = true;
+    libraryTable.hidden = false;
+
+    for (const track of tracks) {
+      const row = document.createElement("tr");
+      appendCell(row, track.title || track.file_name);
+      appendCell(row, track.artist || "Unknown artist");
+      appendCell(row, displayFormat(track.file_name));
+      appendCell(row, displayDuration(track.duration_seconds));
+      appendCell(row, track.relinked ? "Relinked" : "Imported");
+      appendCell(row, track.metadata_origin);
+      libraryRows.appendChild(row);
+    }
+  }
+
+  function renderIssues(issues) {
+    issueList.replaceChildren();
+    if (issues.length === 0) {
+      issuesPanel.hidden = true;
+      return;
+    }
+
+    for (const issue of issues) {
+      const item = document.createElement("li");
+      const file = issue.file_name ? ` — ${issue.file_name}` : "";
+      item.textContent = `${issue.stage}: ${issue.code}${file}`;
+      issueList.appendChild(item);
+    }
+    issuesPanel.hidden = false;
+  }
+
+  function clearResults() {
+    summary.hidden = true;
+    libraryResults.hidden = true;
+    libraryTable.hidden = true;
+    libraryEmpty.hidden = true;
+    issuesPanel.hidden = true;
+    libraryRows.replaceChildren();
+    issueList.replaceChildren();
   }
 
   async function chooseLibrary() {
@@ -97,7 +221,7 @@
 
       selectedCapability = capability;
       selectedLibrary.textContent = capability.display_name;
-      summary.hidden = true;
+      clearResults();
       setStatus("Library selected. Ready to import.");
     } catch (error) {
       setStatus(errorMessage(error));
@@ -122,14 +246,18 @@
       }
 
       renderImportSummary(result);
+      renderLibraryTracks(result.tracks);
+      renderIssues(result.issues);
+
       if (result.cancelled) {
-        setStatus("Import cancelled.");
+        setStatus("Import cancelled. Partial results are shown.");
       } else if (result.complete) {
         setStatus(`Import complete. ${result.counts.persisted} tracks persisted.`);
       } else {
-        setStatus("Import stopped before completion.");
+        setStatus("Import stopped before completion. Partial results are shown.");
       }
     } catch (error) {
+      clearResults();
       setStatus(errorMessage(error));
     } finally {
       setBusy(false);

--- a/desktop/host-proof/index.html
+++ b/desktop/host-proof/index.html
@@ -4,30 +4,31 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>APPLAYLIST Desktop</title>
+  <link rel="stylesheet" href="./app.css">
   <script src="./app.js" defer></script>
 </head>
 <body>
   <main>
     <h1>APPLAYLIST</h1>
-    <section aria-labelledby="library-import-heading">
+    <section id="library-import" aria-labelledby="library-import-heading" aria-busy="false">
       <h2 id="library-import-heading">Library import</h2>
       <p>Select a music library folder, then import it through the authorized desktop bridge.</p>
 
-      <p>
+      <div class="actions">
         <button id="choose-library" type="button">Choose library</button>
         <button id="import-library" type="button" disabled>Import library</button>
-      </p>
+      </div>
 
-      <dl>
+      <dl class="selected-library">
         <dt>Selected library</dt>
         <dd id="selected-library">None</dd>
       </dl>
 
-      <p id="status" role="status" aria-live="polite">Ready.</p>
+      <p id="status" class="status" role="status" aria-live="polite">Ready.</p>
 
       <section id="import-summary" aria-labelledby="import-summary-heading" hidden>
         <h3 id="import-summary-heading">Import summary</h3>
-        <dl>
+        <dl class="summary-grid">
           <dt>Library</dt>
           <dd id="summary-library">—</dd>
           <dt>Discovered</dt>
@@ -41,6 +42,33 @@
           <dt>Issues</dt>
           <dd id="summary-issues">0</dd>
         </dl>
+      </section>
+
+      <section id="library-results" aria-labelledby="library-results-heading" hidden>
+        <h3 id="library-results-heading">Imported tracks</h3>
+        <p id="library-empty" class="empty-state" hidden>No imported tracks were returned for this folder.</p>
+        <div class="table-wrap">
+          <table id="library-table" hidden>
+            <caption>Imported library tracks</caption>
+            <thead>
+              <tr>
+                <th scope="col">Title</th>
+                <th scope="col">Artist</th>
+                <th scope="col">Format</th>
+                <th scope="col">Duration</th>
+                <th scope="col">State</th>
+                <th scope="col">Metadata</th>
+              </tr>
+            </thead>
+            <tbody id="library-rows"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="import-issues" aria-labelledby="import-issues-heading" hidden>
+        <h3 id="import-issues-heading">Import issues</h3>
+        <p>Only bounded issue codes and safe file names are shown.</p>
+        <ul id="issue-list"></ul>
       </section>
     </section>
   </main>

--- a/docs/bundles/BUNDLE_49B_DESKTOP_LIBRARY_READ_MODEL.md
+++ b/docs/bundles/BUNDLE_49B_DESKTOP_LIBRARY_READ_MODEL.md
@@ -1,0 +1,72 @@
+# Bundle 49B — Desktop Library Read Model and Safe Renderer UX
+
+## Status
+
+Implementation slice for issue #100 on canonical base `bc6fd0ab2fa88c21af3f2bddeb8df28b641b92bd`.
+
+## Product value
+
+The existing secure desktop import command already returns bounded track and issue DTOs. Bundle 49B makes those results inspectable without adding renderer filesystem, shell, network or database authority.
+
+## Schema tree
+
+```text
+native folder selection
+  -> opaque LibraryRootCapability
+  -> library_import_root
+  -> DesktopLibraryImportResult
+       |- tracks[]: safe track DTOs
+       `- issues[]: bounded issue DTOs
+  -> renderer validation
+  -> semantic library table / empty state / issue list
+```
+
+## Changed boundary
+
+```text
+BEFORE
+choose -> import -> counts summary
+
+AFTER
+choose -> import -> counts summary
+                 -> imported track read model
+                 -> bounded issue presentation
+                 -> explicit empty/error/result states
+```
+
+No host command, Tauri capability, sidecar protocol or persistence contract changes in this slice.
+
+## Security invariants
+
+- renderer invoke set remains exactly `library_choose_root` and `library_import_root`;
+- renderer receives no generic filesystem or shell API;
+- renderer performs no network call;
+- canonical paths remain host-side and are not rendered;
+- only safe `file_name` values from the existing DTO are displayed;
+- DOM output uses created nodes and `textContent`, never HTML injection sinks;
+- local stylesheet is compatible with the existing `style-src 'self'` CSP.
+
+## Acceptance evidence expected
+
+- Python renderer contract tests pass;
+- PR Guard passes;
+- desktop proof jobs applicable to changed renderer assets pass;
+- exact PR head has no unresolved review threads before merge consideration.
+
+## Out of scope
+
+- streaming import progress;
+- active cancellation command/lifecycle;
+- background job persistence;
+- analysis inspector;
+- provider authority change;
+- signing, notarization, updater or release distribution;
+- merge authorization.
+
+## Follow-up
+
+Bundle 49C should add a bounded import job lifecycle with progress and cancellation. Bundle 50 starts only after Bundle 49 acceptance is complete.
+
+## Rollback
+
+Revert the isolated Bundle 49B commit. The slice has no database migration and adds no new runtime authority.

--- a/tests/test_desktop_renderer_contract.py
+++ b/tests/test_desktop_renderer_contract.py
@@ -7,18 +7,25 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 HTML = ROOT / "desktop" / "host-proof" / "index.html"
 APP_JS = ROOT / "desktop" / "host-proof" / "app.js"
+APP_CSS = ROOT / "desktop" / "host-proof" / "app.css"
 TAURI_CONF = ROOT / "src-tauri" / "tauri.conf.json"
 CAPABILITY = ROOT / "src-tauri" / "capabilities" / "main-library-root.json"
 
 
-def test_renderer_uses_external_script_and_safe_dom_sinks() -> None:
+def test_renderer_uses_external_assets_and_safe_dom_sinks() -> None:
     html = HTML.read_text(encoding="utf-8")
     js = APP_JS.read_text(encoding="utf-8")
+    css = APP_CSS.read_text(encoding="utf-8")
 
     assert '<script src="./app.js" defer></script>' in html
+    assert '<link rel="stylesheet" href="./app.css">' in html
     assert "<script>" not in html
+    assert "<style" not in html
+    assert css.strip()
     assert ".innerHTML" not in js
     assert "insertAdjacentHTML" not in js
+    assert "document.createElement" in js
+    assert ".replaceChildren()" in js
     assert ".textContent" in js
 
 
@@ -44,8 +51,48 @@ def test_renderer_prevents_duplicate_actions_and_handles_cancel() -> None:
 
     assert 'if (busy || typeof invoke !== "function")' in js
     assert "importButton.disabled = nextBusy || selectedCapability === null;" in js
+    assert 'importSection.setAttribute("aria-busy", nextBusy ? "true" : "false");' in js
     assert "if (capability === null)" in js
     assert 'setStatus("Selection cancelled.");' in js
+
+
+def test_renderer_validates_and_renders_bounded_library_read_model() -> None:
+    html = HTML.read_text(encoding="utf-8")
+    js = APP_JS.read_text(encoding="utf-8")
+
+    for required_id in (
+        'id="library-results"',
+        'id="library-empty"',
+        'id="library-table"',
+        'id="library-rows"',
+        'id="import-issues"',
+        'id="issue-list"',
+    ):
+        assert required_id in html
+
+    assert "Array.isArray(value.tracks)" in js
+    assert "value.tracks.every(validTrack)" in js
+    assert "value.issues.every(validIssue)" in js
+    assert "renderLibraryTracks(result.tracks);" in js
+    assert "renderIssues(result.issues);" in js
+    assert "track.title || track.file_name" in js
+    assert "displayFormat(track.file_name)" in js
+    assert "displayDuration(track.duration_seconds)" in js
+    assert 'track.relinked ? "Relinked" : "Imported"' in js
+    assert "track.metadata_origin" in js
+    assert "issue.file_name" in js
+    assert ".path" not in js
+    assert "absolute_path" not in js
+
+
+def test_renderer_has_accessible_table_and_status_regions() -> None:
+    html = HTML.read_text(encoding="utf-8")
+
+    assert 'role="status"' in html
+    assert 'aria-live="polite"' in html
+    assert 'aria-busy="false"' in html
+    assert "<caption>Imported library tracks</caption>" in html
+    assert html.count('scope="col"') == 6
 
 
 def test_renderer_has_no_network_shell_or_filesystem_authority() -> None:


### PR DESCRIPTION
## Summary
- render imported track DTOs in the desktop library table
- show bounded import issues and empty/result states
- preserve the existing renderer command surface
- extend renderer contract tests

## Verification
- base: `bc6fd0ab2fa88c21af3f2bddeb8df28b641b92bd`
- head: `1884a874a2c467919959dee17f0257faeb79c944`
- compare audit: one commit, five changed files
- CI is pending and required before merge consideration

## Notes
- progress/cancellation is deferred to Bundle 49C
- no merge or release action is included

## Bundle Context
- Bundle: 49B
- Base branch: `feature/bundle-0-bootstrap`
- Related issue: #100