### PR TITLE
Bundle 55: exact incremental analysis evidence reuse R1

### DIFF
--- a/core/analysis/execution_identity.py
+++ b/core/analysis/execution_identity.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+_CONTENT_TRACK_ID_RE = re.compile(r"^aptrack:v1:sha256:[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True, slots=True)
+class AnalysisExecutionIdentity:
+    """Identity of one reproducible canonical analysis execution contract.
+
+    This identity is intentionally limited to values that are knowable before the
+    provider is executed. Reuse is permitted only when all fields match persisted
+    successful evidence exactly.
+    """
+
+    provider: str
+    analysis_version: str
+    provider_version: str
+    algorithm_version: str
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "provider",
+            "analysis_version",
+            "provider_version",
+            "algorithm_version",
+        ):
+            value = getattr(self, field_name)
+            if not isinstance(value, str):
+                raise TypeError(f"{field_name} must be text")
+            normalized = value.strip()
+            if not normalized:
+                raise ValueError(f"{field_name} must not be empty")
+            if field_name == "provider":
+                normalized = normalized.lower()
+            object.__setattr__(self, field_name, normalized)
+
+
+def is_content_addressed_track_id(track_id: str) -> bool:
+    """Return True only for canonical byte-addressed APPLAYLIST track identities."""
+
+    return isinstance(track_id, str) and _CONTENT_TRACK_ID_RE.fullmatch(track_id) is not None
+
+
+__all__ = ["AnalysisExecutionIdentity", "is_content_addressed_track_id"]

--- a/core/analysis/provider_service.py
+++ b/core/analysis/provider_service.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
+from importlib import metadata
 from typing import Any, Protocol
 
