### PR TITLE
Bundle 55: real-library incremental evidence reconciliation R1

### DIFF
--- a/docs/architecture/APPLAYLIST_BUNDLE_55B_REAL_LIBRARY_INCREMENTAL_EVIDENCE_RECONCILIATION_R1.md
+++ b/docs/architecture/APPLAYLIST_BUNDLE_55B_REAL_LIBRARY_INCREMENTAL_EVIDENCE_RECONCILIATION_R1.md
@@ -1,0 +1,146 @@
+# APPLAYLIST Bundle 55B — Real-Library Incremental Evidence Reconciliation R1
+
+## Status
+
+Implementation slice only. No merge, release, deploy, production activation, optimizer activation, or Personal DJ Model training is authorized by this document.
+
+## Purpose
+
+Bundle 54 proved a real local-audio path, but its benchmark bridge directly hashes and analyzes every selected track before case materialization. Bundle 55 established exact reuse for canonical Bundle 50 AnalysisEvidence. Bundle 55B reconnects the real-library bridge to that canonical evidence path.
+
+The performance goal is architectural work elimination, not a larger worker count.
+
+## Runtime split
+
+```text
+REAL AUDIO
+   |
+   v
+ContentTrackIdentityService
+actual bytes -> aptrack:v1:sha256:<digest>
+   |
+   v
+PERSISTENT PRIVATE ANALYSIS DB
+Bundle 50 AnalysisJob + AnalysisEvidence
+   |
+   | exact hit --------------------> reuse evidence_id, 0 MIR calls
+   |
+   | miss / identity drift --------> canonical provider -> append evidence
+   v
+MusicDNARevision
+   |
+   v
+Bundle 54 case materialization
+TransitionAssessment -> greedy/beam -> blinded review packet
+```
+
+The per-run TransitionAssessment/optimizer database remains isolated from the persistent analysis evidence database.
+
+## Stable analysis database
+
+The CLI accepts `--analysis-database`. When omitted, it derives a stable private database beside the run directories:
+
+```text
+real-library-pilot-r1/
+├── APPLAYLIST_REAL_LIBRARY_ANALYSIS_EVIDENCE_R1.sqlite3
+├── <run-a>/
+└── <run-b>/
+```
+
+This preserves compatibility with the existing launcher while making analysis evidence durable across subsequent runs.
+
+## Exact reuse authority
+
+Reuse is delegated to Bundle 55. A track is eligible only when:
+
+- actual bytes produce canonical `aptrack:v1:sha256:<digest>` identity,
+- successful persisted AnalysisEvidence exists,
+- provider matches,
+- canonical analysis version matches,
+- provider version matches,
+- algorithm version matches.
+
+Anything uncertain executes the provider again.
+
+## Content identity cost
+
+Warm runs still verify actual file bytes through `ContentTrackIdentityService`. This is intentional. The opaque inventory `File Signature`, path, filename, size, or mtime alone are not promoted to cryptographic content authority.
+
+The eliminated work is the expensive full MIR provider execution (decode, HPSS, beat/onset, chroma/CQT, RMS/spectral analysis), not the bounded streaming SHA-256 identity proof.
+
+## Interruption / restart
+
+Reconciliation creates one persisted AnalysisJob work unit per selected content identity. Successful evidence is appended before moving to the next selected track. A restarted run therefore re-hashes identity but reuses already completed exact analysis evidence and executes MIR only for incomplete or invalidated content.
+
+## Progress evidence
+
+The CLI emits bounded path-free progress events:
+
+```text
+MIR_PROGRESS {
+  "stage": "analysis_evidence_reused",
+  "targets_total": 124,
+  "evidence_reused": 83,
+  "provider_executed": 2,
+  "succeeded": 85,
+  "failed": 0,
+  "remaining": 39
+}
+```
+
+No absolute local path is emitted by progress telemetry.
+
+## Acceptance matrix
+
+| Scenario | Expected provider execution |
+| --- | --- |
+| cold analysis DB | all selected content |
+| warm exact identity | 0 |
+| one track byte change | changed content only |
+| provider/algorithm/version drift | invalidated content only |
+| interruption + restart | unfinished/invalidated content only |
+| legacy/non-content identity | no reuse |
+| provider drift + fresh failure | fail closed; never use stale success |
+
+A reuse hit must not append duplicate successful AnalysisEvidence.
+
+## Current Bundle 54 pilot migration boundary
+
+The already-running Bundle 54 cold pilot predates Bundle 55B and does not persist its full canonical MIR result into the new persistent AnalysisEvidence database. Its private runtime manifest is intentionally not auto-imported because it does not contain every canonical analysis field required to prove exact semantic equivalence.
+
+Therefore R1 does **not** synthesize or reconstruct missing canonical fields from the old private manifest. The current cold pilot remains valid evidence; future Bundle 55B runs establish the durable reusable evidence base without falsifying provenance.
+
+## Truth and authority boundaries
+
+Bundle 55B does not:
+
+- reinterpret inventory `File Signature` as SHA-256,
+- create a second cache authority,
+- create a second track identity,
+- change MusicDNA or TransitionAssessment scoring semantics,
+- change `TransitionAssessment` as sole pairwise transition authority,
+- expose local paths in reviewer-visible output,
+- alter blind PLAN_A / PLAN_B semantics,
+- activate optimizer ranking in production,
+- train a Personal DJ Model,
+- upload the user's audio library to cloud services.
+
+## Review evidence
+
+Private runtime evidence adds the canonical `analysis_evidence_id` and reconciliation counters. Reviewer-visible packets remain algorithm-blinded and path-free.
+
+## Governed next gate
+
+Required before merge:
+
+- exact-head CI Python 3.11 PASS,
+- exact-head CI Python 3.12 PASS,
+- regression suite PASS,
+- PR Guard PASS,
+- zero unresolved review threads,
+- explicit merge authorization.
+
+`MERGE_AUTHORIZATION=NO`
+`RELEASE_AUTHORIZATION=NO`
+`DEPLOY_AUTHORIZATION=NO`
+`PRODUCTION_EFFECTS=NO`

