### PR TITLE
Bundle 50: analysis job and inspector backend foundation

### DIFF
--- a/core/analysis/inspector_contract.py
+++ b/core/analysis/inspector_contract.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Literal
+
+AnalysisInspectorFilter = Literal["all", "uncertain", "failed", "corrected"]
+AnalysisInspectorSource = Literal["provider", "manual-correction"]
+
+
+@dataclass(frozen=True, slots=True)
+class AnalysisInspectorItem:
+    track_id: str
+    title: str
+    artist: str | None
+    status: Literal["succeeded", "failed"]
+    bpm: float | None
+    bpm_confidence: float | None
+    key_tonic: str | None
+    key_scale: str | None
+    camelot: str | None
+    key_confidence: float | None
+    energy: float | None
+    duration_seconds: float | None
+    provider: str
+    provider_version: str | None
+    analysis_version: str
+    algorithm_version: str | None
+    warnings: tuple[str, ...]
+    source: AnalysisInspectorSource
+    uncertain: bool
+    corrected: bool
+    attempt_evidence_id: str
+    effective_evidence_id: str | None
+    correction_id: str | None = None
+    correction_reason: str | None = None
+    error_code: str | None = None
+    error_detail: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/core/analysis/job_contract.py
+++ b/core/analysis/job_contract.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Literal
+
+AnalysisJobState = Literal[
+    "pending",
+    "running",
+    "cancelling",
+    "done",
+    "failed",
+    "cancelled",
+]
+
+TERMINAL_ANALYSIS_JOB_STATES = frozenset({"done", "failed", "cancelled"})
+
+
+@dataclass(frozen=True, slots=True)
+class AnalysisJobCounts:
+    selected: int
+    completed: int = 0
+    succeeded: int = 0
+    failed: int = 0
+    uncertain: int = 0
+
+    def __post_init__(self) -> None:
+        values = (
+            self.selected,
+            self.completed,
+            self.succeeded,
+            self.failed,
+            self.uncertain,
+        )
+        if any(isinstance(value, bool) or not isinstance(value, int) for value in values):
+            raise TypeError("Analysis job counts must be integers")
+        if any(value < 0 for value in values):
+            raise ValueError("Analysis job counts must be non-negative")
+        if self.completed != self.succeeded + self.failed:
+            raise ValueError("completed must equal succeeded + failed")
+        if self.completed > self.selected:
+            raise ValueError("completed cannot exceed selected")
+        if self.uncertain > self.succeeded:
+            raise ValueError("uncertain cannot exceed succeeded")
+
+    def to_dict(self) -> dict[str, int]:
+        return asdict(self)
+
+    def has_regressed_from(self, previous: AnalysisJobCounts) -> bool:
+        if self.selected != previous.selected:
+            return True
+        return any(
+            current < old
+            for current, old in (
+                (self.completed, previous.completed),
+                (self.succeeded, previous.succeeded),
+                (self.failed, previous.failed),
+                (self.uncertain, previous.uncertain),
+            )
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AnalysisJobSnapshot:
+    job_id: str
+    status: AnalysisJobState
+    counts: AnalysisJobCounts
+    preferred_provider: str | None = None
+    cancel_requested: bool = False
+    error_code: str | None = None
+    error_detail: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.job_id, str) or not self.job_id.strip():
+            raise ValueError("job_id must be a non-empty string")
+        if self.status not in {
+            "pending",
+            "running",
+            "cancelling",
+            "done",
+            "failed",
+            "cancelled",
+        }:
+            raise ValueError("invalid analysis job state")
+        if self.status == "done" and self.counts.completed != self.counts.selected:
+            raise ValueError("done jobs must complete the selected scope")
+        if self.status == "cancelling" and not self.cancel_requested:
+            raise ValueError("cancelling jobs must have cancel_requested=true")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "job_id": self.job_id,
+            "status": self.status,
+            "counts": self.counts.to_dict(),
+            "preferred_provider": self.preferred_provider,
+            "cancel_requested": self.cancel_requested,
+            "error_code": self.error_code,
+            "error_detail": self.error_detail,
+        }

--- a/data/models/analysis_evidence_record.py
+++ b/data/models/analysis_evidence_record.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class AnalysisEvidenceRecord:
+    evidence_id: str
+    track_id: str
+    provider: str
+    analysis_version: str
+    provider_version: str | None = None
+    algorithm_version: str | None = None
+    bpm: float | None = None
+    bpm_confidence: float | None = None
+    key_tonic: str | None = None
+    key_scale: str | None = None
+    camelot: str | None = None
+    key_confidence: float | None = None
+    energy: float | None = None
+    duration_seconds: float | None = None
+    warnings: tuple[str, ...] = ()
+    created_at: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AnalysisCorrectionRecord:
+    correction_id: str
+    track_id: str
+    payload_json: str
+    reason: str | None = None
+    created_at: str | None = None

--- a/data/models/analysis_evidence_record.py
+++ b/data/models/analysis_evidence_record.py
@@ -9,6 +9,7 @@ class AnalysisEvidenceRecord:
     track_id: str
     provider: str
     analysis_version: str
+    status: str = "succeeded"
     provider_version: str | None = None
     algorithm_version: str | None = None
     bpm: float | None = None
@@ -20,6 +21,8 @@ class AnalysisEvidenceRecord:
     energy: float | None = None
     duration_seconds: float | None = None
     warnings: tuple[str, ...] = ()
+    error_code: str | None = None
+    error_detail: str | None = None
     created_at: str | None = None
 
 

--- a/data/models/analysis_evidence_record.py
+++ b/data/models/analysis_evidence_record.py
@@ -19,7 +19,12 @@ class AnalysisEvidenceRecord:
     camelot: str | None = None
     key_confidence: float | None = None
     energy: float | None = None
+    loudness_db: float | None = None
     duration_seconds: float | None = None
+    beat_stability: float | None = None
+    harmonic_ratio: float | None = None
+    percussive_ratio: float | None = None
+    genre_hint: str | None = None
     warnings: tuple[str, ...] = ()
     error_code: str | None = None
     error_detail: str | None = None
@@ -30,6 +35,7 @@ class AnalysisEvidenceRecord:
 class AnalysisCorrectionRecord:
     correction_id: str
     track_id: str
+    base_evidence_id: str
     payload_json: str
     reason: str | None = None
     created_at: str | None = None

--- a/data/models/analysis_job_record.py
+++ b/data/models/analysis_job_record.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class AnalysisJobRecord:
+    job_id: str
+    status: str
+    selected: int
+    completed: int = 0
+    succeeded: int = 0
+    failed: int = 0
+    uncertain: int = 0
+    preferred_provider: str | None = None
+    cancel_requested: bool = False
+    error_code: str | None = None
+    error_detail: str | None = None

--- a/data/repositories/analysis_evidence_repository.py
+++ b/data/repositories/analysis_evidence_repository.py
@@ -21,6 +21,8 @@ class AnalysisEvidenceRepository:
                     track_id TEXT NOT NULL,
                     provider TEXT NOT NULL,
                     analysis_version TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'succeeded'
+                        CHECK (status IN ('succeeded', 'failed')),
                     provider_version TEXT,
                     algorithm_version TEXT,
                     bpm REAL,
@@ -32,10 +34,14 @@ class AnalysisEvidenceRepository:
                     energy REAL,
                     duration_seconds REAL,
                     warnings_json TEXT NOT NULL DEFAULT '[]',
+                    error_code TEXT,
+                    error_detail TEXT,
                     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
                 );
                 CREATE INDEX IF NOT EXISTS idx_analysis_evidence_track_created
                     ON analysis_evidence(track_id, created_at, evidence_id);