+from core.analysis.execution_identity import AnalysisExecutionIdentity
 from core.analysis.provider_contract import (
     CanonicalAnalysisResult,
     ProviderContractError,
@@ -29,6 +31,34 @@ class RoutedAnalysisService:
 
     def __init__(self, selector: ProviderSelector = select_best_provider) -> None:
         self._selector = selector
+
+    def execution_identity(
+        self,
+        *,
+        preferred_provider: str | None = None,
+    ) -> AnalysisExecutionIdentity | None:
+        """Return a pre-execution identity only when exact evidence reuse is safe.
+
+        R1 intentionally enables reuse only for the versioned baseline librosa
+        provider. Other providers remain fail-closed to fresh execution until they
+        expose an equally stable pre-run identity contract.
+        """
+
+        provider = self._select_provider(preferred_provider)
+        if provider.name != "librosa":
+            return None
+        try:
+            from services.analysis.librosa_baseline import BaselineLibrosaMIR
+
+            provider_version = metadata.version("librosa")
+        except (ImportError, metadata.PackageNotFoundError):
+            return None
+        return AnalysisExecutionIdentity(
+            provider=provider.name,
+            analysis_version="canonical-mir-v1",
+            provider_version=provider_version,
+            algorithm_version=BaselineLibrosaMIR.algorithm_version,
+        )
 
     def analyze_path(
         self,

--- a/docs/architecture/APPLAYLIST_BUNDLE_55_INCREMENTAL_ANALYSIS_EVIDENCE_REUSE_R1.md
+++ b/docs/architecture/APPLAYLIST_BUNDLE_55_INCREMENTAL_ANALYSIS_EVIDENCE_REUSE_R1.md
@@ -1,0 +1,109 @@
+# APPLAYLIST Bundle 55 — Incremental Analysis Evidence Reuse R1
+
+## Status
+
+Implementation slice only. No merge, release, deploy, production activation, optimizer activation, or Personal DJ Model training is authorized by this document.
+
+## Why this exists
+
+APPLAYLIST already has the two primitives required for incremental MIR:
+
+1. canonical content-addressed `TrackIdentity` (`aptrack:v1:sha256:<digest>`), and
+2. append-only Bundle 50 `AnalysisEvidenceRecord` persistence.
+
+Re-running the MIR provider for unchanged audio under the same provider/algorithm contract is therefore redundant work. R1 removes that work without creating a second cache database or a second source of truth.
+
+## Reuse rule
+
+A previous successful analysis may be reused only when all of the following are true:
+
+- track identity is canonical content-addressed identity (`aptrack:v1:sha256:<digest>`),
+- provider matches exactly,
+- canonical analysis version matches exactly,
+- provider version matches exactly,
+- algorithm version matches exactly,
+- the persisted evidence status is `succeeded`.
+
+Any missing identity or identity drift forces fresh provider execution.
+
+Legacy/non-content-addressed track IDs are deliberately not reusable because a path may change bytes while retaining a legacy identifier.
+
+## Execution model
+
+```text
+AnalysisJob target
+      |
+      v
+content-addressed TrackIdentity?
+      | no ------------------------------> run provider
+      |
+     yes
+      v
+provider can prove pre-run execution identity?
+      | no ------------------------------> run provider
+      |
+     yes
+      v
+latest successful evidence exact-match?
+      | no ------------------------------> run provider -> append evidence
+      |
+     yes
+      v
+reuse existing evidence_id
+      |
+      v
+record target success in current AnalysisJob
+```
+
+A reuse hit does not append a duplicate evidence row. Job history remains explicit because the new AnalysisJob target outcome references the previously persisted evidence ID.
+
+## Resume semantics
+
+Because successful evidence is persisted per target, a new job after cancellation/interruption can reuse already completed exact evidence and execute the provider only for remaining or invalidated targets.
+
+This is crash/restart reuse through durable evidence, not in-memory memoization.
+
+## Provider identity
+
+`RoutedAnalysisService.execution_identity()` is optional and fail-closed.
+
+- the versioned baseline librosa provider can expose a pre-run identity from the installed librosa package version, canonical analysis version, and `BaselineLibrosaMIR.algorithm_version`;
+- providers that cannot prove a stable identity before execution return `None` and are never reused in R1.
+
+Provider/algorithm configuration changes that alter analysis semantics must advance the versioned algorithm identity before they are eligible for reuse.
+
+## Security and truth boundaries
+
+R1 does not:
+
+- infer file equality from path alone,
+- trust workbook/inventory `File Signature` as content SHA-256,
+- mutate historical analysis evidence,
+- reuse failed evidence,
+- bypass provider validation,
+- change `TransitionAssessment` authority,
+- activate optimizer/ranking behavior,
+- train the Personal DJ Model,
+- expose local filesystem paths to Music DNA.
+
+## Performance expectation
+
+The architecture changes warm-run cost from approximately:
+
+```text
+N unchanged tracks -> N provider executions
+```
+
+into:
+
+```text
+N unchanged tracks -> N cheap evidence lookups -> 0 provider executions
+```
+
+Only new content or analysis-identity drift triggers expensive MIR.
+
+## Follow-up boundary
+
+Bundle 54 is a real-library benchmark bridge and currently performs direct audio hashing/MIR outside the reusable Bundle 50 AnalysisJob path. A later governed slice should consume/reconcile canonical reusable analysis evidence (and, where appropriate, seed it from verified private runtime evidence) so real-library benchmark reruns do not repeat full MIR work.
+
+That follow-up must preserve the Bundle 54 rule that real content SHA-256 comes from actual bytes and must not reinterpret the historical opaque inventory `File Signature` as a cryptographic digest.

--- a/services/analysis/batch_runner.py
+++ b/services/analysis/batch_runner.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from core.analysis.execution_identity import (
+    AnalysisExecutionIdentity,
+    is_content_addressed_track_id,
+)
 from core.analysis.provider_contract import ProviderContractError
 from core.analysis.provider_service import RoutedAnalysisService
 from core.analysis.job_contract import AnalysisJobSnapshot
@@ -32,6 +36,7 @@ class AnalysisBatchRunner:
             raise ValueError("analysis batch runner requires a pending job")
 
         targets = self._jobs.get_targets(job_id)
+        execution_identity = self._safe_execution_identity(job.preferred_provider)
         self._jobs.mark_running(job_id)
 
         try:
@@ -57,6 +62,20 @@ class AnalysisBatchRunner:
                         error_code=evidence.error_code or "track_unavailable",
                     )
                     continue
+
+                if execution_identity is not None and is_content_addressed_track_id(track_id):
+                    reusable = self._results.reusable_success(
+                        track_id=track_id,
+                        execution_identity=execution_identity,
+                    )
+                    if reusable is not None:
+                        self._jobs.record_success(
+                            job_id,
+                            track_id=track_id,
+                            evidence_id=reusable.evidence_id,
+                            uncertain=self._results.is_uncertain_evidence(reusable),
+                        )
+                        continue
 
                 try:
                     result = self._analysis.analyze_path(
@@ -108,3 +127,18 @@ class AnalysisBatchRunner:
             raise
 
         return self._jobs.finish(job_id)
+
+    def _safe_execution_identity(
+        self,
+        preferred_provider: str | None,
+    ) -> AnalysisExecutionIdentity | None:
+        """Probe optional reuse identity without changing analysis correctness semantics."""
+
+        resolver = getattr(self._analysis, "execution_identity", None)
+        if not callable(resolver):
+            return None
+        try:
+            identity = resolver(preferred_provider=preferred_provider)
+        except Exception:
+            return None
+        return identity if isinstance(identity, AnalysisExecutionIdentity) else None

--- a/services/analysis/result_store.py
+++ b/services/analysis/result_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from core.analysis.execution_identity import AnalysisExecutionIdentity
 from core.analysis.provider_contract import (
     CanonicalAnalysisResult,
     ProviderContractError,
@@ -17,6 +18,27 @@ INSPECTOR_CONFIDENCE_FLOOR = 0.50
 class AnalysisResultStore:
     def __init__(self, repository: AnalysisEvidenceRepository | None = None) -> None:
         self._repo = repository or AnalysisEvidenceRepository()
+
+    def reusable_success(
+        self,
+        *,
+        track_id: str,
+        execution_identity: AnalysisExecutionIdentity,
+    ) -> AnalysisEvidenceRecord | None:
+        """Return latest successful evidence only for an exact execution identity match."""
+
+        evidence = self._repo.latest_success_for_track(track_id)
+        if evidence is None:
+            return None
+        if evidence.provider != execution_identity.provider:
+            return None
+        if evidence.analysis_version != execution_identity.analysis_version:
+            return None
+        if evidence.provider_version != execution_identity.provider_version:
+            return None
+        if evidence.algorithm_version != execution_identity.algorithm_version:
+            return None
+        return evidence
 
     def persist_success(
         self,

--- a/tests/test_incremental_analysis_evidence_reuse.py
+++ b/tests/test_incremental_analysis_evidence_reuse.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.analysis.execution_identity import AnalysisExecutionIdentity
+from core.analysis.provider_contract import CanonicalAnalysisResult
+from core.config.settings import get_settings
+from data.models.track_record import TrackRecord
+from data.repositories.analysis_evidence_repository import AnalysisEvidenceRepository
+from data.repositories.track_repository import TrackRepository
+from services.analysis.batch_runner import AnalysisBatchRunner
+from services.analysis.job_service import AnalysisJobService
+from services.analysis.result_store import AnalysisResultStore
+
+
+@pytest.fixture
+def isolated_database(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    database_path = tmp_path / "bundle55-analysis-reuse.sqlite3"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{database_path}")
+    get_settings.cache_clear()
+    yield database_path
+    get_settings.cache_clear()
+
+
+def _content_track_id(fill: str) -> str:
+    return "aptrack:v1:sha256:" + (fill * 64)
+
+
+def _track(repository: TrackRepository, track_id: str, path: str) -> None:
+    repository.upsert(
+        TrackRecord(
+            track_id=track_id,
+            path=path,
+            title="Track",
+            artist="Test Artist",
+            duration_seconds=300.0,
+        )
+    )
+
+
+def _identity(*, provider_version: str = "0.10.2") -> AnalysisExecutionIdentity:
+    return AnalysisExecutionIdentity(
+        provider="librosa",
+        analysis_version="canonical-mir-v1",
+        provider_version=provider_version,
+        algorithm_version="baseline-librosa-mir-v1",
+    )
+
+
+def _result(path: str, *, provider_version: str = "0.10.2") -> CanonicalAnalysisResult:
+    return CanonicalAnalysisResult(
+        path=path,
+        provider="librosa",
+        bpm=140.0,
+        bpm_confidence=0.90,
+        key="11A",
+        key_confidence=0.88,
+        energy=0.72,
+        loudness_db=-10.0,
+        duration_seconds=300.0,
+        genre_hint=None,
+        key_tonic="F#",
+        key_scale="minor",
+        camelot="11A",
+        beat_stability=0.85,
+        harmonic_ratio=0.55,
+        percussive_ratio=0.45,
+        provider_version=provider_version,
+        algorithm_version="baseline-librosa-mir-v1",
+    )
+
+
+class IdentityAwareAnalysisService:
+    def __init__(
+        self,
+        identity: AnalysisExecutionIdentity,
+        outcomes: dict[str, CanonicalAnalysisResult],
+    ) -> None:
+        self.identity = identity
+        self.outcomes = outcomes
+        self.calls: list[str] = []
+
+    def execution_identity(
+        self,
+        *,
+        preferred_provider: str | None = None,
+    ) -> AnalysisExecutionIdentity:
+        return self.identity
+
+    def analyze_path(
+        self,
+        path: str,
+        *,
+        preferred_provider: str | None = None,
+    ) -> CanonicalAnalysisResult:
+        self.calls.append(path)
+        return self.outcomes[path]
+
+
+class CancellingIdentityAnalysisService(IdentityAwareAnalysisService):
+    def __init__(
+        self,
+        identity: AnalysisExecutionIdentity,
+        outcomes: dict[str, CanonicalAnalysisResult],
+        jobs: AnalysisJobService,
+        job_id: str,
+    ) -> None:
+        super().__init__(identity, outcomes)
+        self.jobs = jobs
+        self.job_id = job_id
+
+    def analyze_path(
+        self,
+        path: str,
+        *,
+        preferred_provider: str | None = None,
+    ) -> CanonicalAnalysisResult:
+        result = super().analyze_path(path, preferred_provider=preferred_provider)
+        self.jobs.request_cancel(self.job_id)
+        return result
+
+
+def test_exact_content_and_execution_identity_reuses_evidence_without_provider_call(
+    isolated_database: Path,
+) -> None:
+    tracks = TrackRepository()
+    jobs = AnalysisJobService()
+    evidence = AnalysisEvidenceRepository()
+    store = AnalysisResultStore(evidence)
+    track_id = _content_track_id("a")
+    path = "/library/a.wav"
+    _track(tracks, track_id, path)
+
+    original = store.persist_success(track_id=track_id, result=_result(path))
+    service = IdentityAwareAnalysisService(_identity(), {path: _result(path)})
+    job = jobs.create_job(track_ids=[track_id], preferred_provider="librosa")
+
+    terminal = AnalysisBatchRunner(
+        analysis_service=service,  # type: ignore[arg-type]
+        job_service=jobs,
+        result_store=store,
+        track_repository=tracks,
+    ).run(job.job_id)
+
+    assert terminal.status == "done"
+    assert terminal.counts.completed == 1
+    assert terminal.counts.succeeded == 1
+    assert service.calls == []
+    assert evidence.latest_success_for_track(track_id) == original
+    assert evidence.list_latest_attempts() == [original]
+
+
+def test_provider_version_drift_forces_fresh_analysis(
+    isolated_database: Path,
+) -> None:
+    tracks = TrackRepository()
+    jobs = AnalysisJobService()
+    evidence = AnalysisEvidenceRepository()
+    store = AnalysisResultStore(evidence)
+    track_id = _content_track_id("b")
+    path = "/library/b.wav"
+    _track(tracks, track_id, path)
+
+    old = store.persist_success(track_id=track_id, result=_result(path, provider_version="0.10.2"))
+    service = IdentityAwareAnalysisService(
+        _identity(provider_version="0.10.3"),
+        {path: _result(path, provider_version="0.10.3")},
+    )
+    job = jobs.create_job(track_ids=[track_id], preferred_provider="librosa")
+
+    terminal = AnalysisBatchRunner(
+        analysis_service=service,  # type: ignore[arg-type]
+        job_service=jobs,
+        result_store=store,
+        track_repository=tracks,
+    ).run(job.job_id)
+
+    latest = evidence.latest_success_for_track(track_id)
+    assert terminal.status == "done"
+    assert service.calls == [path]
+    assert latest is not None
+    assert latest.evidence_id != old.evidence_id
+    assert latest.provider_version == "0.10.3"
+
+
+def test_legacy_track_id_never_reuses_evidence(
+    isolated_database: Path,
+) -> None:
+    tracks = TrackRepository()
+    jobs = AnalysisJobService()
+    evidence = AnalysisEvidenceRepository()
+    store = AnalysisResultStore(evidence)
+    track_id = "legacy-track-a"
+    path = "/library/legacy.wav"
+    _track(tracks, track_id, path)
+
+    store.persist_success(track_id=track_id, result=_result(path))
+    service = IdentityAwareAnalysisService(_identity(), {path: _result(path)})
+    job = jobs.create_job(track_ids=[track_id], preferred_provider="librosa")
+
+    AnalysisBatchRunner(
+        analysis_service=service,  # type: ignore[arg-type]
+        job_service=jobs,
+        result_store=store,
+        track_repository=tracks,
+    ).run(job.job_id)
+
+    assert service.calls == [path]
+
+
+def test_new_job_resumes_from_persisted_exact_evidence_after_cancellation(
+    isolated_database: Path,
+) -> None:
+    tracks = TrackRepository()
+    jobs = AnalysisJobService()
+    evidence = AnalysisEvidenceRepository()
+    store = AnalysisResultStore(evidence)
+    track_a = _content_track_id("c")
+    track_b = _content_track_id("d")
+    path_a = "/library/c.wav"
+    path_b = "/library/d.wav"
+    _track(tracks, track_a, path_a)
+    _track(tracks, track_b, path_b)
+
+    first_job = jobs.create_job(track_ids=[track_a, track_b], preferred_provider="librosa")
+    first_service = CancellingIdentityAnalysisService(
+        _identity(),
+        {path_a: _result(path_a), path_b: _result(path_b)},
+        jobs,
+        first_job.job_id,
+    )
+    first_terminal = AnalysisBatchRunner(
+        analysis_service=first_service,  # type: ignore[arg-type]
+        job_service=jobs,
+        result_store=store,
+        track_repository=tracks,
+    ).run(first_job.job_id)
+
+    assert first_terminal.status == "cancelled"
+    assert first_service.calls == [path_a]
+    first_evidence = evidence.latest_success_for_track(track_a)
+    assert first_evidence is not None
+    assert evidence.latest_success_for_track(track_b) is None
+
+    second_job = jobs.create_job(track_ids=[track_a, track_b], preferred_provider="librosa")
+    second_service = IdentityAwareAnalysisService(
+        _identity(),
+        {path_a: _result(path_a), path_b: _result(path_b)},
+    )
+    second_terminal = AnalysisBatchRunner(
+        analysis_service=second_service,  # type: ignore[arg-type]
+        job_service=jobs,
+        result_store=store,
+        track_repository=tracks,
+    ).run(second_job.job_id)
+
+    assert second_terminal.status == "done"
+    assert second_terminal.counts.completed == 2
+    assert second_terminal.counts.succeeded == 2
+    assert second_service.calls == [path_b]
+    assert evidence.latest_success_for_track(track_a) == first_evidence
+    assert evidence.latest_success_for_track(track_b) is not None


### PR DESCRIPTION
## Summary

Implements the first incremental MIR reuse slice by combining existing canonical content-addressed TrackIdentity with append-only Bundle 50 analysis evidence.

### Changes

- adds a strict `AnalysisExecutionIdentity` contract
- recognizes reuse only for canonical `aptrack:v1:sha256:<digest>` track IDs
- exposes a pre-run librosa execution identity from canonical analysis version + installed provider version + versioned algorithm identity
- reuses only the latest successful evidence on exact identity match
- records the reused evidence ID into the new AnalysisJob target outcome without appending duplicate evidence
- identity drift or legacy/non-content-addressed IDs force fresh provider execution
- adds cancellation/restart resume coverage
- documents Bundle 54 as a separate real-library benchmark bridge that should consume reusable evidence in a later governed slice

## Verification

Exact feature head: `fc2056e80abbd55b82c627f3da09597ff3e3e975`
Exact canonical base: `81c11fadea50ad67deee328bcda2def0122adcc7`

- GitHub compare: 1 commit, 6 files, +507/-0, no unrelated changes
- CI #676 (`31998684258`): SUCCESS
- Python 3.11: compile + critical lint + full pytest + evidence upload SUCCESS
- Python 3.12: compile + critical lint + full pytest + evidence upload SUCCESS
- Python 3.12 full pytest: `369 passed, 5 warnings in 42.70s`
- Python 3.12 artifact ID: `9277684488`
- Python 3.12 artifact SHA-256: `0dc14fb509b5c0df222bf93907b28d511c014ccb1a2c0860e8e45d67f31f40da`
- PR Guard #244 (`31998834344`): SUCCESS

Acceptance tests cover:
- exact warm hit => zero provider calls
- provider version drift => fresh analysis
- legacy track ID => fresh analysis
- cancelled prior job => new job reuses completed exact evidence and runs only remaining targets

## Bundle Context

Bundle 55 follows canonical Bundle 54 merge commit `81c11fadea50ad67deee328bcda2def0122adcc7`.

The prior research and canonical implementation already establish:
- Bundle 43 content-addressed TrackIdentity (`aptrack:v1:sha256:<digest>`)
- Bundle 50 persisted append-only AnalysisJob / AnalysisEvidence lifecycle
- Bundle 51 MusicDNARevision + immutable TransitionAssessment authority
- Bundle 54 as a real-library benchmark/materialization bridge, not a replacement analysis architecture

This slice therefore reuses existing evidence primitives rather than introducing a second cache database or second track identity.

## Why

Re-running full MIR for unchanged bytes under the same exact provider/algorithm contract is redundant. This turns warm jobs into evidence lookups rather than provider executions while remaining fail-closed on any identity uncertainty.

## Follow-up

After canonicalization, the next governed performance slice should reconcile Bundle 54 real-library materialization with the reusable Bundle 50 AnalysisJob/AnalysisEvidence path. The real-library bridge must consume verified content-addressed evidence rather than repeating full MIR for unchanged tracks. No second cache authority should be introduced.

## Boundaries

No TransitionAssessment authority change. No optimizer activation. No Personal DJ Model training. No release/deploy/production effects. No change to the currently running Bundle 54 local pilot.

Closes #122 when merged.

MERGE_AUTHORIZATION=NO
RELEASE_AUTHORIZATION=NO
DEPLOY_AUTHORIZATION=NO
PRODUCTION_EFFECTS=NO