--- a/scripts/materialize_real_library_pilot_r1.py
+++ b/scripts/materialize_real_library_pilot_r1.py
@@ -3,32 +3,49 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+from typing import Mapping
 
-from services.intelligence.real_library_pilot import materialize_real_library_pilot_r1
+from services.intelligence.real_library_incremental_pilot import (
+    materialize_real_library_pilot_incremental_r1,
+)
+
+
+def _emit_progress(event: Mapping[str, int | str]) -> None:
+    print("MIR_PROGRESS " + json.dumps(dict(event), sort_keys=True), flush=True)
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=(
-            "Materialize APPLAYLIST real-library MIR, TransitionAssessment adjacency, "
-            "greedy/beam plan pairs, and a blinded Human DJ Review R1 packet."
+            "Materialize APPLAYLIST real-library MIR evidence with exact incremental reuse, "
+            "TransitionAssessment adjacency, greedy/beam plan pairs, and a blinded Human DJ "
+            "Review R1 packet."
         )
     )
     parser.add_argument("--snapshot", required=True, help="Private LOCAL_LIBRARY_SNAPSHOT_R1 JSON")
     parser.add_argument("--cases", required=True, help="Private CURATED_CASE_SELECTION_R1 JSON")
     parser.add_argument("--output-dir", required=True)
-    parser.add_argument("--database", required=True, help="Dedicated SQLite evidence database path")
+    parser.add_argument("--database", required=True, help="Dedicated per-run transition database path")
+    parser.add_argument(
+        "--analysis-database",
+        help=(
+            "Persistent private AnalysisEvidence SQLite path. When omitted, a stable database "
+            "beside the run directories is used automatically."
+        ),
+    )
     parser.add_argument("--generated-at", required=True, help="Stable evidence timestamp/label")
     parser.add_argument("--blinding-seed", required=True, help="Private deterministic blinding seed")
     args = parser.parse_args()
 
