### PR TITLE
Bundle 900: align README repository visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Until Bundle 54, do not prioritize cloud accounts, streaming integrations, popul
 
 APPLAYLIST is a **commercial proprietary product**. Original APPLAYLIST code and product-specific materials are **All Rights Reserved** unless a specific file explicitly states otherwise.
 
-- Repository visibility: **PRIVATE**
+- Repository visibility: **PUBLIC**
 - Source-code license: [Proprietary / All Rights Reserved](LICENSE.md)
 - Authorized application builds: [End User License Agreement](EULA.md) plus applicable commercial/beta terms
 - Third-party software: [Third-Party Notices and Release Compliance Index](THIRD_PARTY_NOTICES.md)


### PR DESCRIPTION
## Summary
- align README repository visibility with the actual GitHub repository state;
- change only `Repository visibility: PRIVATE` to `Repository visibility: PUBLIC`;
- preserve proprietary / All Rights Reserved licensing unchanged.

## Verification
- exact base: `bc6fd0ab2fa88c21af3f2bddeb8df28b641b92bd`;
- exact head: `87c914eef16629e56663bacffaaa9c7295ec9aad`;
- compare: 1 commit, 1 file, 1 addition / 1 deletion;
- no runtime, license, repository setting, release or deploy mutation.

## Notes
- documentation-only alignment;
- merge remains separately authorized.

## Bundle Context
- Bundle: 900
- Base branch: `feature/bundle-0-bootstrap`
- Related issue: #104