+                CREATE INDEX IF NOT EXISTS idx_analysis_evidence_status_created
+                    ON analysis_evidence(status, created_at, evidence_id);
 
                 CREATE TABLE IF NOT EXISTS analysis_corrections (
                     correction_id TEXT PRIMARY KEY,
@@ -48,6 +54,7 @@ class AnalysisEvidenceRepository:
                     ON analysis_corrections(track_id, created_at, correction_id);
                 '''
             )
+            self._ensure_outcome_columns(conn)
             conn.commit()
 
     def append_evidence(
@@ -56,6 +63,7 @@ class AnalysisEvidenceRepository:
         track_id: str,
         provider: str,
         analysis_version: str,
+        status: str = "succeeded",
         provider_version: str | None = None,
         algorithm_version: str | None = None,
         bpm: float | None = None,
@@ -67,6 +75,8 @@ class AnalysisEvidenceRepository:
         energy: float | None = None,
         duration_seconds: float | None = None,
         warnings: tuple[str, ...] = (),
+        error_code: str | None = None,
+        error_detail: str | None = None,
         evidence_id: str | None = None,
     ) -> AnalysisEvidenceRecord:
         normalized_track_id = self._required_text(track_id, "track_id", 256)
@@ -76,12 +86,23 @@ class AnalysisEvidenceRepository:
             "analysis_version",
             128,
         )
+        normalized_status = self._normalize_status(status)
         normalized_warnings = self._normalize_warnings(warnings)
+        normalized_error_code = self._optional_text(error_code, 128)
+        normalized_error_detail = self._optional_text(error_detail, 512)
+        if normalized_status == "succeeded" and (
+            normalized_error_code is not None or normalized_error_detail is not None
+        ):
+            raise ValueError("successful analysis evidence cannot contain failure details")
+        if normalized_status == "failed" and normalized_error_code is None:
+            raise ValueError("failed analysis evidence requires an error_code")
+
         record = AnalysisEvidenceRecord(
             evidence_id=evidence_id or f"ae_{uuid4().hex}",
             track_id=normalized_track_id,
             provider=normalized_provider,
             analysis_version=normalized_analysis_version,
+            status=normalized_status,
             provider_version=self._optional_text(provider_version, 128),
             algorithm_version=self._optional_text(algorithm_version, 128),
             bpm=self._optional_number(bpm, "bpm", minimum=1.0, maximum=400.0),
@@ -108,24 +129,27 @@ class AnalysisEvidenceRepository:
                 maximum=None,
             ),
             warnings=normalized_warnings,
+            error_code=normalized_error_code,
+            error_detail=normalized_error_detail,
         )
         self.ensure_schema()
         with get_sqlite_connection() as conn:
             conn.execute(
                 '''
                 INSERT INTO analysis_evidence (
-                    evidence_id, track_id, provider, analysis_version,
+                    evidence_id, track_id, provider, analysis_version, status,
                     provider_version, algorithm_version, bpm, bpm_confidence,
                     key_tonic, key_scale, camelot, key_confidence, energy,
-                    duration_seconds, warnings_json
+                    duration_seconds, warnings_json, error_code, error_detail
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ''',
                 (
                     record.evidence_id,
                     record.track_id,
                     record.provider,
                     record.analysis_version,
+                    record.status,
                     record.provider_version,
                     record.algorithm_version,
                     record.bpm,
@@ -137,6 +161,8 @@ class AnalysisEvidenceRepository:
                     record.energy,
                     record.duration_seconds,
                     json.dumps(record.warnings, separators=(",", ":")),
+                    record.error_code,
+                    record.error_detail,
                 ),
             )
             conn.commit()
@@ -237,6 +263,31 @@ class AnalysisEvidenceRepository:
         if row is None:
             return None
         return AnalysisCorrectionRecord(**dict(row))
+
+    @staticmethod
+    def _ensure_outcome_columns(conn: object) -> None:
+        columns = {
+            str(row[1])
+            for row in conn.execute("PRAGMA table_info(analysis_evidence)").fetchall()  # type: ignore[attr-defined]
+        }
+        for name, declaration in (
+            ("status", "TEXT NOT NULL DEFAULT 'succeeded'"),
+            ("error_code", "TEXT"),
+            ("error_detail", "TEXT"),
+        ):
+            if name not in columns:
+                conn.execute(  # type: ignore[attr-defined]
+                    f"ALTER TABLE analysis_evidence ADD COLUMN {name} {declaration}"
+                )
+
+    @staticmethod
+    def _normalize_status(value: str) -> str:
+        if not isinstance(value, str):
+            raise TypeError("analysis evidence status must be text")
+        normalized = value.strip().lower()
+        if normalized not in {"succeeded", "failed"}:
+            raise ValueError("analysis evidence status must be succeeded or failed")
+        return normalized
 
     @staticmethod
     def _required_text(value: str, field: str, maximum_length: int) -> str:
@@ -344,6 +395,7 @@ class AnalysisEvidenceRepository:
             track_id=str(row["track_id"]),
             provider=str(row["provider"]),
             analysis_version=str(row["analysis_version"]),
+            status=str(row["status"]),
             provider_version=(
                 str(row["provider_version"])
                 if row["provider_version"] is not None
@@ -375,5 +427,11 @@ class AnalysisEvidenceRepository:
                 else None
             ),
             warnings=tuple(warnings),
+            error_code=(str(row["error_code"]) if row["error_code"] is not None else None),
+            error_detail=(
+                str(row["error_detail"])
+                if row["error_detail"] is not None
+                else None
+            ),
             created_at=(str(row["created_at"]) if row["created_at"] is not None else None),
         )

--- a/data/repositories/analysis_evidence_repository.py
+++ b/data/repositories/analysis_evidence_repository.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from uuid import uuid4
+
+from data.connection import get_sqlite_connection
+from data.models.analysis_evidence_record import (
+    AnalysisCorrectionRecord,
+    AnalysisEvidenceRecord,
+)
+
+
+class AnalysisEvidenceRepository:
+    def ensure_schema(self) -> None:
+        with get_sqlite_connection() as conn:
+            conn.executescript(
+                '''
+                CREATE TABLE IF NOT EXISTS analysis_evidence (
+                    evidence_id TEXT PRIMARY KEY,
+                    track_id TEXT NOT NULL,
+                    provider TEXT NOT NULL,
+                    analysis_version TEXT NOT NULL,
+                    provider_version TEXT,
+                    algorithm_version TEXT,
+                    bpm REAL,
+                    bpm_confidence REAL,
+                    key_tonic TEXT,
+                    key_scale TEXT,
+                    camelot TEXT,
+                    key_confidence REAL,
+                    energy REAL,
+                    duration_seconds REAL,
+                    warnings_json TEXT NOT NULL DEFAULT '[]',
+                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                );
+                CREATE INDEX IF NOT EXISTS idx_analysis_evidence_track_created
+                    ON analysis_evidence(track_id, created_at, evidence_id);
+
+                CREATE TABLE IF NOT EXISTS analysis_corrections (
+                    correction_id TEXT PRIMARY KEY,
+                    track_id TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    reason TEXT,
+                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                );
+                CREATE INDEX IF NOT EXISTS idx_analysis_corrections_track_created
+                    ON analysis_corrections(track_id, created_at, correction_id);
+                '''
+            )
+            conn.commit()
+
+    def append_evidence(
+        self,
+        *,
+        track_id: str,
+        provider: str,
+        analysis_version: str,
+        provider_version: str | None = None,
+        algorithm_version: str | None = None,
+        bpm: float | None = None,
+        bpm_confidence: float | None = None,
+        key_tonic: str | None = None,
+        key_scale: str | None = None,
+        camelot: str | None = None,
+        key_confidence: float | None = None,
+        energy: float | None = None,
+        duration_seconds: float | None = None,
+        warnings: tuple[str, ...] = (),
+        evidence_id: str | None = None,
+    ) -> AnalysisEvidenceRecord:
+        normalized_track_id = self._required_text(track_id, "track_id", 256)
+        normalized_provider = self._required_text(provider, "provider", 128).lower()
+        normalized_analysis_version = self._required_text(
+            analysis_version,
+            "analysis_version",
+            128,
+        )
+        normalized_warnings = self._normalize_warnings(warnings)
+        record = AnalysisEvidenceRecord(
+            evidence_id=evidence_id or f"ae_{uuid4().hex}",
+            track_id=normalized_track_id,
+            provider=normalized_provider,
+            analysis_version=normalized_analysis_version,
+            provider_version=self._optional_text(provider_version, 128),
+            algorithm_version=self._optional_text(algorithm_version, 128),
+            bpm=self._optional_number(bpm, "bpm", minimum=1.0, maximum=400.0),
+            bpm_confidence=self._optional_number(
+                bpm_confidence,
+                "bpm_confidence",
+                minimum=0.0,
+                maximum=1.0,
+            ),
+            key_tonic=self._optional_text(key_tonic, 16),
+            key_scale=self._optional_text(key_scale, 16),
+            camelot=self._optional_text(camelot, 3),
+            key_confidence=self._optional_number(
+                key_confidence,
+                "key_confidence",
+                minimum=0.0,
+                maximum=1.0,
+            ),
+            energy=self._optional_number(energy, "energy", minimum=0.0, maximum=1.0),
+            duration_seconds=self._optional_number(
+                duration_seconds,
+                "duration_seconds",
+                minimum=0.0,
+                maximum=None,
+            ),
+            warnings=normalized_warnings,
+        )
+        self.ensure_schema()
+        with get_sqlite_connection() as conn:
+            conn.execute(
+                '''
+                INSERT INTO analysis_evidence (
+                    evidence_id, track_id, provider, analysis_version,
+                    provider_version, algorithm_version, bpm, bpm_confidence,
+                    key_tonic, key_scale, camelot, key_confidence, energy,
+                    duration_seconds, warnings_json
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ''',
+                (
+                    record.evidence_id,
+                    record.track_id,
+                    record.provider,
+                    record.analysis_version,
+                    record.provider_version,
+                    record.algorithm_version,
+                    record.bpm,
+                    record.bpm_confidence,
+                    record.key_tonic,
+                    record.key_scale,
+                    record.camelot,
+                    record.key_confidence,
+                    record.energy,
+                    record.duration_seconds,
+                    json.dumps(record.warnings, separators=(",", ":")),
+                ),
+            )
+            conn.commit()
+        inserted = self.get_evidence(record.evidence_id)
+        if inserted is None:
+            raise RuntimeError("analysis evidence insert was not observable")
+        return inserted
+
+    def append_correction(
+        self,
+        *,
+        track_id: str,
+        values: Mapping[str, object],
+        reason: str | None = None,
+        correction_id: str | None = None,
+    ) -> AnalysisCorrectionRecord:
+        normalized_track_id = self._required_text(track_id, "track_id", 256)
+        payload = self._normalize_correction_values(values)
+        payload_json = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        record = AnalysisCorrectionRecord(
+            correction_id=correction_id or f"ac_{uuid4().hex}",
+            track_id=normalized_track_id,
+            payload_json=payload_json,
+            reason=self._optional_text(reason, 512),
+        )
+        self.ensure_schema()
+        with get_sqlite_connection() as conn:
+            conn.execute(
+                '''
+                INSERT INTO analysis_corrections (
+                    correction_id, track_id, payload_json, reason
+                )
+                VALUES (?, ?, ?, ?)
+                ''',
+                (
+                    record.correction_id,
+                    record.track_id,
+                    record.payload_json,
+                    record.reason,
+                ),
+            )
+            conn.commit()
+        inserted = self.get_correction(record.correction_id)
+        if inserted is None:
+            raise RuntimeError("analysis correction insert was not observable")
+        return inserted
+
+    def get_evidence(self, evidence_id: str) -> AnalysisEvidenceRecord | None:
+        self.ensure_schema()
+        with get_sqlite_connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM analysis_evidence WHERE evidence_id = ?",
+                (evidence_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return self._evidence_from_row(dict(row))
+
+    def get_correction(self, correction_id: str) -> AnalysisCorrectionRecord | None:
+        self.ensure_schema()
+        with get_sqlite_connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM analysis_corrections WHERE correction_id = ?",
+                (correction_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return AnalysisCorrectionRecord(**dict(row))
+
+    def latest_evidence_for_track(self, track_id: str) -> AnalysisEvidenceRecord | None:
+        self.ensure_schema()
+        with get_sqlite_connection() as conn:
+            row = conn.execute(
+                '''
+                SELECT * FROM analysis_evidence
+                WHERE track_id = ?
+                ORDER BY created_at DESC, evidence_id DESC
+                LIMIT 1
+                ''',
+                (track_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return self._evidence_from_row(dict(row))
+
+    def latest_correction_for_track(self, track_id: str) -> AnalysisCorrectionRecord | None:
+        self.ensure_schema()
+        with get_sqlite_connection() as conn:
+            row = conn.execute(
+                '''
+                SELECT * FROM analysis_corrections
+                WHERE track_id = ?
+                ORDER BY created_at DESC, correction_id DESC
+                LIMIT 1
+                ''',
+                (track_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return AnalysisCorrectionRecord(**dict(row))
+
+    @staticmethod
+    def _required_text(value: str, field: str, maximum_length: int) -> str:
+        if not isinstance(value, str):
+            raise TypeError(f"{field} must be text")
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError(f"{field} must be non-empty")
+        if len(normalized) > maximum_length:
+            raise ValueError(f"{field} is too long")
+        return normalized
+
+    @staticmethod
+    def _optional_text(value: str | None, maximum_length: int) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise TypeError("optional text field must be text")
+        normalized = value.strip()
+        if not normalized:
+            return None
+        if len(normalized) > maximum_length:
+            raise ValueError("optional text field is too long")
+        return normalized
+
+    @staticmethod
+    def _optional_number(
+        value: float | int | None,
+        field: str,
+        *,
+        minimum: float | None,
+        maximum: float | None,
+    ) -> float | None:
+        if value is None:
+            return None
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(f"{field} must be numeric")
+        normalized = float(value)
+        if minimum is not None and normalized < minimum:
+            raise ValueError(f"{field} is below minimum")
+        if maximum is not None and normalized > maximum:
+            raise ValueError(f"{field} is above maximum")
+        return normalized
+
+    @classmethod
+    def _normalize_warnings(cls, warnings: tuple[str, ...]) -> tuple[str, ...]:
+        if not isinstance(warnings, tuple):
+            raise TypeError("warnings must be a tuple")
+        if len(warnings) > 32:
+            raise ValueError("too many analysis warnings")
+        normalized: list[str] = []
+        for warning in warnings:
+            text = cls._required_text(warning, "warning", 256)
+            if text not in normalized:
+                normalized.append(text)
+        return tuple(normalized)
+
+    @classmethod
+    def _normalize_correction_values(
+        cls,
+        values: Mapping[str, object],
+    ) -> dict[str, object]:
+        if not isinstance(values, Mapping):
+            raise TypeError("correction values must be an object")
+        allowed = {"bpm", "key_tonic", "key_scale", "camelot", "energy"}
+        unknown = set(values) - allowed
+        if unknown:
+            raise ValueError("correction contains unsupported fields")
+        if not values:
+            raise ValueError("correction must change at least one field")
+        payload: dict[str, object] = {}
+        if "bpm" in values:
+            payload["bpm"] = cls._optional_number(
+                values["bpm"],  # type: ignore[arg-type]
+                "bpm",
+                minimum=1.0,
+                maximum=400.0,
+            )
+        if "energy" in values:
+            payload["energy"] = cls._optional_number(
+                values["energy"],  # type: ignore[arg-type]
+                "energy",
+                minimum=0.0,
+                maximum=1.0,
+            )
+        for field, maximum_length in (
+            ("key_tonic", 16),
+            ("key_scale", 16),
+            ("camelot", 3),
+        ):
+            if field in values:
+                raw_value = values[field]
+                if raw_value is not None and not isinstance(raw_value, str):
+                    raise TypeError(f"{field} must be text or null")
+                payload[field] = cls._optional_text(raw_value, maximum_length)  # type: ignore[arg-type]
+        return payload
+
+    @staticmethod
+    def _evidence_from_row(row: dict[str, object]) -> AnalysisEvidenceRecord:
+        warnings = json.loads(str(row["warnings_json"]))
+        if not isinstance(warnings, list) or not all(isinstance(item, str) for item in warnings):
+            raise ValueError("stored analysis warnings are invalid")
+        return AnalysisEvidenceRecord(
+            evidence_id=str(row["evidence_id"]),
+            track_id=str(row["track_id"]),
+            provider=str(row["provider"]),
+            analysis_version=str(row["analysis_version"]),
+            provider_version=(
+                str(row["provider_version"])
+                if row["provider_version"] is not None
+                else None
+            ),
+            algorithm_version=(
+                str(row["algorithm_version"])
+                if row["algorithm_version"] is not None
+                else None
+            ),
+            bpm=float(row["bpm"]) if row["bpm"] is not None else None,
+            bpm_confidence=(
+                float(row["bpm_confidence"])
+                if row["bpm_confidence"] is not None
+                else None
+            ),
+            key_tonic=(str(row["key_tonic"]) if row["key_tonic"] is not None else None),
+            key_scale=(str(row["key_scale"]) if row["key_scale"] is not None else None),
+            camelot=(str(row["camelot"]) if row["camelot"] is not None else None),
+            key_confidence=(
+                float(row["key_confidence"])
+                if row["key_confidence"] is not None
+                else None
+            ),
+            energy=float(row["energy"]) if row["energy"] is not None else None,
+            duration_seconds=(
+                float(row["duration_seconds"])
+                if row["duration_seconds"] is not None
+                else None
+            ),
+            warnings=tuple(warnings),
+            created_at=(str(row["created_at"]) if row["created_at"] is not None else None),
+        )

--- a/data/repositories/analysis_evidence_repository.py
+++ b/data/repositories/analysis_evidence_repository.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import math
 import re
+import time
 from collections.abc import Mapping
 from uuid import uuid4
 
@@ -45,10 +46,6 @@ class AnalysisEvidenceRepository:
                     error_detail TEXT,
                     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
                 );
-                CREATE INDEX IF NOT EXISTS idx_analysis_evidence_track_created
-                    ON analysis_evidence(track_id, created_at, evidence_id);
-                CREATE INDEX IF NOT EXISTS idx_analysis_evidence_status_created
-                    ON analysis_evidence(status, created_at, evidence_id);
 
                 CREATE TABLE IF NOT EXISTS analysis_corrections (
                     correction_id TEXT PRIMARY KEY,
@@ -58,13 +55,21 @@ class AnalysisEvidenceRepository:
                     reason TEXT,
                     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
                 );
+                '''
+            )
+            self._ensure_columns(conn)
+            conn.executescript(
+                '''
+                CREATE INDEX IF NOT EXISTS idx_analysis_evidence_track_created
+                    ON analysis_evidence(track_id, created_at, evidence_id);
+                CREATE INDEX IF NOT EXISTS idx_analysis_evidence_status_created
+                    ON analysis_evidence(status, created_at, evidence_id);
                 CREATE INDEX IF NOT EXISTS idx_analysis_corrections_track_created
                     ON analysis_corrections(track_id, created_at, correction_id);
                 CREATE INDEX IF NOT EXISTS idx_analysis_corrections_base_created
                     ON analysis_corrections(base_evidence_id, created_at, correction_id);
                 '''
             )
-            self._ensure_columns(conn)
             conn.commit()
 
     def append_evidence(
@@ -113,7 +118,7 @@ class AnalysisEvidenceRepository:
             raise ValueError("failed analysis evidence requires an error_code")
 
         record = AnalysisEvidenceRecord(
-            evidence_id=evidence_id or f"ae_{uuid4().hex}",
+            evidence_id=evidence_id or self._ordered_id("ae"),
             track_id=normalized_track_id,
             provider=normalized_provider,
             analysis_version=normalized_analysis_version,
@@ -238,7 +243,7 @@ class AnalysisEvidenceRepository:
         payload = self._normalize_correction_values(values)
         payload_json = json.dumps(payload, sort_keys=True, separators=(",", ":"))
         record = AnalysisCorrectionRecord(
-            correction_id=correction_id or f"ac_{uuid4().hex}",
+            correction_id=correction_id or self._ordered_id("ac"),
             track_id=normalized_track_id,
             base_evidence_id=normalized_base_evidence_id,
             payload_json=payload_json,
@@ -407,6 +412,10 @@ class AnalysisEvidenceRepository:
                 "ALTER TABLE analysis_corrections "
                 "ADD COLUMN base_evidence_id TEXT NOT NULL DEFAULT ''"
             )
+
+    @staticmethod
+    def _ordered_id(prefix: str) -> str:
+        return f"{prefix}_{time.time_ns():020d}_{uuid4().hex}"
 
     @staticmethod
     def _normalize_status(value: str) -> str:

--- a/data/repositories/analysis_evidence_repository.py
+++ b/data/repositories/analysis_evidence_repository.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import math
+import re
 from collections.abc import Mapping
 from uuid import uuid4
 
@@ -32,7 +34,12 @@ class AnalysisEvidenceRepository:
                     camelot TEXT,
                     key_confidence REAL,
                     energy REAL,
+                    loudness_db REAL,
                     duration_seconds REAL,
+                    beat_stability REAL,
+                    harmonic_ratio REAL,
+                    percussive_ratio REAL,
+                    genre_hint TEXT,
                     warnings_json TEXT NOT NULL DEFAULT '[]',
                     error_code TEXT,
                     error_detail TEXT,
@@ -46,15 +53,18 @@ class AnalysisEvidenceRepository:
                 CREATE TABLE IF NOT EXISTS analysis_corrections (
                     correction_id TEXT PRIMARY KEY,
                     track_id TEXT NOT NULL,
+                    base_evidence_id TEXT NOT NULL,
                     payload_json TEXT NOT NULL,
                     reason TEXT,
                     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
                 );
                 CREATE INDEX IF NOT EXISTS idx_analysis_corrections_track_created
                     ON analysis_corrections(track_id, created_at, correction_id);
+                CREATE INDEX IF NOT EXISTS idx_analysis_corrections_base_created
+                    ON analysis_corrections(base_evidence_id, created_at, correction_id);
                 '''
             )
-            self._ensure_outcome_columns(conn)
+            self._ensure_columns(conn)
             conn.commit()
 
     def append_evidence(
@@ -73,7 +83,12 @@ class AnalysisEvidenceRepository:
         camelot: str | None = None,
         key_confidence: float | None = None,
         energy: float | None = None,
+        loudness_db: float | None = None,
         duration_seconds: float | None = None,
+        beat_stability: float | None = None,
+        harmonic_ratio: float | None = None,
+        percussive_ratio: float | None = None,
+        genre_hint: str | None = None,
         warnings: tuple[str, ...] = (),
         error_code: str | None = None,
         error_detail: str | None = None,
@@ -105,7 +120,7 @@ class AnalysisEvidenceRepository:
             status=normalized_status,
             provider_version=self._optional_text(provider_version, 128),
             algorithm_version=self._optional_text(algorithm_version, 128),
-            bpm=self._optional_number(bpm, "bpm", minimum=1.0, maximum=400.0),
+            bpm=self._optional_number(bpm, "bpm", minimum=20.0, maximum=400.0),
             bpm_confidence=self._optional_number(
                 bpm_confidence,
                 "bpm_confidence",
@@ -113,8 +128,8 @@ class AnalysisEvidenceRepository:
                 maximum=1.0,
             ),
             key_tonic=self._optional_text(key_tonic, 16),
-            key_scale=self._optional_text(key_scale, 16),
-            camelot=self._optional_text(camelot, 3),
+            key_scale=self._optional_scale(key_scale),
+            camelot=self._optional_camelot(camelot),
             key_confidence=self._optional_number(
                 key_confidence,
                 "key_confidence",
@@ -122,12 +137,37 @@ class AnalysisEvidenceRepository:
                 maximum=1.0,
             ),
             energy=self._optional_number(energy, "energy", minimum=0.0, maximum=1.0),
+            loudness_db=self._optional_number(
+                loudness_db,
+                "loudness_db",
+                minimum=None,
+                maximum=None,
+            ),
             duration_seconds=self._optional_number(
                 duration_seconds,
                 "duration_seconds",
                 minimum=0.0,
                 maximum=None,
             ),
+            beat_stability=self._optional_number(
+                beat_stability,
+                "beat_stability",
+                minimum=0.0,
+                maximum=1.0,
+            ),
+            harmonic_ratio=self._optional_number(
+                harmonic_ratio,
+                "harmonic_ratio",
+                minimum=0.0,
+                maximum=1.0,
+            ),
+            percussive_ratio=self._optional_number(
+                percussive_ratio,
+                "percussive_ratio",
+                minimum=0.0,
+                maximum=1.0,
+            ),
+            genre_hint=self._optional_text(genre_hint, 128),
             warnings=normalized_warnings,
             error_code=normalized_error_code,
             error_detail=normalized_error_detail,
@@ -140,9 +180,10 @@ class AnalysisEvidenceRepository:
                     evidence_id, track_id, provider, analysis_version, status,
                     provider_version, algorithm_version, bpm, bpm_confidence,
                     key_tonic, key_scale, camelot, key_confidence, energy,
-                    duration_seconds, warnings_json, error_code, error_detail
+                    loudness_db, duration_seconds, beat_stability, harmonic_ratio,
+                    percussive_ratio, genre_hint, warnings_json, error_code, error_detail
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ''',
                 (
                     record.evidence_id,
@@ -159,7 +200,12 @@ class AnalysisEvidenceRepository:
                     record.camelot,
                     record.key_confidence,
                     record.energy,
+                    record.loudness_db,
                     record.duration_seconds,
+                    record.beat_stability,
+                    record.harmonic_ratio,
+                    record.percussive_ratio,
+                    record.genre_hint,
                     json.dumps(record.warnings, separators=(",", ":")),
                     record.error_code,
                     record.error_detail,
@@ -175,16 +221,26 @@ class AnalysisEvidenceRepository:
         self,
         *,
         track_id: str,
+        base_evidence_id: str,
         values: Mapping[str, object],
         reason: str | None = None,
         correction_id: str | None = None,
     ) -> AnalysisCorrectionRecord:
         normalized_track_id = self._required_text(track_id, "track_id", 256)
+        normalized_base_evidence_id = self._required_text(
+            base_evidence_id,
+            "base_evidence_id",
+            256,
+        )
+        base = self.get_evidence(normalized_base_evidence_id)
+        if base is None or base.track_id != normalized_track_id or base.status != "succeeded":
+            raise ValueError("correction must reference successful evidence for the same track")
         payload = self._normalize_correction_values(values)
         payload_json = json.dumps(payload, sort_keys=True, separators=(",", ":"))
         record = AnalysisCorrectionRecord(
             correction_id=correction_id or f"ac_{uuid4().hex}",
             track_id=normalized_track_id,
+            base_evidence_id=normalized_base_evidence_id,
             payload_json=payload_json,
             reason=self._optional_text(reason, 512),
         )
@@ -193,13 +249,14 @@ class AnalysisEvidenceRepository:
             conn.execute(
                 '''
                 INSERT INTO analysis_corrections (
-                    correction_id, track_id, payload_json, reason
+                    correction_id, track_id, base_evidence_id, payload_json, reason
                 )
-                VALUES (?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?)
                 ''',
                 (
                     record.correction_id,
                     record.track_id,
+                    record.base_evidence_id,
                     record.payload_json,
                     record.reason,
                 ),
@@ -233,20 +290,34 @@ class AnalysisEvidenceRepository:
         return AnalysisCorrectionRecord(**dict(row))
 
     def latest_evidence_for_track(self, track_id: str) -> AnalysisEvidenceRecord | None:
+        return self._latest_evidence(track_id, succeeded_only=False)
+
+    def latest_success_for_track(self, track_id: str) -> AnalysisEvidenceRecord | None:
+        return self._latest_evidence(track_id, succeeded_only=True)
+
+    def list_latest_attempts(self) -> list[AnalysisEvidenceRecord]:
         self.ensure_schema()
         with get_sqlite_connection() as conn:
-            row = conn.execute(
+            rows = conn.execute(
                 '''
-                SELECT * FROM analysis_evidence
-                WHERE track_id = ?
-                ORDER BY created_at DESC, evidence_id DESC
-                LIMIT 1
-                ''',
-                (track_id,),
-            ).fetchone()
-        if row is None:
-            return None
-        return self._evidence_from_row(dict(row))
+                SELECT evidence.*
+                FROM analysis_evidence AS evidence
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM analysis_evidence AS newer
+                    WHERE newer.track_id = evidence.track_id
+                      AND (
+                          newer.created_at > evidence.created_at
+                          OR (
+                              newer.created_at = evidence.created_at
+                              AND newer.evidence_id > evidence.evidence_id
+                          )
+                      )
+                )
+                ORDER BY evidence.track_id
+                '''
+            ).fetchall()
+        return [self._evidence_from_row(dict(row)) for row in rows]
 
     def latest_correction_for_track(self, track_id: str) -> AnalysisCorrectionRecord | None:
         self.ensure_schema()
@@ -264,21 +335,78 @@ class AnalysisEvidenceRepository:
             return None
         return AnalysisCorrectionRecord(**dict(row))
 
+    def latest_active_correction(
+        self,
+        track_id: str,
+        base_evidence_id: str,
+    ) -> AnalysisCorrectionRecord | None:
+        self.ensure_schema()
+        with get_sqlite_connection() as conn:
+            row = conn.execute(
+                '''
+                SELECT * FROM analysis_corrections
+                WHERE track_id = ? AND base_evidence_id = ?
+                ORDER BY created_at DESC, correction_id DESC
+                LIMIT 1
+                ''',
+                (track_id, base_evidence_id),
+            ).fetchone()
+        if row is None:
+            return None
+        return AnalysisCorrectionRecord(**dict(row))
+
+    def _latest_evidence(
+        self,
+        track_id: str,
+        *,
+        succeeded_only: bool,
+    ) -> AnalysisEvidenceRecord | None:
+        self.ensure_schema()
+        status_clause = "AND status = 'succeeded'" if succeeded_only else ""
+        with get_sqlite_connection() as conn:
+            row = conn.execute(
+                f'''
+                SELECT * FROM analysis_evidence
+                WHERE track_id = ? {status_clause}
+                ORDER BY created_at DESC, evidence_id DESC
+                LIMIT 1
+                ''',
+                (track_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return self._evidence_from_row(dict(row))
+
     @staticmethod
-    def _ensure_outcome_columns(conn: object) -> None:
-        columns = {
+    def _ensure_columns(conn: object) -> None:
+        evidence_columns = {
             str(row[1])
             for row in conn.execute("PRAGMA table_info(analysis_evidence)").fetchall()  # type: ignore[attr-defined]
         }
         for name, declaration in (
             ("status", "TEXT NOT NULL DEFAULT 'succeeded'"),
+            ("loudness_db", "REAL"),
+            ("beat_stability", "REAL"),
+            ("harmonic_ratio", "REAL"),
+            ("percussive_ratio", "REAL"),
+            ("genre_hint", "TEXT"),
             ("error_code", "TEXT"),
             ("error_detail", "TEXT"),
         ):
-            if name not in columns:
+            if name not in evidence_columns:
                 conn.execute(  # type: ignore[attr-defined]
                     f"ALTER TABLE analysis_evidence ADD COLUMN {name} {declaration}"
                 )
+
+        correction_columns = {
+            str(row[1])
+            for row in conn.execute("PRAGMA table_info(analysis_corrections)").fetchall()  # type: ignore[attr-defined]
+        }
+        if "base_evidence_id" not in correction_columns:
+            conn.execute(  # type: ignore[attr-defined]
+                "ALTER TABLE analysis_corrections "
+                "ADD COLUMN base_evidence_id TEXT NOT NULL DEFAULT ''"
+            )
 
     @staticmethod
     def _normalize_status(value: str) -> str:
@@ -313,6 +441,26 @@ class AnalysisEvidenceRepository:
             raise ValueError("optional text field is too long")
         return normalized
 
+    @classmethod
+    def _optional_scale(cls, value: str | None) -> str | None:
+        normalized = cls._optional_text(value, 16)
+        if normalized is None:
+            return None
+        normalized = normalized.lower()
+        if normalized not in {"major", "minor"}:
+            raise ValueError("key_scale must be major or minor")
+        return normalized
+
+    @classmethod
+    def _optional_camelot(cls, value: str | None) -> str | None:
+        normalized = cls._optional_text(value, 3)
+        if normalized is None:
+            return None
+        normalized = normalized.upper()
+        if re.fullmatch(r"(?:[1-9]|1[0-2])[AB]", normalized) is None:
+            raise ValueError("camelot must be between 1A and 12B")
+        return normalized
+
     @staticmethod
     def _optional_number(
         value: float | int | None,
@@ -326,6 +474,8 @@ class AnalysisEvidenceRepository:
         if isinstance(value, bool) or not isinstance(value, (int, float)):
             raise TypeError(f"{field} must be numeric")
         normalized = float(value)
+        if not math.isfinite(normalized):
+            raise ValueError(f"{field} must be finite")
         if minimum is not None and normalized < minimum:
             raise ValueError(f"{field} is below minimum")
         if maximum is not None and normalized > maximum:
@@ -363,7 +513,7 @@ class AnalysisEvidenceRepository:
             payload["bpm"] = cls._optional_number(
                 values["bpm"],  # type: ignore[arg-type]
                 "bpm",
-                minimum=1.0,
+                minimum=20.0,
                 maximum=400.0,
             )
         if "energy" in values:
@@ -373,16 +523,21 @@ class AnalysisEvidenceRepository:
                 minimum=0.0,
                 maximum=1.0,
             )
-        for field, maximum_length in (
-            ("key_tonic", 16),
-            ("key_scale", 16),
-            ("camelot", 3),
-        ):
-            if field in values:
-                raw_value = values[field]
-                if raw_value is not None and not isinstance(raw_value, str):
-                    raise TypeError(f"{field} must be text or null")
-                payload[field] = cls._optional_text(raw_value, maximum_length)  # type: ignore[arg-type]
+        if "key_tonic" in values:
+            raw_tonic = values["key_tonic"]
+            if raw_tonic is not None and not isinstance(raw_tonic, str):
+                raise TypeError("key_tonic must be text or null")
+            payload["key_tonic"] = cls._optional_text(raw_tonic, 16)  # type: ignore[arg-type]
+        if "key_scale" in values:
+            raw_scale = values["key_scale"]
+            if raw_scale is not None and not isinstance(raw_scale, str):
+                raise TypeError("key_scale must be text or null")
+            payload["key_scale"] = cls._optional_scale(raw_scale)  # type: ignore[arg-type]
+        if "camelot" in values:
+            raw_camelot = values["camelot"]
+            if raw_camelot is not None and not isinstance(raw_camelot, str):
+                raise TypeError("camelot must be text or null")
+            payload["camelot"] = cls._optional_camelot(raw_camelot)  # type: ignore[arg-type]
         return payload
 
     @staticmethod
@@ -421,11 +576,32 @@ class AnalysisEvidenceRepository:
                 else None
             ),
             energy=float(row["energy"]) if row["energy"] is not None else None,
+            loudness_db=(
+                float(row["loudness_db"])
+                if row["loudness_db"] is not None
+                else None
+            ),
             duration_seconds=(
                 float(row["duration_seconds"])
                 if row["duration_seconds"] is not None
                 else None
             ),
+            beat_stability=(
+                float(row["beat_stability"])
+                if row["beat_stability"] is not None
+                else None
+            ),
+            harmonic_ratio=(
+                float(row["harmonic_ratio"])
+                if row["harmonic_ratio"] is not None
+                else None
+            ),
+            percussive_ratio=(
+                float(row["percussive_ratio"])
+                if row["percussive_ratio"] is not None
+                else None
+            ),
+            genre_hint=(str(row["genre_hint"]) if row["genre_hint"] is not None else None),
             warnings=tuple(warnings),
             error_code=(str(row["error_code"]) if row["error_code"] is not None else None),
             error_detail=(

--- a/data/repositories/analysis_job_repository.py
+++ b/data/repositories/analysis_job_repository.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from core.analysis.job_contract import AnalysisJobCounts, AnalysisJobSnapshot
+from data.connection import get_sqlite_connection
+from data.models.analysis_job_record import AnalysisJobRecord
+
+
+class AnalysisJobRepository:
+    def ensure_schema(self) -> None:
+        with get_sqlite_connection() as conn:
+            conn.execute(
+                '''
+                CREATE TABLE IF NOT EXISTS analysis_jobs (
+                    job_id TEXT PRIMARY KEY,
+                    status TEXT NOT NULL,
+                    preferred_provider TEXT,
+                    selected INTEGER NOT NULL,
+                    completed INTEGER NOT NULL DEFAULT 0,
+                    succeeded INTEGER NOT NULL DEFAULT 0,
+                    failed INTEGER NOT NULL DEFAULT 0,
+                    uncertain INTEGER NOT NULL DEFAULT 0,
+                    cancel_requested INTEGER NOT NULL DEFAULT 0,
+                    error_code TEXT,
+                    error_detail TEXT,
+                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    CHECK (selected >= 0),
+                    CHECK (completed >= 0),
+                    CHECK (succeeded >= 0),
+                    CHECK (failed >= 0),
+                    CHECK (uncertain >= 0),
+                    CHECK (completed = succeeded + failed),
+                    CHECK (completed <= selected),
+                    CHECK (uncertain <= succeeded),
+                    CHECK (cancel_requested IN (0, 1))
+                )
+                '''
+            )
+            conn.commit()
+
+    def create(
+        self,
+        *,
+        selected: int,
+        preferred_provider: str | None = None,
+        job_id: str | None = None,
+    ) -> AnalysisJobSnapshot:
+        counts = AnalysisJobCounts(selected=selected)
+        normalized_job_id = job_id or f"aj_{uuid4().hex}"
+        record = AnalysisJobRecord(
+            job_id=normalized_job_id,
+            status="pending",
+            preferred_provider=self._normalize_provider(preferred_provider),
+            selected=counts.selected,
+        )
+        self.ensure_schema()
+        with get_sqlite_connection() as conn:
+            conn.execute(
+                '''
+                INSERT INTO analysis_jobs (
+                    job_id, status, preferred_provider, selected, completed,
+                    succeeded, failed, uncertain, cancel_requested,
+                    error_code, error_detail
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ''',
+                (
+                    record.job_id,
+                    record.status,
+                    record.preferred_provider,
+                    record.selected,
+                    record.completed,
+                    record.succeeded,
+                    record.failed,
+                    record.uncertain,
+                    int(record.cancel_requested),
+                    record.error_code,
+                    record.error_detail,
+                ),
+            )
+            conn.commit()
+        snapshot = self.get(normalized_job_id)
+        if snapshot is None:
+            raise RuntimeError("analysis job insert was not observable")
+        return snapshot
+
+    def get(self, job_id: str) -> AnalysisJobSnapshot | None:
+        self.ensure_schema()
+        with get_sqlite_connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM analysis_jobs WHERE job_id = ?",
+                (job_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return self._snapshot_from_row(dict(row))
+
+    def update(
+        self,
+        job_id: str,
+        *,
+        status: str,
+        counts: AnalysisJobCounts,
+        cancel_requested: bool | None = None,
+        error_code: str | None = None,
+        error_detail: str | None = None,
+    ) -> AnalysisJobSnapshot:
+        self.ensure_schema()
+        with get_sqlite_connection() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT * FROM analysis_jobs WHERE job_id = ?",
+                (job_id,),
+            ).fetchone()
+            if row is None:
+                raise KeyError("unknown analysis job")
+            current = self._snapshot_from_row(dict(row))
+            if counts.has_regressed_from(current.counts):
+                raise ValueError("analysis job counts must be monotonic")
+            next_cancel_requested = (
+                current.cancel_requested
+                if cancel_requested is None
+                else bool(cancel_requested)
+            )
+            candidate = AnalysisJobSnapshot(
+                job_id=job_id,
+                status=status,  # type: ignore[arg-type]
+                counts=counts,
+                preferred_provider=current.preferred_provider,
+                cancel_requested=next_cancel_requested,
+                error_code=error_code,
+                error_detail=error_detail,
+            )
+            conn.execute(
+                '''
+                UPDATE analysis_jobs
+                SET status = ?, completed = ?, succeeded = ?, failed = ?,
+                    uncertain = ?, cancel_requested = ?, error_code = ?,
+                    error_detail = ?, updated_at = CURRENT_TIMESTAMP
+                WHERE job_id = ?
+                ''',
+                (
+                    candidate.status,
+                    candidate.counts.completed,
+                    candidate.counts.succeeded,
+                    candidate.counts.failed,
+                    candidate.counts.uncertain,
+                    int(candidate.cancel_requested),
+                    candidate.error_code,
+                    candidate.error_detail,
+                    job_id,
+                ),
+            )
+            conn.commit()
+        return candidate
+
+    def request_cancel(self, job_id: str) -> AnalysisJobSnapshot:
+        current = self.get(job_id)
+        if current is None:
+            raise KeyError("unknown analysis job")
+        if current.status in {"done", "failed", "cancelled"}:
+            return current
+        return self.update(
+            job_id,
+            status="cancelling",
+            counts=current.counts,
+            cancel_requested=True,
+            error_code=current.error_code,
+            error_detail=current.error_detail,
+        )
+
+    @staticmethod
+    def _normalize_provider(value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip().lower()
+        return normalized or None
+
+    @staticmethod
+    def _snapshot_from_row(row: dict[str, object]) -> AnalysisJobSnapshot:
+        return AnalysisJobSnapshot(
+            job_id=str(row["job_id"]),
+            status=str(row["status"]),  # type: ignore[arg-type]
+            counts=AnalysisJobCounts(
+                selected=int(row["selected"]),
+                completed=int(row["completed"]),
+                succeeded=int(row["succeeded"]),
+                failed=int(row["failed"]),
+                uncertain=int(row["uncertain"]),
+            ),
+            preferred_provider=(
+                str(row["preferred_provider"])
+                if row["preferred_provider"] is not None
+                else None
+            ),
+            cancel_requested=bool(row["cancel_requested"]),
+            error_code=(str(row["error_code"]) if row["error_code"] is not None else None),
+            error_detail=(
+                str(row["error_detail"])
+                if row["error_detail"] is not None
+                else None
+            ),
+        )

--- a/data/repositories/analysis_job_repository.py
+++ b/data/repositories/analysis_job_repository.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from uuid import uuid4
 
 from core.analysis.job_contract import AnalysisJobCounts, AnalysisJobSnapshot
 from data.connection import get_sqlite_connection
 from data.models.analysis_job_record import AnalysisJobRecord
 
+MAX_ANALYSIS_JOB_TRACKS = 10_000
+
 
 class AnalysisJobRepository:
     def ensure_schema(self) -> None:
         with get_sqlite_connection() as conn:
-            conn.execute(
+            conn.executescript(
                 '''
                 CREATE TABLE IF NOT EXISTS analysis_jobs (
                     job_id TEXT PRIMARY KEY,
@@ -26,7 +29,7 @@ class AnalysisJobRepository:
                     error_detail TEXT,
                     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
                     updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                    CHECK (selected >= 0),
+                    CHECK (selected > 0),
                     CHECK (completed >= 0),
                     CHECK (succeeded >= 0),
                     CHECK (failed >= 0),
@@ -35,19 +38,36 @@ class AnalysisJobRepository:
                     CHECK (completed <= selected),
                     CHECK (uncertain <= succeeded),
                     CHECK (cancel_requested IN (0, 1))
-                )
+                );
+
+                CREATE TABLE IF NOT EXISTS analysis_job_targets (
+                    job_id TEXT NOT NULL,
+                    ordinal INTEGER NOT NULL,
+                    track_id TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'pending'
+                        CHECK (status IN ('pending', 'succeeded', 'failed')),
+                    evidence_id TEXT,
+                    error_code TEXT,
+                    PRIMARY KEY (job_id, ordinal),
+                    UNIQUE (job_id, track_id),
+                    FOREIGN KEY (job_id) REFERENCES analysis_jobs(job_id)
+                        ON DELETE CASCADE
+                );
+                CREATE INDEX IF NOT EXISTS idx_analysis_job_targets_job_status
+                    ON analysis_job_targets(job_id, status, ordinal);
                 '''
             )
             conn.commit()
 
-    def create(
+    def create_scope(
         self,
         *,
-        selected: int,
+        track_ids: Sequence[str],
         preferred_provider: str | None = None,
         job_id: str | None = None,
     ) -> AnalysisJobSnapshot:
-        counts = AnalysisJobCounts(selected=selected)
+        normalized_track_ids = self._normalize_track_ids(track_ids)
+        counts = AnalysisJobCounts(selected=len(normalized_track_ids))
         normalized_job_id = job_id or f"aj_{uuid4().hex}"
         record = AnalysisJobRecord(
             job_id=normalized_job_id,
@@ -57,6 +77,7 @@ class AnalysisJobRepository:
         )
         self.ensure_schema()
         with get_sqlite_connection() as conn:
+            conn.execute("BEGIN IMMEDIATE")
             conn.execute(
                 '''
                 INSERT INTO analysis_jobs (
@@ -80,6 +101,16 @@ class AnalysisJobRepository:
                     record.error_detail,
                 ),
             )
+            conn.executemany(
+                '''
+                INSERT INTO analysis_job_targets (job_id, ordinal, track_id)
+                VALUES (?, ?, ?)
+                ''',
+                (
+                    (normalized_job_id, ordinal, track_id)
+                    for ordinal, track_id in enumerate(normalized_track_ids)
+                ),
+            )
             conn.commit()
         snapshot = self.get(normalized_job_id)
         if snapshot is None:
@@ -96,6 +127,29 @@ class AnalysisJobRepository:
         if row is None:
             return None
         return self._snapshot_from_row(dict(row))
+
+    def get_targets(self, job_id: str) -> tuple[str, ...]:
+        self.ensure_schema()
+        with get_sqlite_connection() as conn:
+            job = conn.execute(
+                "SELECT selected FROM analysis_jobs WHERE job_id = ?",
+                (job_id,),
+            ).fetchone()
+            if job is None:
+                raise KeyError("unknown analysis job")
+            rows = conn.execute(
+                '''
+                SELECT track_id
+                FROM analysis_job_targets
+                WHERE job_id = ?
+                ORDER BY ordinal
+                ''',
+                (job_id,),
+            ).fetchall()
+        targets = tuple(str(row["track_id"]) for row in rows)
+        if len(targets) != int(job["selected"]):
+            raise RuntimeError("analysis job target scope is inconsistent")
+        return targets
 
     def update(
         self,
@@ -133,26 +187,88 @@ class AnalysisJobRepository:
                 error_code=error_code,
                 error_detail=error_detail,
             )
+            self._write_snapshot(conn, candidate)
+            conn.commit()
+        return candidate
+
+    def record_target_outcome(
+        self,
+        job_id: str,
+        *,
+        track_id: str,
+        status: str,
+        evidence_id: str,
+        uncertain: bool = False,
+        error_code: str | None = None,
+    ) -> AnalysisJobSnapshot:
+        if status not in {"succeeded", "failed"}:
+            raise ValueError("target outcome must be succeeded or failed")
+        if status == "failed" and uncertain:
+            raise ValueError("failed target cannot be marked uncertain")
+        if not isinstance(evidence_id, str) or not evidence_id.strip():
+            raise ValueError("target outcome requires an evidence_id")
+
+        self.ensure_schema()
+        with get_sqlite_connection() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT * FROM analysis_jobs WHERE job_id = ?",
+                (job_id,),
+            ).fetchone()
+            if row is None:
+                raise KeyError("unknown analysis job")
+            current = self._snapshot_from_row(dict(row))
+            if current.status not in {"running", "cancelling"}:
+                raise ValueError("analysis target outcome requires an active job")
+            if current.counts.completed >= current.counts.selected:
+                raise ValueError("analysis job selected scope is already complete")
+
+            target = conn.execute(
+                '''
+                SELECT status
+                FROM analysis_job_targets
+                WHERE job_id = ? AND track_id = ?
+                ''',
+                (job_id, track_id),
+            ).fetchone()
+            if target is None:
+                raise KeyError("track is outside analysis job scope")
+            if str(target["status"]) != "pending":
+                raise ValueError("analysis target outcome is already recorded")
+
+            succeeded = current.counts.succeeded + int(status == "succeeded")
+            failed = current.counts.failed + int(status == "failed")
+            counts = AnalysisJobCounts(
+                selected=current.counts.selected,
+                completed=current.counts.completed + 1,
+                succeeded=succeeded,
+                failed=failed,
+                uncertain=current.counts.uncertain + int(bool(uncertain)),
+            )
+            candidate = AnalysisJobSnapshot(
+                job_id=job_id,
+                status=current.status,
+                counts=counts,
+                preferred_provider=current.preferred_provider,
+                cancel_requested=current.cancel_requested,
+                error_code=current.error_code,
+                error_detail=current.error_detail,
+            )
             conn.execute(
                 '''
-                UPDATE analysis_jobs
-                SET status = ?, completed = ?, succeeded = ?, failed = ?,
-                    uncertain = ?, cancel_requested = ?, error_code = ?,
-                    error_detail = ?, updated_at = CURRENT_TIMESTAMP
-                WHERE job_id = ?
+                UPDATE analysis_job_targets
+                SET status = ?, evidence_id = ?, error_code = ?
+                WHERE job_id = ? AND track_id = ? AND status = 'pending'
                 ''',
                 (
-                    candidate.status,
-                    candidate.counts.completed,
-                    candidate.counts.succeeded,
-                    candidate.counts.failed,
-                    candidate.counts.uncertain,
-                    int(candidate.cancel_requested),
-                    candidate.error_code,
-                    candidate.error_detail,
+                    status,
+                    evidence_id.strip(),
+                    error_code,
                     job_id,
+                    track_id,
                 ),
             )
+            self._write_snapshot(conn, candidate)
             conn.commit()
         return candidate
 
@@ -170,6 +286,53 @@ class AnalysisJobRepository:
             error_code=current.error_code,
             error_detail=current.error_detail,
         )
+
+    @staticmethod
+    def _write_snapshot(conn: object, snapshot: AnalysisJobSnapshot) -> None:
+        conn.execute(  # type: ignore[attr-defined]
+            '''
+            UPDATE analysis_jobs
+            SET status = ?, completed = ?, succeeded = ?, failed = ?,
+                uncertain = ?, cancel_requested = ?, error_code = ?,
+                error_detail = ?, updated_at = CURRENT_TIMESTAMP
+            WHERE job_id = ?
+            ''',
+            (
+                snapshot.status,
+                snapshot.counts.completed,
+                snapshot.counts.succeeded,
+                snapshot.counts.failed,
+                snapshot.counts.uncertain,
+                int(snapshot.cancel_requested),
+                snapshot.error_code,
+                snapshot.error_detail,
+                snapshot.job_id,
+            ),
+        )
+
+    @staticmethod
+    def _normalize_track_ids(track_ids: Sequence[str]) -> tuple[str, ...]:
+        if isinstance(track_ids, (str, bytes)):
+            raise TypeError("analysis track scope must be a sequence of track IDs")
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for value in track_ids:
+            if not isinstance(value, str):
+                raise TypeError("analysis track IDs must be text")
+            track_id = value.strip()
+            if not track_id:
+                raise ValueError("analysis track IDs must be non-empty")
+            if len(track_id) > 256:
+                raise ValueError("analysis track ID is too long")
+            if track_id in seen:
+                raise ValueError("analysis track scope contains duplicate track IDs")
+            seen.add(track_id)
+            normalized.append(track_id)
+        if not normalized:
+            raise ValueError("analysis job scope must contain at least one track")
+        if len(normalized) > MAX_ANALYSIS_JOB_TRACKS:
+            raise ValueError("analysis job scope exceeds the bounded track limit")
+        return tuple(normalized)
 
     @staticmethod
     def _normalize_provider(value: str | None) -> str | None:

--- a/services/analysis/batch_runner.py
+++ b/services/analysis/batch_runner.py
@@ -26,6 +26,8 @@ class AnalysisBatchRunner:
         job = self._jobs.get_job(job_id)
         if job is None:
             raise KeyError("unknown analysis job")
+        if job.cancel_requested or job.status == "cancelling":
+            return self._jobs.finish(job_id)
         if job.status != "pending":
             raise ValueError("analysis batch runner requires a pending job")
 

--- a/services/analysis/batch_runner.py
+++ b/services/analysis/batch_runner.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from core.analysis.provider_contract import ProviderContractError
+from core.analysis.provider_service import RoutedAnalysisService
+from core.analysis.job_contract import AnalysisJobSnapshot
+from data.repositories.track_repository import TrackRepository
+from services.analysis.job_service import AnalysisJobService
+from services.analysis.result_store import AnalysisResultStore
+
+
+class AnalysisBatchRunner:
+    def __init__(
+        self,
+        *,
+        analysis_service: RoutedAnalysisService | None = None,
+        job_service: AnalysisJobService | None = None,
+        result_store: AnalysisResultStore | None = None,
+        track_repository: TrackRepository | None = None,
+    ) -> None:
+        self._analysis = analysis_service or RoutedAnalysisService()
+        self._jobs = job_service or AnalysisJobService()
+        self._results = result_store or AnalysisResultStore()
+        self._tracks = track_repository or TrackRepository()
+
+    def run(self, job_id: str) -> AnalysisJobSnapshot:
+        job = self._jobs.get_job(job_id)
+        if job is None:
+            raise KeyError("unknown analysis job")
+        if job.status != "pending":
+            raise ValueError("analysis batch runner requires a pending job")
+
+        targets = self._jobs.get_targets(job_id)
+        self._jobs.mark_running(job_id)
+
+        try:
+            for track_id in targets:
+                current = self._jobs.get_job(job_id)
+                if current is None:
+                    raise RuntimeError("analysis job disappeared during execution")
+                if current.cancel_requested or current.status == "cancelling":
+                    break
+
+                track = self._tracks.get_by_id(track_id)
+                if track is None or not isinstance(track.path, str) or not track.path.strip():
+                    error = LookupError("track unavailable")
+                    evidence = self._results.persist_failure(
+                        track_id=track_id,
+                        preferred_provider=current.preferred_provider,
+                        error=error,
+                    )
+                    self._jobs.record_failure(
+                        job_id,
+                        track_id=track_id,
+                        evidence_id=evidence.evidence_id,
+                        error_code=evidence.error_code or "track_unavailable",
+                    )
+                    continue
+
+                try:
+                    result = self._analysis.analyze_path(
+                        track.path,
+                        preferred_provider=current.preferred_provider,
+                    )
+                except ProviderContractError as error:
+                    evidence = self._results.persist_failure(
+                        track_id=track_id,
+                        preferred_provider=current.preferred_provider,
+                        error=error,
+                    )
+                    self._jobs.record_failure(
+                        job_id,
+                        track_id=track_id,
+                        evidence_id=evidence.evidence_id,
+                        error_code=evidence.error_code or "provider_error",
+                    )
+                    continue
+                except Exception as error:
+                    evidence = self._results.persist_failure(
+                        track_id=track_id,
+                        preferred_provider=current.preferred_provider,
+                        error=error,
+                    )
+                    self._jobs.record_failure(
+                        job_id,
+                        track_id=track_id,
+                        evidence_id=evidence.evidence_id,
+                        error_code=evidence.error_code or "analysis_internal_error",
+                    )
+                    continue
+
+                evidence = self._results.persist_success(track_id=track_id, result=result)
+                self._jobs.record_success(
+                    job_id,
+                    track_id=track_id,
+                    evidence_id=evidence.evidence_id,
+                    uncertain=self._results.is_uncertain(result),
+                )
+        except Exception:
+            current = self._jobs.get_job(job_id)
+            if current is not None and current.status not in {"done", "failed", "cancelled"}:
+                return self._jobs.fail_job(
+                    job_id,
+                    error_code="analysis_job_integrity_error",
+                    error_detail="Analysis job stopped because its persisted evidence could not be updated safely.",
+                )
+            raise
+
+        return self._jobs.finish(job_id)

--- a/services/analysis/inspector.py
+++ b/services/analysis/inspector.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
-from pathlib import Path
 
 from core.analysis.inspector_contract import (
     AnalysisInspectorFilter,
@@ -86,7 +85,7 @@ class AnalysisInspectorService:
             if isinstance(track.title, str) and track.title.strip():
                 title = track.title.strip()
             elif isinstance(track.path, str) and track.path.strip():
-                title = Path(track.path).name or attempt.track_id
+                title = self._safe_filename(track.path) or attempt.track_id
             if isinstance(track.artist, str) and track.artist.strip():
                 artist = track.artist.strip()
 
@@ -141,6 +140,13 @@ class AnalysisInspectorService:
             error_code=attempt.error_code if attempt.status == "failed" else None,
             error_detail=attempt.error_detail if attempt.status == "failed" else None,
         )
+
+    @staticmethod
+    def _safe_filename(path: str) -> str:
+        normalized = path.replace("\\", "/").rstrip("/")
+        if not normalized:
+            return ""
+        return normalized.rsplit("/", 1)[-1]
 
     @staticmethod
     def _decode_correction(payload_json: str) -> dict[str, object]:

--- a/services/analysis/inspector.py
+++ b/services/analysis/inspector.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+
+from core.analysis.inspector_contract import (
+    AnalysisInspectorFilter,
+    AnalysisInspectorItem,
+)
+from data.models.analysis_evidence_record import AnalysisEvidenceRecord
+from data.repositories.analysis_evidence_repository import AnalysisEvidenceRepository
+from data.repositories.track_repository import TrackRepository
+from services.analysis.result_store import AnalysisResultStore
+
+
+class AnalysisInspectorService:
+    def __init__(
+        self,
+        *,
+        evidence_repository: AnalysisEvidenceRepository | None = None,
+        track_repository: TrackRepository | None = None,
+    ) -> None:
+        self._evidence = evidence_repository or AnalysisEvidenceRepository()
+        self._tracks = track_repository or TrackRepository()
+
+    def list_items(
+        self,
+        filter_by: AnalysisInspectorFilter = "all",
+    ) -> list[AnalysisInspectorItem]:
+        if filter_by not in {"all", "uncertain", "failed", "corrected"}:
+            raise ValueError("unknown analysis inspector filter")
+        items = [self._build_item(attempt) for attempt in self._evidence.list_latest_attempts()]
+        if filter_by == "uncertain":
+            return [item for item in items if item.uncertain]
+        if filter_by == "failed":
+            return [item for item in items if item.status == "failed"]
+        if filter_by == "corrected":
+            return [item for item in items if item.corrected]
+        return items
+
+    def get_item(self, track_id: str) -> AnalysisInspectorItem | None:
+        attempt = self._evidence.latest_evidence_for_track(track_id)
+        if attempt is None:
+            return None
+        return self._build_item(attempt)
+
+    def apply_correction(
+        self,
+        *,
+        track_id: str,
+        values: Mapping[str, object],
+        reason: str | None = None,
+    ) -> AnalysisInspectorItem:
+        latest_success = self._evidence.latest_success_for_track(track_id)
+        if latest_success is None:
+            raise ValueError("manual correction requires successful provider evidence")
+        self._evidence.append_correction(
+            track_id=track_id,
+            base_evidence_id=latest_success.evidence_id,
+            values=values,
+            reason=reason,
+        )
+        item = self.get_item(track_id)
+        if item is None:
+            raise RuntimeError("corrected track disappeared from inspector")
+        return item
+
+    def _build_item(self, attempt: AnalysisEvidenceRecord) -> AnalysisInspectorItem:
+        success = self._evidence.latest_success_for_track(attempt.track_id)
+        correction = (
+            self._evidence.latest_active_correction(attempt.track_id, success.evidence_id)
+            if success is not None
+            else None
+        )
+        correction_values = (
+            self._decode_correction(correction.payload_json)
+            if correction is not None
+            else {}
+        )
+        base = success
+        track = self._tracks.get_by_id(attempt.track_id)
+        title = attempt.track_id
+        artist: str | None = None
+        if track is not None:
+            if isinstance(track.title, str) and track.title.strip():
+                title = track.title.strip()
+            elif isinstance(track.path, str) and track.path.strip():
+                title = Path(track.path).name or attempt.track_id
+            if isinstance(track.artist, str) and track.artist.strip():
+                artist = track.artist.strip()
+
+        provider_source = base or attempt
+        bpm = self._corrected_value(correction_values, "bpm", base.bpm if base else None)
+        key_tonic = self._corrected_value(
+            correction_values,
+            "key_tonic",
+            base.key_tonic if base else None,
+        )
+        key_scale = self._corrected_value(
+            correction_values,
+            "key_scale",
+            base.key_scale if base else None,
+        )
+        camelot = self._corrected_value(
+            correction_values,
+            "camelot",
+            base.camelot if base else None,
+        )
+        energy = self._corrected_value(
+            correction_values,
+            "energy",
+            base.energy if base else None,
+        )
+
+        return AnalysisInspectorItem(
+            track_id=attempt.track_id,
+            title=title,
+            artist=artist,
+            status=attempt.status,  # type: ignore[arg-type]
+            bpm=bpm if isinstance(bpm, (int, float)) else None,
+            bpm_confidence=base.bpm_confidence if base else None,
+            key_tonic=key_tonic if isinstance(key_tonic, str) else None,
+            key_scale=key_scale if isinstance(key_scale, str) else None,
+            camelot=camelot if isinstance(camelot, str) else None,
+            key_confidence=base.key_confidence if base else None,
+            energy=energy if isinstance(energy, (int, float)) else None,
+            duration_seconds=base.duration_seconds if base else None,
+            provider=provider_source.provider,
+            provider_version=provider_source.provider_version,
+            analysis_version=provider_source.analysis_version,
+            algorithm_version=provider_source.algorithm_version,
+            warnings=base.warnings if base else attempt.warnings,
+            source="manual-correction" if correction is not None else "provider",
+            uncertain=AnalysisResultStore.is_uncertain_evidence(base),
+            corrected=correction is not None,
+            attempt_evidence_id=attempt.evidence_id,
+            effective_evidence_id=base.evidence_id if base else None,
+            correction_id=correction.correction_id if correction else None,
+            correction_reason=correction.reason if correction else None,
+            error_code=attempt.error_code if attempt.status == "failed" else None,
+            error_detail=attempt.error_detail if attempt.status == "failed" else None,
+        )
+
+    @staticmethod
+    def _decode_correction(payload_json: str) -> dict[str, object]:
+        value = json.loads(payload_json)
+        if not isinstance(value, dict):
+            raise ValueError("stored correction payload is invalid")
+        allowed = {"bpm", "key_tonic", "key_scale", "camelot", "energy"}
+        if set(value) - allowed:
+            raise ValueError("stored correction payload contains unsupported fields")
+        return value
+
+    @staticmethod
+    def _corrected_value(
+        correction: Mapping[str, object],
+        field: str,
+        provider_value: object,
+    ) -> object:
+        return correction[field] if field in correction else provider_value

--- a/services/analysis/job_service.py
+++ b/services/analysis/job_service.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from core.analysis.job_contract import AnalysisJobCounts, AnalysisJobSnapshot
+from collections.abc import Sequence
+
+from core.analysis.job_contract import AnalysisJobSnapshot
 from data.repositories.analysis_job_repository import AnalysisJobRepository
 
 
@@ -11,18 +13,19 @@ class AnalysisJobService:
     def create_job(
         self,
         *,
-        selected: int,
+        track_ids: Sequence[str],
         preferred_provider: str | None = None,
     ) -> AnalysisJobSnapshot:
-        if selected <= 0:
-            raise ValueError("analysis job scope must contain at least one track")
-        return self._repo.create(
-            selected=selected,
+        return self._repo.create_scope(
+            track_ids=track_ids,
             preferred_provider=preferred_provider,
         )
 
     def get_job(self, job_id: str) -> AnalysisJobSnapshot | None:
         return self._repo.get(job_id)
+
+    def get_targets(self, job_id: str) -> tuple[str, ...]:
+        return self._repo.get_targets(job_id)
 
     def mark_running(self, job_id: str) -> AnalysisJobSnapshot:
         current = self._require(job_id)
@@ -37,40 +40,36 @@ class AnalysisJobService:
             error_detail=current.error_detail,
         )
 
-    def record_success(self, job_id: str, *, uncertain: bool = False) -> AnalysisJobSnapshot:
-        current = self._require_running(job_id)
-        counts = AnalysisJobCounts(
-            selected=current.counts.selected,
-            completed=current.counts.completed + 1,
-            succeeded=current.counts.succeeded + 1,
-            failed=current.counts.failed,
-            uncertain=current.counts.uncertain + int(bool(uncertain)),
-        )
-        return self._repo.update(
+    def record_success(
+        self,
+        job_id: str,
+        *,
+        track_id: str,
+        evidence_id: str,
+        uncertain: bool = False,
+    ) -> AnalysisJobSnapshot:
+        return self._repo.record_target_outcome(
             job_id,
-            status=current.status,
-            counts=counts,
-            cancel_requested=current.cancel_requested,
-            error_code=current.error_code,
-            error_detail=current.error_detail,
+            track_id=track_id,
+            status="succeeded",
+            evidence_id=evidence_id,
+            uncertain=uncertain,
         )
 
-    def record_failure(self, job_id: str) -> AnalysisJobSnapshot:
-        current = self._require_running(job_id)
-        counts = AnalysisJobCounts(
-            selected=current.counts.selected,
-            completed=current.counts.completed + 1,
-            succeeded=current.counts.succeeded,
-            failed=current.counts.failed + 1,
-            uncertain=current.counts.uncertain,
-        )
-        return self._repo.update(
+    def record_failure(
+        self,
+        job_id: str,
+        *,
+        track_id: str,
+        evidence_id: str,
+        error_code: str,
+    ) -> AnalysisJobSnapshot:
+        return self._repo.record_target_outcome(
             job_id,
-            status=current.status,
-            counts=counts,
-            cancel_requested=current.cancel_requested,
-            error_code=current.error_code,
-            error_detail=current.error_detail,
+            track_id=track_id,
+            status="failed",
+            evidence_id=evidence_id,
+            error_code=error_code,
         )
 
     def request_cancel(self, job_id: str) -> AnalysisJobSnapshot:
@@ -123,12 +122,4 @@ class AnalysisJobService:
         current = self._repo.get(job_id)
         if current is None:
             raise KeyError("unknown analysis job")
-        return current
-
-    def _require_running(self, job_id: str) -> AnalysisJobSnapshot:
-        current = self._require(job_id)
-        if current.status not in {"running", "cancelling"}:
-            raise ValueError("analysis result can only be recorded for an active job")
-        if current.counts.completed >= current.counts.selected:
-            raise ValueError("analysis job selected scope is already complete")
         return current

--- a/services/analysis/job_service.py
+++ b/services/analysis/job_service.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from core.analysis.job_contract import AnalysisJobCounts, AnalysisJobSnapshot
+from data.repositories.analysis_job_repository import AnalysisJobRepository
+
+
+class AnalysisJobService:
+    def __init__(self, repository: AnalysisJobRepository | None = None) -> None:
+        self._repo = repository or AnalysisJobRepository()
+
+    def create_job(
+        self,
+        *,
+        selected: int,
+        preferred_provider: str | None = None,
+    ) -> AnalysisJobSnapshot:
+        if selected <= 0:
+            raise ValueError("analysis job scope must contain at least one track")
+        return self._repo.create(
+            selected=selected,
+            preferred_provider=preferred_provider,
+        )
+
+    def get_job(self, job_id: str) -> AnalysisJobSnapshot | None:
+        return self._repo.get(job_id)
+
+    def mark_running(self, job_id: str) -> AnalysisJobSnapshot:
+        current = self._require(job_id)
+        if current.status not in {"pending", "running"}:
+            raise ValueError("analysis job cannot enter running state")
+        return self._repo.update(
+            job_id,
+            status="running",
+            counts=current.counts,
+            cancel_requested=current.cancel_requested,
+            error_code=current.error_code,
+            error_detail=current.error_detail,
+        )
+
+    def record_success(self, job_id: str, *, uncertain: bool = False) -> AnalysisJobSnapshot:
+        current = self._require_running(job_id)
+        counts = AnalysisJobCounts(
+            selected=current.counts.selected,
+            completed=current.counts.completed + 1,
+            succeeded=current.counts.succeeded + 1,
+            failed=current.counts.failed,
+            uncertain=current.counts.uncertain + int(bool(uncertain)),
+        )
+        return self._repo.update(
+            job_id,
+            status=current.status,
+            counts=counts,
+            cancel_requested=current.cancel_requested,
+            error_code=current.error_code,
+            error_detail=current.error_detail,
+        )
+
+    def record_failure(self, job_id: str) -> AnalysisJobSnapshot:
+        current = self._require_running(job_id)
+        counts = AnalysisJobCounts(
+            selected=current.counts.selected,
+            completed=current.counts.completed + 1,
+            succeeded=current.counts.succeeded,
+            failed=current.counts.failed + 1,
+            uncertain=current.counts.uncertain,
+        )
+        return self._repo.update(
+            job_id,
+            status=current.status,
+            counts=counts,
+            cancel_requested=current.cancel_requested,
+            error_code=current.error_code,
+            error_detail=current.error_detail,
+        )
+
+    def request_cancel(self, job_id: str) -> AnalysisJobSnapshot:
+        return self._repo.request_cancel(job_id)
+
+    def finish(self, job_id: str) -> AnalysisJobSnapshot:
+        current = self._require(job_id)
+        if current.status == "cancelled":
+            return current
+        if current.cancel_requested or current.status == "cancelling":
+            return self._repo.update(
+                job_id,
+                status="cancelled",
+                counts=current.counts,
+                cancel_requested=True,
+                error_code=current.error_code,
+                error_detail=current.error_detail,
+            )
+        if current.status != "running":
+            raise ValueError("only running analysis jobs can finish")
+        if current.counts.completed != current.counts.selected:
+            raise ValueError("analysis job cannot finish before selected scope completes")
+        return self._repo.update(
+            job_id,
+            status="done",
+            counts=current.counts,
+            cancel_requested=False,
+        )
+
+    def fail_job(
+        self,
+        job_id: str,
+        *,
+        error_code: str,
+        error_detail: str,
+    ) -> AnalysisJobSnapshot:
+        current = self._require(job_id)
+        if current.status in {"done", "failed", "cancelled"}:
+            raise ValueError("terminal analysis job state is immutable")
+        return self._repo.update(
+            job_id,
+            status="failed",
+            counts=current.counts,
+            cancel_requested=current.cancel_requested,
+            error_code=error_code.strip()[:128] or "analysis_job_failed",
+            error_detail=error_detail.strip()[:512] or "analysis job failed",
+        )
+
+    def _require(self, job_id: str) -> AnalysisJobSnapshot:
+        current = self._repo.get(job_id)
+        if current is None:
+            raise KeyError("unknown analysis job")
+        return current
+
+    def _require_running(self, job_id: str) -> AnalysisJobSnapshot:
+        current = self._require(job_id)
+        if current.status not in {"running", "cancelling"}:
+            raise ValueError("analysis result can only be recorded for an active job")
+        if current.counts.completed >= current.counts.selected:
+            raise ValueError("analysis job selected scope is already complete")
+        return current

--- a/services/analysis/result_store.py
+++ b/services/analysis/result_store.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from core.analysis.provider_contract import (
+    CanonicalAnalysisResult,
+    ProviderContractError,
+    ProviderOutputInvalid,
+    ProviderRuntimeFailure,
+    ProviderUnavailableError,
+    UnknownProviderError,
+)
+from data.models.analysis_evidence_record import AnalysisEvidenceRecord
+from data.repositories.analysis_evidence_repository import AnalysisEvidenceRepository
+
+INSPECTOR_CONFIDENCE_FLOOR = 0.50
+
+
+class AnalysisResultStore:
+    def __init__(self, repository: AnalysisEvidenceRepository | None = None) -> None:
+        self._repo = repository or AnalysisEvidenceRepository()
+
+    def persist_success(
+        self,
+        *,
+        track_id: str,
+        result: CanonicalAnalysisResult,
+    ) -> AnalysisEvidenceRecord:
+        return self._repo.append_evidence(
+            track_id=track_id,
+            provider=result.provider,
+            analysis_version=result.analysis_version,
+            status="succeeded",
+            provider_version=result.provider_version,
+            algorithm_version=result.algorithm_version,
+            bpm=result.bpm,
+            bpm_confidence=result.bpm_confidence,
+            key_tonic=result.key_tonic,
+            key_scale=result.key_scale,
+            camelot=result.camelot,
+            key_confidence=result.key_confidence,
+            energy=result.energy,
+            loudness_db=result.loudness_db,
+            duration_seconds=result.duration_seconds,
+            beat_stability=result.beat_stability,
+            harmonic_ratio=result.harmonic_ratio,
+            percussive_ratio=result.percussive_ratio,
+            genre_hint=result.genre_hint,
+            warnings=result.warnings,
+        )
+
+    def persist_failure(
+        self,
+        *,
+        track_id: str,
+        preferred_provider: str | None,
+        error: Exception,
+    ) -> AnalysisEvidenceRecord:
+        provider, code, detail = self.safe_failure(error, preferred_provider=preferred_provider)
+        return self._repo.append_evidence(
+            track_id=track_id,
+            provider=provider,
+            analysis_version="canonical-mir-v1",
+            status="failed",
+            error_code=code,
+            error_detail=detail,
+        )
+
+    @staticmethod
+    def is_uncertain(result: CanonicalAnalysisResult) -> bool:
+        return (
+            result.bpm is None
+            or result.camelot is None
+            or result.energy is None
+            or result.bpm_confidence is None
+            or result.bpm_confidence < INSPECTOR_CONFIDENCE_FLOOR
+            or result.key_confidence is None
+            or result.key_confidence < INSPECTOR_CONFIDENCE_FLOOR
+        )
+
+    @staticmethod
+    def is_uncertain_evidence(evidence: AnalysisEvidenceRecord | None) -> bool:
+        if evidence is None or evidence.status != "succeeded":
+            return False
+        return (
+            evidence.bpm is None
+            or evidence.camelot is None
+            or evidence.energy is None
+            or evidence.bpm_confidence is None
+            or evidence.bpm_confidence < INSPECTOR_CONFIDENCE_FLOOR
+            or evidence.key_confidence is None
+            or evidence.key_confidence < INSPECTOR_CONFIDENCE_FLOOR
+        )
+
+    @staticmethod
+    def safe_failure(
+        error: Exception,
+        *,
+        preferred_provider: str | None,
+    ) -> tuple[str, str, str]:
+        provider = preferred_provider.strip().lower() if preferred_provider else "unresolved"
+        if isinstance(error, ProviderContractError) and error.provider:
+            provider = error.provider.strip().lower() or provider
+
+        if isinstance(error, UnknownProviderError):
+            return provider, error.code, "Requested analysis provider is unknown."
+        if isinstance(error, ProviderOutputInvalid):
+            return provider, error.code, "Analysis provider returned invalid output."
+        if isinstance(error, ProviderRuntimeFailure):
+            return provider, error.code, "Analysis provider failed for this track."
+        if isinstance(error, ProviderUnavailableError):
+            return provider, error.code, "Analysis provider is unavailable."
+        if isinstance(error, ProviderContractError):
+            return provider, error.code, "Analysis failed with a controlled provider error."
+        if isinstance(error, LookupError):
+            return provider, "track_unavailable", "Track is not available for analysis."
+        return provider, "analysis_internal_error", "Analysis failed for this track."

--- a/tests/test_analysis_batch_inspector.py
+++ b/tests/test_analysis_batch_inspector.py
@@ -184,6 +184,42 @@ def test_cancel_during_track_finishes_that_evidence_and_stops_next_track(
     assert evidence.latest_evidence_for_track("track-b") is None
 
 
+def test_cancel_before_worker_start_is_terminal_without_provider_call(
+    isolated_database: Path,
+) -> None:
+    tracks = TrackRepository()
+    jobs = AnalysisJobService()
+    evidence = AnalysisEvidenceRepository()
+    _track(tracks, "track-a", "/library/a.wav")
+    _track(tracks, "track-b", "/library/b.wav")
+
+    scripted = ScriptedAnalysisService(
+        {
+            "/library/a.wav": _result("/library/a.wav"),
+            "/library/b.wav": _result("/library/b.wav"),
+        }
+    )
+    job = jobs.create_job(track_ids=["track-a", "track-b"], preferred_provider="librosa")
+    cancelling = jobs.request_cancel(job.job_id)
+    assert cancelling.status == "cancelling"
+
+    terminal = AnalysisBatchRunner(
+        analysis_service=scripted,  # type: ignore[arg-type]
+        job_service=jobs,
+        result_store=AnalysisResultStore(evidence),
+        track_repository=tracks,
+    ).run(job.job_id)
+
+    assert terminal.status == "cancelled"
+    assert terminal.cancel_requested is True
+    assert terminal.counts.completed == 0
+    assert terminal.counts.succeeded == 0
+    assert terminal.counts.failed == 0
+    assert scripted.calls == []
+    assert evidence.latest_evidence_for_track("track-a") is None
+    assert evidence.latest_evidence_for_track("track-b") is None
+
+
 def test_inspector_uses_safe_fields_and_manual_correction_overlay(
     isolated_database: Path,
 ) -> None:

--- a/tests/test_analysis_batch_inspector.py
+++ b/tests/test_analysis_batch_inspector.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.analysis.provider_contract import CanonicalAnalysisResult, ProviderRuntimeFailure
+from core.config.settings import get_settings
+from data.models.track_record import TrackRecord
+from data.repositories.analysis_evidence_repository import AnalysisEvidenceRepository
+from data.repositories.track_repository import TrackRepository
+from services.analysis.batch_runner import AnalysisBatchRunner
+from services.analysis.inspector import AnalysisInspectorService
+from services.analysis.job_service import AnalysisJobService
+from services.analysis.result_store import AnalysisResultStore
+
+
+@pytest.fixture
+def isolated_database(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    database_path = tmp_path / "bundle50-batch.sqlite3"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{database_path}")
+    get_settings.cache_clear()
+    yield database_path
+    get_settings.cache_clear()
+
+
+def _track(repository: TrackRepository, track_id: str, path: str, *, title: str | None = None) -> None:
+    repository.upsert(
+        TrackRecord(
+            track_id=track_id,
+            path=path,
+            title=title,
+            artist="Test Artist",
+            duration_seconds=300.0,
+        )
+    )
+
+
+def _result(
+    path: str,
+    *,
+    bpm: float = 140.0,
+    bpm_confidence: float = 0.85,
+    key_confidence: float = 0.82,
+    warnings: tuple[str, ...] = ("baseline provider output is not benchmark-approved",),
+) -> CanonicalAnalysisResult:
+    return CanonicalAnalysisResult(
+        path=path,
+        provider="librosa",
+        bpm=bpm,
+        bpm_confidence=bpm_confidence,
+        key="11A",
+        key_confidence=key_confidence,
+        energy=0.72,
+        loudness_db=-10.0,
+        duration_seconds=300.0,
+        genre_hint=None,
+        key_tonic="F#",
+        key_scale="minor",
+        camelot="11A",
+        beat_stability=0.8,
+        harmonic_ratio=0.55,
+        percussive_ratio=0.45,
+        provider_version="0.10.2",
+        algorithm_version="baseline-librosa-mir-v1",
+        warnings=warnings,
+    )
+
+
+class ScriptedAnalysisService:
+    def __init__(self, script: dict[str, CanonicalAnalysisResult | Exception]) -> None:
+        self.script = script
+        self.calls: list[str] = []
+
+    def analyze_path(
+        self,
+        path: str,
+        *,
+        preferred_provider: str | None = None,
+    ) -> CanonicalAnalysisResult:
+        self.calls.append(path)
+        outcome = self.script[path]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+class CancellingAnalysisService:
+    def __init__(self, job_service: AnalysisJobService, job_id: str) -> None:
+        self.job_service = job_service
+        self.job_id = job_id
+        self.calls: list[str] = []
+
+    def analyze_path(
+        self,
+        path: str,
+        *,
+        preferred_provider: str | None = None,
+    ) -> CanonicalAnalysisResult:
+        self.calls.append(path)
+        self.job_service.request_cancel(self.job_id)
+        return _result(path)
+
+
+def test_batch_runner_isolates_track_failures_and_keeps_safe_evidence(
+    isolated_database: Path,
+) -> None:
+    tracks = TrackRepository()
+    jobs = AnalysisJobService()
+    evidence = AnalysisEvidenceRepository()
+    _track(tracks, "track-a", "/private/library/a.wav")
+    _track(tracks, "track-b", "/private/library/b.wav")
+    _track(tracks, "track-c", "/private/library/c.wav")
+
+    scripted = ScriptedAnalysisService(
+        {
+            "/private/library/a.wav": _result("/private/library/a.wav"),
+            "/private/library/b.wav": ProviderRuntimeFailure(
+                "raw provider detail /private/library/b.wav",
+                provider="librosa",
+            ),
+            "/private/library/c.wav": _result(
+                "/private/library/c.wav",
+                bpm_confidence=0.20,
+            ),
+        }
+    )
+    job = jobs.create_job(
+        track_ids=["track-a", "track-b", "track-c"],
+        preferred_provider="librosa",
+    )
+    terminal = AnalysisBatchRunner(
+        analysis_service=scripted,  # type: ignore[arg-type]
+        job_service=jobs,
+        result_store=AnalysisResultStore(evidence),
+        track_repository=tracks,
+    ).run(job.job_id)
+
+    assert terminal.status == "done"
+    assert terminal.counts.selected == 3
+    assert terminal.counts.completed == 3
+    assert terminal.counts.succeeded == 2
+    assert terminal.counts.failed == 1
+    assert terminal.counts.uncertain == 1
+    assert scripted.calls == [
+        "/private/library/a.wav",
+        "/private/library/b.wav",
+        "/private/library/c.wav",
+    ]
+
+    failure = evidence.latest_evidence_for_track("track-b")
+    assert failure is not None
+    assert failure.status == "failed"
+    assert failure.error_code == "provider_runtime_error"
+    assert failure.error_detail == "Analysis provider failed for this track."
+    assert "/private/" not in failure.error_detail
+
+
+def test_cancel_during_track_finishes_that_evidence_and_stops_next_track(
+    isolated_database: Path,
+) -> None:
+    tracks = TrackRepository()
+    jobs = AnalysisJobService()
+    evidence = AnalysisEvidenceRepository()
+    _track(tracks, "track-a", "/library/a.wav")
+    _track(tracks, "track-b", "/library/b.wav")
+
+    job = jobs.create_job(track_ids=["track-a", "track-b"], preferred_provider="librosa")
+    cancelling = CancellingAnalysisService(jobs, job.job_id)
+    terminal = AnalysisBatchRunner(
+        analysis_service=cancelling,  # type: ignore[arg-type]
+        job_service=jobs,
+        result_store=AnalysisResultStore(evidence),
+        track_repository=tracks,
+    ).run(job.job_id)
+
+    assert terminal.status == "cancelled"
+    assert terminal.cancel_requested is True
+    assert terminal.counts.completed == 1
+    assert terminal.counts.succeeded == 1
+    assert terminal.counts.failed == 0
+    assert cancelling.calls == ["/library/a.wav"]
+    assert evidence.latest_evidence_for_track("track-a") is not None
+    assert evidence.latest_evidence_for_track("track-b") is None
+
+
+def test_inspector_uses_safe_fields_and_manual_correction_overlay(
+    isolated_database: Path,
+) -> None:
+    tracks = TrackRepository()
+    evidence = AnalysisEvidenceRepository()
+    inspector = AnalysisInspectorService(
+        evidence_repository=evidence,
+        track_repository=tracks,
+    )
+    _track(tracks, "track-a", "/private/secret/fallback.wav", title=None)
+
+    first = AnalysisResultStore(evidence).persist_success(
+        track_id="track-a",
+        result=_result("/private/secret/fallback.wav"),
+    )
+    corrected = inspector.apply_correction(
+        track_id="track-a",
+        values={"bpm": 141.0, "camelot": "12A"},
+        reason="confirmed on deck",
+    )
+
+    assert corrected.title == "fallback.wav"
+    assert corrected.source == "manual-correction"
+    assert corrected.corrected is True
+    assert corrected.bpm == 141.0
+    assert corrected.camelot == "12A"
+    assert corrected.effective_evidence_id == first.evidence_id
+    assert corrected.correction_id is not None
+    assert corrected.uncertain is False
+    assert "/private/" not in repr(corrected.to_dict())
+    assert "path" not in corrected.to_dict()
+    assert inspector.list_items("corrected") == [corrected]
+
+
+def test_successful_reanalysis_keeps_correction_history_but_deactivates_old_override(
+    isolated_database: Path,
+) -> None:
+    tracks = TrackRepository()
+    evidence = AnalysisEvidenceRepository()
+    store = AnalysisResultStore(evidence)
+    inspector = AnalysisInspectorService(
+        evidence_repository=evidence,
+        track_repository=tracks,
+    )
+    _track(tracks, "track-a", "/library/a.wav", title="A")
+
+    first = store.persist_success(track_id="track-a", result=_result("/library/a.wav", bpm=138.0))
+    correction = evidence.append_correction(
+        track_id="track-a",
+        base_evidence_id=first.evidence_id,
+        values={"bpm": 139.0},
+        reason="manual verification",
+    )
+    assert inspector.get_item("track-a").bpm == 139.0  # type: ignore[union-attr]
+
+    second = store.persist_success(track_id="track-a", result=_result("/library/a.wav", bpm=140.0))
+    item = inspector.get_item("track-a")
+    assert item is not None
+    assert item.effective_evidence_id == second.evidence_id
+    assert item.bpm == 140.0
+    assert item.source == "provider"
+    assert item.corrected is False
+    assert evidence.latest_correction_for_track("track-a") == correction
+    assert evidence.latest_active_correction("track-a", second.evidence_id) is None
+
+
+def test_failed_reanalysis_preserves_last_good_effective_result_and_failed_filter(
+    isolated_database: Path,
+) -> None:
+    tracks = TrackRepository()
+    evidence = AnalysisEvidenceRepository()
+    inspector = AnalysisInspectorService(
+        evidence_repository=evidence,
+        track_repository=tracks,
+    )
+    _track(tracks, "track-a", "/library/a.wav", title="A")
+    store = AnalysisResultStore(evidence)
+    store.persist_success(track_id="track-a", result=_result("/library/a.wav", bpm=140.0))
+    store.persist_failure(
+        track_id="track-a",
+        preferred_provider="librosa",
+        error=RuntimeError("raw /library/a.wav detail must not escape"),
+    )
+
+    item = inspector.get_item("track-a")
+    assert item is not None
+    assert item.status == "failed"
+    assert item.bpm == 140.0
+    assert item.error_code == "analysis_internal_error"
+    assert item.error_detail == "Analysis failed for this track."
+    assert "/library/" not in repr(item.to_dict())
+    assert inspector.list_items("failed") == [item]
+
+
+def test_baseline_warning_alone_does_not_mark_result_uncertain() -> None:
+    result = _result("/library/a.wav")
+    assert result.warnings
+    assert AnalysisResultStore.is_uncertain(result) is False
+    assert AnalysisResultStore.is_uncertain(
+        _result("/library/a.wav", key_confidence=0.49)
+    ) is True

--- a/tests/test_analysis_batch_inspector.py
+++ b/tests/test_analysis_batch_inspector.py
@@ -218,6 +218,30 @@ def test_inspector_uses_safe_fields_and_manual_correction_overlay(
     assert inspector.list_items("corrected") == [corrected]
 
 
+def test_inspector_never_leaks_windows_style_absolute_path(
+    isolated_database: Path,
+) -> None:
+    tracks = TrackRepository()
+    evidence = AnalysisEvidenceRepository()
+    inspector = AnalysisInspectorService(
+        evidence_repository=evidence,
+        track_repository=tracks,
+    )
+    windows_path = r"C:\Users\Eimy\Music\secret\windows-track.wav"
+    _track(tracks, "track-windows", windows_path, title=None)
+    AnalysisResultStore(evidence).persist_success(
+        track_id="track-windows",
+        result=_result(windows_path),
+    )
+
+    item = inspector.get_item("track-windows")
+    assert item is not None
+    assert item.title == "windows-track.wav"
+    assert "C:\\Users" not in repr(item.to_dict())
+    assert "secret" not in item.title
+    assert "path" not in item.to_dict()
+
+
 def test_successful_reanalysis_keeps_correction_history_but_deactivates_old_override(
     isolated_database: Path,
 ) -> None:

--- a/tests/test_analysis_job_contract.py
+++ b/tests/test_analysis_job_contract.py
@@ -22,6 +22,27 @@ def isolated_database(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     get_settings.cache_clear()
 
 
+def _success_evidence(
+    repository: AnalysisEvidenceRepository,
+    *,
+    evidence_id: str,
+    track_id: str,
+) -> str:
+    return repository.append_evidence(
+        evidence_id=evidence_id,
+        track_id=track_id,
+        provider="librosa",
+        analysis_version="canonical-mir-v1",
+        bpm=140.0,
+        bpm_confidence=0.8,
+        key_tonic="F#",
+        key_scale="minor",
+        camelot="11A",
+        key_confidence=0.8,
+        energy=0.7,
+    ).evidence_id
+
+
 def test_analysis_job_contract_rejects_invalid_counts() -> None:
     with pytest.raises(ValueError, match="completed must equal"):
         AnalysisJobCounts(selected=2, completed=1, succeeded=0, failed=0)
@@ -36,21 +57,36 @@ def test_analysis_job_contract_rejects_invalid_counts() -> None:
         )
 
 
-def test_analysis_job_persists_monotonic_progress_and_cancel(
+def test_analysis_job_persists_scope_progress_and_cancel(
     isolated_database: Path,
 ) -> None:
     service = AnalysisJobService()
-    created = service.create_job(selected=3, preferred_provider=" Librosa ")
+    evidence = AnalysisEvidenceRepository()
+    created = service.create_job(
+        track_ids=["track-a", "track-b", "track-c"],
+        preferred_provider=" Librosa ",
+    )
 
     assert created.job_id.startswith("aj_")
     assert created.status == "pending"
     assert created.preferred_provider == "librosa"
     assert created.counts == AnalysisJobCounts(selected=3)
+    assert service.get_targets(created.job_id) == ("track-a", "track-b", "track-c")
 
     running = service.mark_running(created.job_id)
     assert running.status == "running"
 
-    first = service.record_success(created.job_id, uncertain=True)
+    first_evidence = _success_evidence(
+        evidence,
+        evidence_id="ae_job_success",
+        track_id="track-a",
+    )
+    first = service.record_success(
+        created.job_id,
+        track_id="track-a",
+        evidence_id=first_evidence,
+        uncertain=True,
+    )
     assert first.counts == AnalysisJobCounts(
         selected=3,
         completed=1,
@@ -59,7 +95,21 @@ def test_analysis_job_persists_monotonic_progress_and_cancel(
         uncertain=1,
     )
 
-    second = service.record_failure(created.job_id)
+    failed_evidence = evidence.append_evidence(
+        evidence_id="ae_job_failure",
+        track_id="track-b",
+        provider="librosa",
+        analysis_version="canonical-mir-v1",
+        status="failed",
+        error_code="provider_runtime_error",
+        error_detail="Analysis provider failed for this track.",
+    )
+    second = service.record_failure(
+        created.job_id,
+        track_id="track-b",
+        evidence_id=failed_evidence.evidence_id,
+        error_code=failed_evidence.error_code or "provider_runtime_error",
+    )
     assert second.counts == AnalysisJobCounts(
         selected=3,
         completed=2,
@@ -84,18 +134,61 @@ def test_analysis_job_persists_monotonic_progress_and_cancel(
     assert isolated_database.exists()
 
 
-def test_analysis_job_completes_only_after_selected_scope(
+def test_analysis_job_scope_is_bounded_unique_and_fail_closed(
+    isolated_database: Path,
+) -> None:
+    repository = AnalysisJobRepository()
+
+    with pytest.raises(ValueError, match="at least one track"):
+        repository.create_scope(track_ids=[])
+
+    with pytest.raises(ValueError, match="duplicate"):
+        repository.create_scope(track_ids=["track-a", "track-a"])
+
+    created = repository.create_scope(track_ids=["track-a", "track-b"], job_id="aj_fixed")
+    assert repository.get_targets(created.job_id) == ("track-a", "track-b")
+
+    with pytest.raises(KeyError, match="unknown analysis job"):
+        repository.get_targets("aj_missing")
+
+    with pytest.raises(KeyError, match="outside analysis job scope"):
+        repository.record_target_outcome(
+            created.job_id,
+            track_id="track-outside",
+            status="succeeded",
+            evidence_id="ae_missing",
+        )
+
+
+def test_analysis_job_completes_only_after_all_target_outcomes(
     isolated_database: Path,
 ) -> None:
     service = AnalysisJobService()
-    created = service.create_job(selected=2)
+    evidence = AnalysisEvidenceRepository()
+    created = service.create_job(track_ids=["track-a", "track-b"])
     service.mark_running(created.job_id)
-    service.record_success(created.job_id)
+    service.record_success(
+        created.job_id,
+        track_id="track-a",
+        evidence_id=_success_evidence(
+            evidence,
+            evidence_id="ae_complete_1",
+            track_id="track-a",
+        ),
+    )
 
     with pytest.raises(ValueError, match="cannot finish before"):
         service.finish(created.job_id)
 
-    service.record_success(created.job_id)
+    service.record_success(
+        created.job_id,
+        track_id="track-b",
+        evidence_id=_success_evidence(
+            evidence,
+            evidence_id="ae_complete_2",
+            track_id="track-b",
+        ),
+    )
     done = service.finish(created.job_id)
     assert done.status == "done"
     assert done.counts == AnalysisJobCounts(
@@ -114,40 +207,33 @@ def test_analysis_job_completes_only_after_selected_scope(
         )
 
 
-def test_analysis_job_repository_rejects_regression_and_unknown_job(
+def test_analysis_job_rejects_duplicate_target_outcome(
     isolated_database: Path,
 ) -> None:
-    repository = AnalysisJobRepository()
-    created = repository.create(selected=2, job_id="aj_fixed")
-    progressed = repository.update(
-        created.job_id,
-        status="running",
-        counts=AnalysisJobCounts(
-            selected=2,
-            completed=1,
-            succeeded=1,
-            failed=0,
-            uncertain=0,
-        ),
+    service = AnalysisJobService()
+    evidence = AnalysisEvidenceRepository()
+    created = service.create_job(track_ids=["track-a"])
+    service.mark_running(created.job_id)
+    evidence_id = _success_evidence(
+        evidence,
+        evidence_id="ae_once",
+        track_id="track-a",
     )
-    assert progressed.counts.completed == 1
+    service.record_success(
+        created.job_id,
+        track_id="track-a",
+        evidence_id=evidence_id,
+    )
 
-    with pytest.raises(ValueError, match="must be monotonic"):
-        repository.update(
+    with pytest.raises(ValueError, match="already complete|already recorded"):
+        service.record_success(
             created.job_id,
-            status="running",
-            counts=AnalysisJobCounts(selected=2),
-        )
-
-    with pytest.raises(KeyError, match="unknown analysis job"):
-        repository.update(
-            "aj_missing",
-            status="running",
-            counts=AnalysisJobCounts(selected=1),
+            track_id="track-a",
+            evidence_id=evidence_id,
         )
 
 
-def test_analysis_evidence_and_corrections_are_append_only(
+def test_analysis_evidence_and_corrections_are_append_only_and_anchored(
     isolated_database: Path,
 ) -> None:
     repository = AnalysisEvidenceRepository()
@@ -187,24 +273,36 @@ def test_analysis_evidence_and_corrections_are_append_only(
     )
 
     assert first.evidence_id != second.evidence_id
-    latest = repository.latest_evidence_for_track("track-1")
-    assert latest is not None
-    assert latest.evidence_id == "ae_0002"
-    assert latest.warnings == ()
+    assert repository.latest_evidence_for_track("track-1") == second
+    assert repository.latest_success_for_track("track-1") == second
 
     correction = repository.append_correction(
         correction_id="ac_0001",
         track_id="track-1",
+        base_evidence_id=second.evidence_id,
         values={"bpm": 140.0, "camelot": "11A"},
         reason="confirmed on deck",
     )
     assert json.loads(correction.payload_json) == {"bpm": 140.0, "camelot": "11A"}
-    assert correction.reason == "confirmed on deck"
-    assert repository.latest_correction_for_track("track-1") == correction
+    assert correction.base_evidence_id == second.evidence_id
+    assert repository.latest_active_correction("track-1", second.evidence_id) == correction
+
+    failed = repository.append_evidence(
+        evidence_id="ae_0003",
+        track_id="track-1",
+        provider="librosa",
+        analysis_version="canonical-mir-v1",
+        status="failed",
+        error_code="provider_runtime_error",
+        error_detail="Analysis provider failed for this track.",
+    )
+    assert repository.latest_evidence_for_track("track-1") == failed
+    assert repository.latest_success_for_track("track-1") == second
+    assert repository.latest_active_correction("track-1", second.evidence_id) == correction
 
     with pytest.raises(sqlite3.IntegrityError):
         repository.append_evidence(
-            evidence_id="ae_0002",
+            evidence_id="ae_0003",
             track_id="track-1",
             provider="librosa",
             analysis_version="canonical-mir-v1",
@@ -213,5 +311,13 @@ def test_analysis_evidence_and_corrections_are_append_only(
     with pytest.raises(ValueError, match="unsupported fields"):
         repository.append_correction(
             track_id="track-1",
+            base_evidence_id=second.evidence_id,
             values={"path": "/must/not/be/stored"},
+        )
+
+    with pytest.raises(ValueError, match="same track"):
+        repository.append_correction(
+            track_id="other-track",
+            base_evidence_id=second.evidence_id,
+            values={"bpm": 140.0},
         )

--- a/tests/test_analysis_job_contract.py
+++ b/tests/test_analysis_job_contract.py
@@ -151,6 +151,11 @@ def test_analysis_job_scope_is_bounded_unique_and_fail_closed(
     with pytest.raises(KeyError, match="unknown analysis job"):
         repository.get_targets("aj_missing")
 
+    repository.update(
+        created.job_id,
+        status="running",
+        counts=created.counts,
+    )
     with pytest.raises(KeyError, match="outside analysis job scope"):
         repository.record_target_outcome(
             created.job_id,

--- a/tests/test_analysis_job_contract.py
+++ b/tests/test_analysis_job_contract.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from core.analysis.job_contract import AnalysisJobCounts
+from core.config.settings import get_settings
+from data.repositories.analysis_evidence_repository import AnalysisEvidenceRepository
+from data.repositories.analysis_job_repository import AnalysisJobRepository
+from services.analysis.job_service import AnalysisJobService
+
+
+@pytest.fixture
+def isolated_database(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    database_path = tmp_path / "bundle50.sqlite3"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{database_path}")
+    get_settings.cache_clear()
+    yield database_path
+    get_settings.cache_clear()
+
+
+def test_analysis_job_contract_rejects_invalid_counts() -> None:
+    with pytest.raises(ValueError, match="completed must equal"):
+        AnalysisJobCounts(selected=2, completed=1, succeeded=0, failed=0)
+
+    with pytest.raises(ValueError, match="uncertain cannot exceed"):
+        AnalysisJobCounts(
+            selected=2,
+            completed=1,
+            succeeded=1,
+            failed=0,
+            uncertain=2,
+        )
+
+
+def test_analysis_job_persists_monotonic_progress_and_cancel(
+    isolated_database: Path,
+) -> None:
+    service = AnalysisJobService()
+    created = service.create_job(selected=3, preferred_provider=" Librosa ")
+
+    assert created.job_id.startswith("aj_")
+    assert created.status == "pending"
+    assert created.preferred_provider == "librosa"
+    assert created.counts == AnalysisJobCounts(selected=3)
+
+    running = service.mark_running(created.job_id)
+    assert running.status == "running"
+
+    first = service.record_success(created.job_id, uncertain=True)
+    assert first.counts == AnalysisJobCounts(
+        selected=3,
+        completed=1,
+        succeeded=1,
+        failed=0,
+        uncertain=1,
+    )
+
+    second = service.record_failure(created.job_id)
+    assert second.counts == AnalysisJobCounts(
+        selected=3,
+        completed=2,
+        succeeded=1,
+        failed=1,
+        uncertain=1,
+    )
+
+    cancelling = service.request_cancel(created.job_id)
+    assert cancelling.status == "cancelling"
+    assert cancelling.cancel_requested is True
+
+    repeated = service.request_cancel(created.job_id)
+    assert repeated == cancelling
+
+    cancelled = service.finish(created.job_id)
+    assert cancelled.status == "cancelled"
+    assert cancelled.counts == second.counts
+
+    persisted = AnalysisJobRepository().get(created.job_id)
+    assert persisted == cancelled
+    assert isolated_database.exists()
+
+
+def test_analysis_job_completes_only_after_selected_scope(
+    isolated_database: Path,
+) -> None:
+    service = AnalysisJobService()
+    created = service.create_job(selected=2)
+    service.mark_running(created.job_id)
+    service.record_success(created.job_id)
+
+    with pytest.raises(ValueError, match="cannot finish before"):
+        service.finish(created.job_id)
+
+    service.record_success(created.job_id)
+    done = service.finish(created.job_id)
+    assert done.status == "done"
+    assert done.counts == AnalysisJobCounts(
+        selected=2,
+        completed=2,
+        succeeded=2,
+        failed=0,
+        uncertain=0,
+    )
+
+    with pytest.raises(ValueError, match="terminal analysis job state"):
+        service.fail_job(
+            created.job_id,
+            error_code="late_failure",
+            error_detail="must not rewrite a completed job",
+        )
+
+
+def test_analysis_job_repository_rejects_regression_and_unknown_job(
+    isolated_database: Path,
+) -> None:
+    repository = AnalysisJobRepository()
+    created = repository.create(selected=2, job_id="aj_fixed")
+    progressed = repository.update(
+        created.job_id,
+        status="running",
+        counts=AnalysisJobCounts(
+            selected=2,
+            completed=1,
+            succeeded=1,
+            failed=0,
+            uncertain=0,
+        ),
+    )
+    assert progressed.counts.completed == 1
+
+    with pytest.raises(ValueError, match="must be monotonic"):
+        repository.update(
+            created.job_id,
+            status="running",
+            counts=AnalysisJobCounts(selected=2),
+        )
+
+    with pytest.raises(KeyError, match="unknown analysis job"):
+        repository.update(
+            "aj_missing",
+            status="running",
+            counts=AnalysisJobCounts(selected=1),
+        )
+
+
+def test_analysis_evidence_and_corrections_are_append_only(
+    isolated_database: Path,
+) -> None:
+    repository = AnalysisEvidenceRepository()
+
+    first = repository.append_evidence(
+        evidence_id="ae_0001",
+        track_id="track-1",
+        provider="librosa",
+        analysis_version="canonical-mir-v1",
+        provider_version="0.10.2",
+        algorithm_version="baseline-r1",
+        bpm=139.8,
+        bpm_confidence=0.82,
+        key_tonic="F#",
+        key_scale="minor",
+        camelot="11A",
+        key_confidence=0.74,
+        energy=0.71,
+        duration_seconds=312.4,
+        warnings=("tempo_half_time_possible",),
+    )
+    second = repository.append_evidence(
+        evidence_id="ae_0002",
+        track_id="track-1",
+        provider="librosa",
+        analysis_version="canonical-mir-v1",
+        provider_version="0.10.2",
+        algorithm_version="baseline-r1",
+        bpm=140.1,
+        bpm_confidence=0.91,
+        key_tonic="F#",
+        key_scale="minor",
+        camelot="11A",
+        key_confidence=0.80,
+        energy=0.73,
+        duration_seconds=312.4,
+    )
+
+    assert first.evidence_id != second.evidence_id
+    latest = repository.latest_evidence_for_track("track-1")
+    assert latest is not None
+    assert latest.evidence_id == "ae_0002"
+    assert latest.warnings == ()
+
+    correction = repository.append_correction(
+        correction_id="ac_0001",
+        track_id="track-1",
+        values={"bpm": 140.0, "camelot": "11A"},
+        reason="confirmed on deck",
+    )
+    assert json.loads(correction.payload_json) == {"bpm": 140.0, "camelot": "11A"}
+    assert correction.reason == "confirmed on deck"
+    assert repository.latest_correction_for_track("track-1") == correction
+
+    with pytest.raises(sqlite3.IntegrityError):
+        repository.append_evidence(
+            evidence_id="ae_0002",
+            track_id="track-1",
+            provider="librosa",
+            analysis_version="canonical-mir-v1",
+        )
+
+    with pytest.raises(ValueError, match="unsupported fields"):
+        repository.append_correction(
+            track_id="track-1",
+            values={"path": "/must/not/be/stored"},
+        )

--- a/tests/test_analysis_job_contract.py
+++ b/tests/test_analysis_job_contract.py
@@ -321,3 +321,89 @@ def test_analysis_evidence_and_corrections_are_append_only_and_anchored(
             base_evidence_id=second.evidence_id,
             values={"bpm": 140.0},
         )
+
+
+def test_analysis_evidence_migrates_pre_outcome_schema_before_index_creation(
+    isolated_database: Path,
+) -> None:
+    with sqlite3.connect(isolated_database) as conn:
+        conn.executescript(
+            '''
+            CREATE TABLE analysis_evidence (
+                evidence_id TEXT PRIMARY KEY,
+                track_id TEXT NOT NULL,
+                provider TEXT NOT NULL,
+                analysis_version TEXT NOT NULL,
+                provider_version TEXT,
+                algorithm_version TEXT,
+                bpm REAL,
+                bpm_confidence REAL,
+                key_tonic TEXT,
+                key_scale TEXT,
+                camelot TEXT,
+                key_confidence REAL,
+                energy REAL,
+                duration_seconds REAL,
+                warnings_json TEXT NOT NULL DEFAULT '[]',
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE analysis_corrections (
+                correction_id TEXT PRIMARY KEY,
+                track_id TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                reason TEXT,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            '''
+        )
+
+    repository = AnalysisEvidenceRepository()
+    repository.ensure_schema()
+
+    with sqlite3.connect(isolated_database) as conn:
+        evidence_columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(analysis_evidence)").fetchall()
+        }
+        correction_columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(analysis_corrections)").fetchall()
+        }
+        indexes = {
+            row[1] for row in conn.execute("PRAGMA index_list(analysis_evidence)").fetchall()
+        }
+
+    assert {"status", "error_code", "error_detail", "loudness_db"} <= evidence_columns
+    assert "base_evidence_id" in correction_columns
+    assert "idx_analysis_evidence_status_created" in indexes
+
+
+def test_generated_evidence_ids_preserve_latest_order_with_timestamp_ties(
+    isolated_database: Path,
+) -> None:
+    repository = AnalysisEvidenceRepository()
+    first = repository.append_evidence(
+        track_id="track-order",
+        provider="librosa",
+        analysis_version="canonical-mir-v1",
+        bpm=138.0,
+        bpm_confidence=0.8,
+        key_tonic="F#",
+        key_scale="minor",
+        camelot="11A",
+        key_confidence=0.8,
+        energy=0.7,
+    )
+    second = repository.append_evidence(
+        track_id="track-order",
+        provider="librosa",
+        analysis_version="canonical-mir-v1",
+        bpm=140.0,
+        bpm_confidence=0.8,
+        key_tonic="F#",
+        key_scale="minor",
+        camelot="11A",
+        key_confidence=0.8,
+        energy=0.7,
+    )
+
+    assert second.evidence_id > first.evidence_id
+    assert repository.latest_evidence_for_track("track-order") == second


### PR DESCRIPTION
## Summary
Implements the first governed Bundle 50 backend vertical slice on top of merged Bundle 49 canonical SHA `70dbddd8f6c61de3e9c2c533eb4d01e9f892f3fe`.

This slice adds:
- typed persisted `AnalysisJob` lifecycle with bounded track scope,
- per-target transactional outcomes and monotonic count progress,
- cooperative cancellation at track work-unit boundaries,
- failure-isolated batch analysis through the existing `RoutedAnalysisService`,
- append-only normalized provider evidence,
- append-only manual corrections anchored to exact provider evidence,
- safe inspector read model and `all | uncertain | failed | corrected` filters,
- explicit distinction between latest attempt and latest successful/effective evidence,
- sanitized bounded per-track failure evidence without path/raw-exception leakage,
- migration coverage for the pre-outcome evidence schema,
- cross-platform inspector basename sanitization for POSIX and Windows-style stored paths,
- pre-worker cancellation that terminates without provider execution.

Related issue: #107.

## Verification

Exact head: `ac568bad38dc4a633b6214595e0625915037ca9e`

- CI #517: **SUCCESS**
  - Python 3.11: SUCCESS
  - Python 3.12: SUCCESS
  - Compile: SUCCESS
  - Critical Ruff lint gate: SUCCESS
  - Python 3.12 pytest: **295 passed, 5 warnings in 37.15s**
  - Python 3.12 artifact digest: `sha256:d125978e293a360ad0294f8fc00c80b9e821f6198e9fff88692c752f681e87ed`
  - Python 3.11 artifact digest: `sha256:df75b41e9de4b7f84802ab03186b7a3093827ed6a656b255e35547bbd05a8c6b`
- PR Guard #156: **SUCCESS**
- unresolved review threads: **0**

CASER checkpoint:
`/CASER/Projects/APPLAYLIST/E/17_RECEIPTS/APPLAYLIST_BUNDLE_50_BACKEND_PR108_CHECKPOINT_2026-08-16.md`

Checkpoint SHA-256:
`81b9f04a9439ef92da229e4c660de0390db60fa5967cc0ffb798fd53b8a53bfe`

## Regression / integration coverage

- invalid and monotonic job counts,
- persisted unique target scope,
- idempotent cancellation,
- duplicate and out-of-scope target rejection,
- full-scope completion requirement,
- append-only evidence and corrections,
- correction anchoring,
- pre-outcome schema migration before new indexes,
- deterministic latest-evidence ordering,
- one-track provider failure while the remaining batch continues,
- cancellation during one track with the next track never started,
- cancellation before worker start with zero provider calls,
- inspector path safety for POSIX and Windows-style paths,
- manual correction overlay,
- successful re-analysis deactivating an old override without deleting history,
- failed re-analysis preserving the last good effective provider result.

## Bundle Context

### Value
A DJ needs a repository-backed analysis lifecycle and auditable inspector evidence before Bundle 50 can safely expose analysis commands in the desktop renderer.

### Data flow
```text
persisted track scope
  -> typed AnalysisJob
  -> existing RoutedAnalysisService
  -> normalized CanonicalAnalysisResult
  -> append-only provider evidence
  -> safe inspector read model
  -> optional append-only correction anchored to evidence
```

### Security / authority
- no new renderer command in this backend slice,
- no generic filesystem/shell/network/SQLite authority,
- inspector DTO contains no absolute path,
- raw provider exceptions are not persisted or exposed,
- corrections cannot contain a path field,
- unknown jobs and out-of-scope tracks fail closed.

### Still required before Bundle 50 completion
- typed sidecar endpoints,
- trusted Rust/Tauri analysis command surface,
- renderer Analysis screen/Inspector UI,
- explicit re-analysis desktop action,
- desktop progress/cancel UX,
- current-status documentation alignment.

### Out of scope
- Bundle 51 transition scoring,
- composition/set building,
- cloud/network analysis,
- concurrent analysis jobs,
- resume after process restart,
- MIR provider production-authority promotion,
- release/deploy/signing/notarization.

`MERGE_AUTHORIZATION=NO`
`RELEASE_AUTHORIZATION=NO`
`DEPLOY_AUTHORIZATION=NO`
`PRODUCTION_EFFECTS=NO`