-    result = materialize_real_library_pilot_r1(
+    result = materialize_real_library_pilot_incremental_r1(
         snapshot_path=Path(args.snapshot),
         selection_path=Path(args.cases),
         output_dir=Path(args.output_dir),
         database_path=Path(args.database),
+        analysis_database_path=(Path(args.analysis_database) if args.analysis_database else None),
         generated_at=args.generated_at,
         blinding_seed=args.blinding_seed,
+        progress=_emit_progress,
     )
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0

--- a/services/intelligence/real_library_incremental_pilot.py
+++ b/services/intelligence/real_library_incremental_pilot.py
@@ -185,7 +185,7 @@ def reconcile_real_tracks(
         provider_ran = counted.provider_calls > before_calls
 
         record = evidence_repository.latest_success_for_track(canonical_track_id)
-        failed = terminal.status != "done" or record is None
+        failed = terminal.status != "done" or terminal.counts.failed != 0 or record is None
         if failed:
             stats = ReconciliationStats(
                 targets_total=stats.targets_total,

--- a/services/intelligence/real_library_incremental_pilot.py
+++ b/services/intelligence/real_library_incremental_pilot.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from core.analysis.provider_contract import CanonicalAnalysisResult
+from core.analysis.provider_service import RoutedAnalysisService
+from core.intelligence.music_dna import build_music_dna
+from data.models.analysis_evidence_record import AnalysisEvidenceRecord
+from data.models.track_record import TrackRecord
+from data.repositories.analysis_evidence_repository import AnalysisEvidenceRepository
+from data.repositories.track_repository import TrackRepository
+from services.analysis.batch_runner import AnalysisBatchRunner
+from services.analysis.job_service import AnalysisJobService
+from services.analysis.result_store import AnalysisResultStore
+from services.library.identity import ContentTrackIdentityService
+from services.intelligence.real_library_pilot import (
+    MaterializedTrackEvidence,
+    RealLibraryPilotError,
+    _analysis_revision,
+    _case_specs,
+    _load_json,
+    _prepare_database,
+    _track_inputs,
+    _validate_snapshot,
+    materialize_cases,
+    private_runtime_manifest,
+    required_track_ids,
+    reviewer_packet,
+)
+
+REAL_LIBRARY_INCREMENTAL_RECONCILIATION_VERSION = (
+    "real-library-incremental-evidence-reconciliation-r1"
+)
+ProgressCallback = Callable[[Mapping[str, int | str]], None]
+
+
+@dataclass(frozen=True, slots=True)
+class ReconciliationStats:
+    targets_total: int
+    evidence_reused: int
+    provider_executed: int
+    succeeded: int
+    failed: int
+    remaining: int
+
+    def as_progress(self, *, stage: str) -> dict[str, int | str]:
+        return {
+            "stage": stage,
+            "targets_total": self.targets_total,
+            "evidence_reused": self.evidence_reused,
+            "provider_executed": self.provider_executed,
+            "succeeded": self.succeeded,
+            "failed": self.failed,
+            "remaining": self.remaining,
+        }
+
+
+class _CountingAnalysisService:
+    def __init__(self, delegate: RoutedAnalysisService) -> None:
+        self._delegate = delegate
+        self.provider_calls = 0
+
+    def execution_identity(self, *, preferred_provider: str | None = None):
+        return self._delegate.execution_identity(preferred_provider=preferred_provider)
+
+    def analyze_path(self, path: str, *, preferred_provider: str | None = None):
+        self.provider_calls += 1
+        return self._delegate.analyze_path(path, preferred_provider=preferred_provider)
+
+
+def _canonical_from_evidence(
+    *,
+    record: AnalysisEvidenceRecord,
+    path: str,
+) -> CanonicalAnalysisResult:
+    if record.status != "succeeded":
+        raise RealLibraryPilotError("reconciled analysis evidence must be successful")
+    return CanonicalAnalysisResult(
+        path=path,
+        provider=record.provider,
+        bpm=record.bpm,
+        bpm_confidence=record.bpm_confidence,
+        key=record.camelot or record.key_tonic,
+        key_confidence=record.key_confidence,
+        energy=record.energy,
+        loudness_db=record.loudness_db,
+        duration_seconds=record.duration_seconds,
+        genre_hint=record.genre_hint,
+        analysis_status="ok",
+        analysis_version=record.analysis_version,
+        key_tonic=record.key_tonic,
+        key_scale=record.key_scale,
+        camelot=record.camelot,
+        beat_stability=record.beat_stability,
+        harmonic_ratio=record.harmonic_ratio,
+        percussive_ratio=record.percussive_ratio,
+        provider_version=record.provider_version,
+        algorithm_version=record.algorithm_version,
+        warnings=record.warnings,
+    )
+
+
+def _emit(progress: ProgressCallback | None, stats: ReconciliationStats, *, stage: str) -> None:
+    if progress is not None:
+        progress(stats.as_progress(stage=stage))
+
+
+def reconcile_real_tracks(
+    *,
+    snapshot_raw: Mapping[str, Any],
+    selection_raw: Mapping[str, Any],
+    analysis_database_path: str | Path,
+    analysis_service: RoutedAnalysisService | None = None,
+    identity_service: ContentTrackIdentityService | None = None,
+    progress: ProgressCallback | None = None,
+) -> tuple[dict[str, MaterializedTrackEvidence], ReconciliationStats]:
+    """Resolve real audio into canonical reusable analysis evidence.
+
+    Actual file bytes remain the content authority. The historical inventory file
+    signature is retained as provenance only. Expensive MIR runs only when Bundle 55
+    cannot reuse exact successful analysis evidence for the canonical content ID.
+    """
+    _validate_snapshot(snapshot_raw)
+    tracks = _track_inputs(snapshot_raw)
+    selected_ids = required_track_ids(selection_raw)
+    missing = tuple(track_id for track_id in selected_ids if track_id not in tracks)
+    if missing:
+        raise RealLibraryPilotError(f"curated selection references unknown tracks: {missing}")
+
+    _prepare_database(analysis_database_path)
+    identity = identity_service or ContentTrackIdentityService()
+    routed = analysis_service or RoutedAnalysisService()
+    counted = _CountingAnalysisService(routed)
+    track_repository = TrackRepository()
+    evidence_repository = AnalysisEvidenceRepository()
+    result_store = AnalysisResultStore(evidence_repository)
+    jobs = AnalysisJobService()
+
+    stats = ReconciliationStats(
+        targets_total=len(selected_ids),
+        evidence_reused=0,
+        provider_executed=0,
+        succeeded=0,
+        failed=0,
+        remaining=len(selected_ids),
+    )
+    _emit(progress, stats, stage="analysis_reconciliation_started")
+
+    materialized: dict[str, MaterializedTrackEvidence] = {}
+    for snapshot_track_id in selected_ids:
+        source = tracks[snapshot_track_id]
+        try:
+            content_identity = identity.identify(source.absolute_path)
+        except Exception as exc:
+            raise RealLibraryPilotError(
+                f"content identity failed for selected track {snapshot_track_id}"
+            ) from exc
+
+        canonical_track_id = content_identity.track_id
+        track_repository.upsert(
+            TrackRecord(
+                track_id=canonical_track_id,
+                path=source.absolute_path,
+                title=source.display_name,
+                artist=source.artist,
+                genre=source.genre,
+            )
+        )
+
+        before_calls = counted.provider_calls
+        job = jobs.create_job(
+            track_ids=[canonical_track_id],
+            preferred_provider="librosa",
+        )
+        terminal = AnalysisBatchRunner(
+            analysis_service=counted,  # type: ignore[arg-type]
+            job_service=jobs,
+            result_store=result_store,
+            track_repository=track_repository,
+        ).run(job.job_id)
+        provider_ran = counted.provider_calls > before_calls
+
+        record = evidence_repository.latest_success_for_track(canonical_track_id)
+        failed = terminal.status != "done" or record is None
+        if failed:
+            stats = ReconciliationStats(
+                targets_total=stats.targets_total,
+                evidence_reused=stats.evidence_reused,
+                provider_executed=stats.provider_executed + int(provider_ran),
+                succeeded=stats.succeeded,
+                failed=stats.failed + 1,
+                remaining=max(0, stats.remaining - 1),
+            )
+            _emit(progress, stats, stage="analysis_target_failed")
+            raise RealLibraryPilotError(
+                f"canonical analysis evidence unavailable for selected track {snapshot_track_id}"
+            )
+
+        canonical = _canonical_from_evidence(record=record, path=source.absolute_path)
+        if canonical.duration_seconds is None or canonical.duration_seconds <= 0.0:
+            raise RealLibraryPilotError(
+                f"positive duration evidence missing for selected track {snapshot_track_id}"
+            )
+        revision = _analysis_revision(source, canonical, content_identity.digest_hex)
+        content_ref = f"sha256:{content_identity.digest_hex}"
+        dna = build_music_dna(
+            track_id=snapshot_track_id,
+            content_identity=content_ref,
+            analysis_revision=revision,
+            evidence_id=record.evidence_id,
+            input_identity=content_ref,
+            canonical=canonical,
+            rhythmic_structure=None,
+            benchmark_status="real-library-pilot-r1-candidate",
+        )
+        materialized[snapshot_track_id] = MaterializedTrackEvidence(
+            source=source,
+            content_sha256=content_identity.digest_hex,
+            canonical=canonical,
+            music_dna=dna,
+        )
+
+        stats = ReconciliationStats(
+            targets_total=stats.targets_total,
+            evidence_reused=stats.evidence_reused + int(not provider_ran),
+            provider_executed=stats.provider_executed + int(provider_ran),
+            succeeded=stats.succeeded + 1,
+            failed=stats.failed,
+            remaining=max(0, stats.remaining - 1),
+        )
+        _emit(
+            progress,
+            stats,
+            stage="analysis_provider_executed" if provider_ran else "analysis_evidence_reused",
+        )
+
+    _emit(progress, stats, stage="analysis_reconciliation_complete")
+    return materialized, stats
+
+
+def default_analysis_database_path(output_dir: str | Path) -> Path:
+    output = Path(output_dir).expanduser().resolve()
+    return output.parent / "APPLAYLIST_REAL_LIBRARY_ANALYSIS_EVIDENCE_R1.sqlite3"
+
+
+def materialize_real_library_pilot_incremental_r1(
+    *,
+    snapshot_path: str | Path,
+    selection_path: str | Path,
+    output_dir: str | Path,
+    database_path: str | Path,
+    analysis_database_path: str | Path | None,
+    generated_at: str,
+    blinding_seed: str,
+    analysis_service: RoutedAnalysisService | None = None,
+    identity_service: ContentTrackIdentityService | None = None,
+    progress: ProgressCallback | None = None,
+) -> dict[str, Any]:
+    snapshot_raw = _load_json(snapshot_path)
+    selection_raw = _load_json(selection_path)
+    persistent_analysis_db = (
+        Path(analysis_database_path)
+        if analysis_database_path is not None
+        else default_analysis_database_path(output_dir)
+    )
+    evidence, stats = reconcile_real_tracks(
+        snapshot_raw=snapshot_raw,
+        selection_raw=selection_raw,
+        analysis_database_path=persistent_analysis_db,
+        analysis_service=analysis_service,
+        identity_service=identity_service,
+        progress=progress,
+    )
+    cases = materialize_cases(
+        snapshot_raw=snapshot_raw,
+        selection_raw=selection_raw,
+        evidence=evidence,
+        database_path=database_path,
+        generated_at=generated_at,
+        blinding_seed=blinding_seed,
+    )
+    if len(cases) != len(_case_specs(selection_raw)):
+        raise RealLibraryPilotError("not every curated case produced a blind plan pair")
+
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    private_path = output / "APPLAYLIST_REAL_LIBRARY_RUNTIME_EVIDENCE_R1.private.json"
+    reviewer_path = output / "APPLAYLIST_BLINDED_HUMAN_DJ_REVIEW_PACKET_R1.json"
+    private_payload = private_runtime_manifest(
+        snapshot_raw=snapshot_raw,
+        evidence=evidence,
+        cases=cases,
+        generated_at=generated_at,
+    )
+    private_payload["analysis_reconciliation"] = {
+        "version": REAL_LIBRARY_INCREMENTAL_RECONCILIATION_VERSION,
+        "targets_total": stats.targets_total,
+        "evidence_reused": stats.evidence_reused,
+        "provider_executed": stats.provider_executed,
+        "succeeded": stats.succeeded,
+        "failed": stats.failed,
+        "analysis_database": "persistent-private-analysis-evidence",
+    }
+    for row in private_payload.get("tracks", []):
+        track_id = str(row.get("track_id", ""))
+        if track_id in evidence:
+            row["analysis_evidence_id"] = evidence[track_id].music_dna.identity.evidence_refs[0]
+
+    reviewer_payload = reviewer_packet(
+        snapshot_raw=snapshot_raw,
+        evidence=evidence,
+        cases=cases,
+        generated_at=generated_at,
+    )
+    private_path.write_text(
+        json.dumps(private_payload, indent=2, ensure_ascii=False, default=str) + "\n",
+        encoding="utf-8",
+    )
+    reviewer_path.write_text(
+        json.dumps(reviewer_payload, indent=2, ensure_ascii=False, default=str) + "\n",
+        encoding="utf-8",
+    )
+    return {
+        "private_runtime_manifest": str(private_path),
+        "blind_reviewer_packet": str(reviewer_path),
+        "private_runtime_manifest_sha256": hashlib.sha256(private_path.read_bytes()).hexdigest(),
+        "blind_reviewer_packet_sha256": hashlib.sha256(reviewer_path.read_bytes()).hexdigest(),
+        "analysis_reconciliation": asdict(stats),
+        "analysis_database_path": str(persistent_analysis_db),
+    }
+
+
+__all__ = [
+    "REAL_LIBRARY_INCREMENTAL_RECONCILIATION_VERSION",
+    "ReconciliationStats",
+    "default_analysis_database_path",
+    "materialize_real_library_pilot_incremental_r1",
+    "reconcile_real_tracks",
+]

--- a/tests/test_real_library_incremental_reconciliation.py
+++ b/tests/test_real_library_incremental_reconciliation.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from core.analysis.execution_identity import AnalysisExecutionIdentity
+from core.analysis.provider_contract import CanonicalAnalysisResult
+from core.config.settings import get_settings
+from core.library.track_metadata import TrackIdentity
+from services.intelligence.real_library_incremental_pilot import (
+    default_analysis_database_path,
+    reconcile_real_tracks,
+)
+from services.intelligence.real_library_pilot import RealLibraryPilotError
+
+
+@pytest.fixture(autouse=True)
+def restore_database_environment():
+    previous = os.environ.get("DATABASE_URL")
+    yield
+    if previous is None:
+        os.environ.pop("DATABASE_URL", None)
+    else:
+        os.environ["DATABASE_URL"] = previous
+    get_settings.cache_clear()
+
+
+def _snapshot(path: str = "/library/a.wav") -> dict[str, object]:
+    return {
+        "schema": "applaylist-local-library-snapshot-r1",
+        "snapshot_id": "snapshot-r1",
+        "snapshot_version": "r1",
+        "library_fingerprint": "library-fingerprint-r1",
+        "created_date": "2026-08-17",
+        "scope": {"kind": "REAL_INVENTORY_BACKED_SUBSET"},
+        "privacy": {"publishable_to_public_repo": False},
+        "tracks": [
+            {
+                "track_id": "snapshot-track-a",
+                "absolute_path": path,
+                "file_signature": "opaque-inventory-signature",
+                "display_name": "Track A",
+                "artist": "Artist A",
+                "genre": "Techno",
+                "energy": 7,
+            }
+        ],
+    }
+
+
+def _selection() -> dict[str, object]:
+    return {
+        "schema": "applaylist-curated-case-selection-r1",
+        "case_specs": [
+            {
+                "case_spec_id": "case-a",
+                "seed_track_id": "snapshot-track-a",
+                "candidate_scope_track_ids": ["snapshot-track-a"],
+            }
+        ],
+    }
+
+
+def _result(path: str, *, provider_version: str = "0.10.2.post1") -> CanonicalAnalysisResult:
+    return CanonicalAnalysisResult(
+        path=path,
+        provider="librosa",
+        bpm=140.0,
+        bpm_confidence=0.9,
+        key="11A",
+        key_confidence=0.88,
+        energy=0.72,
+        loudness_db=-10.0,
+        duration_seconds=300.0,
+        genre_hint=None,
+        key_tonic="F#",
+        key_scale="minor",
+        camelot="11A",
+        beat_stability=0.85,
+        harmonic_ratio=0.55,
+        percussive_ratio=0.45,
+        provider_version=provider_version,
+        algorithm_version="baseline-librosa-mir-v1",
+    )
+
+
+class StaticIdentityService:
+    def __init__(self, digest: str = "a" * 64) -> None:
+        self.digest = digest
+
+    def identify(self, path: str | Path) -> TrackIdentity:
+        return TrackIdentity(
+            track_id=f"aptrack:v1:sha256:{self.digest}",
+            digest_algorithm="sha256",
+            digest_hex=self.digest,
+            source_path=str(path),
+            size_bytes=123,
+            mtime_ns=1,
+        )
+
+
+class FakeAnalysisService:
+    def __init__(self, *, provider_version: str = "0.10.2.post1", fail: bool = False) -> None:
+        self.provider_version = provider_version
+        self.fail = fail
+        self.calls: list[str] = []
+
+    def execution_identity(self, *, preferred_provider: str | None = None):
+        return AnalysisExecutionIdentity(
+            provider="librosa",
+            analysis_version="canonical-mir-v1",
+            provider_version=self.provider_version,
+            algorithm_version="baseline-librosa-mir-v1",
+        )
+
+    def analyze_path(self, path: str, *, preferred_provider: str | None = None):
+        self.calls.append(path)
+        if self.fail:
+            raise RuntimeError("simulated provider failure")
+        return _result(path, provider_version=self.provider_version)
+
+
+def test_cold_then_warm_real_library_run_eliminates_provider_execution(tmp_path: Path) -> None:
+    database = tmp_path / "persistent-analysis.sqlite3"
+    service = FakeAnalysisService()
+    identity = StaticIdentityService()
+
+    first, cold = reconcile_real_tracks(
+        snapshot_raw=_snapshot(),
+        selection_raw=_selection(),
+        analysis_database_path=database,
+        analysis_service=service,  # type: ignore[arg-type]
+        identity_service=identity,  # type: ignore[arg-type]
+    )
+    second, warm = reconcile_real_tracks(
+        snapshot_raw=_snapshot(),
+        selection_raw=_selection(),
+        analysis_database_path=database,
+        analysis_service=service,  # type: ignore[arg-type]
+        identity_service=identity,  # type: ignore[arg-type]
+    )
+
+    assert service.calls == ["/library/a.wav"]
+    assert cold.provider_executed == 1
+    assert cold.evidence_reused == 0
+    assert warm.provider_executed == 0
+    assert warm.evidence_reused == 1
+    assert first["snapshot-track-a"].content_sha256 == "a" * 64
+    assert second["snapshot-track-a"].music_dna.identity.evidence_refs == (
+        first["snapshot-track-a"].music_dna.identity.evidence_refs[0],
+    )
+
+
+def test_changed_content_identity_executes_only_invalidated_track(tmp_path: Path) -> None:
+    database = tmp_path / "persistent-analysis.sqlite3"
+    service = FakeAnalysisService()
+    identity = StaticIdentityService("a" * 64)
+
+    reconcile_real_tracks(
+        snapshot_raw=_snapshot(),
+        selection_raw=_selection(),
+        analysis_database_path=database,
+        analysis_service=service,  # type: ignore[arg-type]
+        identity_service=identity,  # type: ignore[arg-type]
+    )
+    identity.digest = "b" * 64
+    _, changed = reconcile_real_tracks(
+        snapshot_raw=_snapshot(),
+        selection_raw=_selection(),
+        analysis_database_path=database,
+        analysis_service=service,  # type: ignore[arg-type]
+        identity_service=identity,  # type: ignore[arg-type]
+    )
+
+    assert service.calls == ["/library/a.wav", "/library/a.wav"]
+    assert changed.provider_executed == 1
+    assert changed.evidence_reused == 0
+
+
+def test_provider_drift_failure_never_falls_back_to_stale_success(tmp_path: Path) -> None:
+    database = tmp_path / "persistent-analysis.sqlite3"
+    identity = StaticIdentityService()
+
+    reconcile_real_tracks(
+        snapshot_raw=_snapshot(),
+        selection_raw=_selection(),
+        analysis_database_path=database,
+        analysis_service=FakeAnalysisService(provider_version="0.10.2.post1"),  # type: ignore[arg-type]
+        identity_service=identity,  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(RealLibraryPilotError, match="canonical analysis evidence unavailable"):
+        reconcile_real_tracks(
+            snapshot_raw=_snapshot(),
+            selection_raw=_selection(),
+            analysis_database_path=database,
+            analysis_service=FakeAnalysisService(provider_version="0.10.3", fail=True),  # type: ignore[arg-type]
+            identity_service=identity,  # type: ignore[arg-type]
+        )
+
+
+def test_progress_is_bounded_and_does_not_expose_local_paths(tmp_path: Path) -> None:
+    events: list[dict[str, int | str]] = []
+    reconcile_real_tracks(
+        snapshot_raw=_snapshot(),
+        selection_raw=_selection(),
+        analysis_database_path=tmp_path / "persistent-analysis.sqlite3",
+        analysis_service=FakeAnalysisService(),  # type: ignore[arg-type]
+        identity_service=StaticIdentityService(),  # type: ignore[arg-type]
+        progress=lambda event: events.append(dict(event)),
+    )
+
+    assert events
+    assert events[-1]["stage"] == "analysis_reconciliation_complete"
+    assert events[-1]["targets_total"] == 1
+    assert events[-1]["remaining"] == 0
+    assert all("/library/" not in str(value) for event in events for value in event.values())
+
+
+def test_default_analysis_database_is_stable_across_run_directories(tmp_path: Path) -> None:
+    root = tmp_path / "real-library-pilot-r1"
+    first = default_analysis_database_path(root / "run-a")
+    second = default_analysis_database_path(root / "run-b")
+
+    assert first == second
+    assert first.name == "APPLAYLIST_REAL_LIBRARY_ANALYSIS_EVIDENCE_R1.sqlite3"

--- a/tests/test_real_library_incremental_reconciliation.py
+++ b/tests/test_real_library_incremental_reconciliation.py
@@ -40,12 +40,21 @@ def _snapshot(path: str = "/library/a.wav") -> dict[str, object]:
             {
                 "track_id": "snapshot-track-a",
                 "absolute_path": path,
-                "file_signature": "opaque-inventory-signature",
+                "file_signature": "opaque-inventory-signature-a",
                 "display_name": "Track A",
                 "artist": "Artist A",
                 "genre": "Techno",
                 "energy": 7,
-            }
+            },
+            {
+                "track_id": "snapshot-track-b",
+                "absolute_path": "/library/b.wav",
+                "file_signature": "opaque-inventory-signature-b",
+                "display_name": "Track B",
+                "artist": "Artist B",
+                "genre": "Techno",
+                "energy": 6,
+            },
         ],
     }
 


### PR DESCRIPTION
## Summary

Implements the **Bundle 55B governed follow-up slice** under the repository's numeric Bundle 55 PR naming policy. It reconnects the Bundle 54 real-library materializer to canonical Bundle 43 content identity + Bundle 50/55 AnalysisJob/AnalysisEvidence reuse so unchanged real audio does not repeat expensive MIR.

Supersedes closed, unmerged PR #125 only because its branch/title metadata violated canonical PR naming policy. The replacement branch began from the same implementation head; no implementation rewrite occurred.

### Changes

- persistent private real-library AnalysisEvidence reconciliation
- actual bytes -> existing `ContentTrackIdentityService` -> canonical `aptrack:v1:sha256:<digest>`
- one Bundle 50 AnalysisJob work unit per selected content identity
- Bundle 55 exact warm hit -> existing evidence ID, zero MIR provider executions
- miss/content drift -> canonical provider execution + append-only evidence
- persistent AnalysisEvidence DB separate from per-run Transition/optimizer DB
- existing launcher remains compatible via stable derived analysis DB path
- MusicDNA evidence reference anchored to canonical `analysis_evidence_id`
- bounded path-free `MIR_PROGRESS` telemetry
- existing Bundle 54 case, TransitionAssessment, optimizer, and reviewer-blinding semantics preserved
- fail closed when provider identity drifts and the fresh provider execution fails; stale prior success is never substituted

## Verification

Exact feature head: `c9c9c4cdbca9f568a523aee75270d7e31db06d41`
Exact canonical base: `7817074b75251af24dd5f324c148b141b9318bf1`
GitHub compare: 6 commits ahead / 0 behind, 4 changed files, +748/-5.

- CI #688 (`32000934787`): SUCCESS
- Python 3.11: compile + critical lint + full pytest + artifact upload SUCCESS
- Python 3.11 full pytest: `374 passed, 6 warnings in 35.97s`
- Python 3.11 artifact ID: `9278377697`
- Python 3.11 artifact SHA-256: `83a8b0ad6e38e5cc9eee2497dc8713883637b2cd2d1382cf7ee6d669b836558d`
- Python 3.12: compile + critical lint + full pytest + artifact upload SUCCESS
- Python 3.12 full pytest: `374 passed, 5 warnings in 39.89s`
- Python 3.12 artifact ID: `9278380480`
- Python 3.12 artifact SHA-256: `57c5682129b6238ac4a62e924302406d363bd7c3e6003cdd20e6bf0f744e528c`
- PR Guard #249 (`32000934789`): SUCCESS
- unresolved review threads: `0`

Acceptance coverage includes cold->warm zero-provider reuse, content invalidation, provider-version drift fail-closed behavior, path-free progress telemetry, and stable persistent analysis DB placement.

## Bundle Context

Canonical base is post-merge Bundle 55 SHA `7817074b75251af24dd5f324c148b141b9318bf1`.

Bundle 43 provides content-addressed track identity from actual bytes. Bundle 50 provides append-only AnalysisJob/AnalysisEvidence persistence. Bundle 55 provides exact execution-identity reuse. This follow-up wires Bundle 54 real-library materialization into those canonical primitives instead of adding a second cache or analysis authority.

The already-running Bundle 54 cold pilot predates this slice. Its private runtime manifest is not auto-seeded into canonical AnalysisEvidence because it does not contain every canonical MIR field required to prove exact semantic equivalence. No missing evidence is synthesized.

### Boundaries

No TransitionAssessment authority change. No optimizer activation. No Personal DJ Model training. No release/deploy/production effects. No cloud upload of user audio.

Closes #124 when merged.

MERGE_AUTHORIZATION=NO
RELEASE_AUTHORIZATION=NO
DEPLOY_AUTHORIZATION=NO
PRODUCTION_EFFECTS=NO