### PR TITLE
Bundle 56: desktop set proposal transport + inspector R1

### DIFF
--- a/desktop/host-proof/index.html
+++ b/desktop/host-proof/index.html
@@ -5,7 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>APPLAYLIST Desktop</title>
   <link rel="stylesheet" href="./app.css">
+  <link rel="stylesheet" href="./set-proposal.css">
   <script src="./app.js" defer></script>
+  <script src="./set-proposal.js" defer></script>
 </head>
 <body>
   <main>
@@ -181,6 +183,25 @@
           </div>
         </form>
       </section>
+    </section>
+
+    <section id="set-proposal" aria-labelledby="set-proposal-heading">
+      <h2 id="set-proposal-heading">Set Proposal Inspector</h2>
+      <p>Build a read-only, explainable set proposal from already-persisted analysis evidence. This does not activate optimization or train the Personal DJ Model.</p>
+
+      <div class="actions">
+        <button id="set-proposal-refresh" type="button">Refresh analyzed tracks</button>
+        <label for="set-proposal-seed">Seed track</label>
+        <select id="set-proposal-seed" disabled></select>
+        <label for="set-proposal-target">Target tracks</label>
+        <input id="set-proposal-target" type="number" min="3" max="8" value="3" step="1" disabled>
+        <button id="set-proposal-generate" type="button" disabled>Generate set proposal</button>
+      </div>
+
+      <p id="set-proposal-status" class="status">Load analyzed tracks to begin.</p>
+      <p id="set-proposal-empty" class="empty-state">No successful analyzed tracks loaded.</p>
+      <ul id="set-proposal-track-list" class="proposal-track-list"></ul>
+      <div id="set-proposal-results"></div>
     </section>
   </main>
 </body>

--- a/desktop/host-proof/set-proposal.css
+++ b/desktop/host-proof/set-proposal.css
@@ -1,0 +1,36 @@
+#set-proposal {
+  margin-top: 2rem;
+}
+
+.proposal-track-list {
+  display: grid;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 1rem 0;
+  padding: 0;
+}
+
+.proposal-track-list label {
+  align-items: center;
+  display: flex;
+  gap: 0.6rem;
+}
+
+#set-proposal-results {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.proposal-summary,
+.proposal-alternative {
+  border: 1px solid currentColor;
+  border-radius: 0.5rem;
+  padding: 1rem;
+}
+
+.proposal-alternative ol {
+  display: grid;
+  gap: 0.35rem;
+  padding-left: 1.5rem;
+}

--- a/desktop/host-proof/set-proposal.js
+++ b/desktop/host-proof/set-proposal.js
@@ -1,0 +1,431 @@
+(() => {
+  "use strict";
+
+  const invoke = window.__TAURI__?.core?.invoke;
+  const section = document.getElementById("set-proposal");
+  const refreshButton = document.getElementById("set-proposal-refresh");
+  const trackList = document.getElementById("set-proposal-track-list");
+  const emptyState = document.getElementById("set-proposal-empty");
+  const seedSelect = document.getElementById("set-proposal-seed");
+  const targetInput = document.getElementById("set-proposal-target");
+  const generateButton = document.getElementById("set-proposal-generate");
+  const status = document.getElementById("set-proposal-status");
+  const results = document.getElementById("set-proposal-results");
+
+  if (
+    !section ||
+    !refreshButton ||
+    !trackList ||
+    !emptyState ||
+    !seedSelect ||
+    !targetInput ||
+    !generateButton ||
+    !status ||
+    !results
+  ) {
+    return;
+  }
+
+  const STATUS_VALUES = new Set([
+    "target_reached",
+    "paths_found",
+    "no_eligible_path",
+    "not_proven_missing_evidence",
+    "budget_exhausted",
+  ]);
+  const TOKEN = /^[A-Za-z0-9][A-Za-z0-9_.:+-]{0,255}$/;
+  const selectedTrackIds = new Set();
+  let analyzedTracks = new Map();
+  let busy = false;
+
+  function exactKeys(value, keys) {
+    if (value === null || typeof value !== "object" || Array.isArray(value)) {
+      return false;
+    }
+    const actual = Object.keys(value).sort();
+    const expected = [...keys].sort();
+    return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+  }
+
+  function validTrackId(value) {
+    return (
+      typeof value === "string" &&
+      value.length > 0 &&
+      value.length <= 256 &&
+      value.trim() === value &&
+      !value.includes("/") &&
+      !value.includes("\\") &&
+      !/[\u0000-\u001f\u007f]/.test(value)
+    );
+  }
+
+  function pathShapedText(value) {
+    return value.startsWith("/") || value.startsWith("\\\\") || /^[A-Za-z]:[\\/]/.test(value);
+  }
+
+  function validDisplayName(value) {
+    return (
+      typeof value === "string" &&
+      value.length > 0 &&
+      value.length <= 512 &&
+      value.trim() === value &&
+      !/[\u0000-\u001f\u007f]/.test(value) &&
+      !pathShapedText(value)
+    );
+  }
+
+  function validToken(value, maximum = 256) {
+    return typeof value === "string" && value.length <= maximum && TOKEN.test(value);
+  }
+
+  function validUnitNumber(value) {
+    return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1;
+  }
+
+  function validCodes(values) {
+    return Array.isArray(values) && values.length <= 128 && values.every((value) => validToken(value, 128));
+  }
+
+  function validObjective(value, expectedDepth) {
+    return (
+      exactKeys(value, [
+        "depth",
+        "mean_candidate_score",
+        "minimum_candidate_score",
+        "required_track_completion",
+        "remaining_required_count",
+        "target_reached",
+      ]) &&
+      Number.isInteger(value.depth) &&
+      value.depth === expectedDepth &&
+      validUnitNumber(value.mean_candidate_score) &&
+      validUnitNumber(value.minimum_candidate_score) &&
+      validUnitNumber(value.required_track_completion) &&
+      Number.isInteger(value.remaining_required_count) &&
+      value.remaining_required_count >= 0 &&
+      value.remaining_required_count <= 24 &&
+      typeof value.target_reached === "boolean"
+    );
+  }
+
+  function validAlternative(value, expectedRank) {
+    if (
+      !exactKeys(value, [
+        "path_id",
+        "rank",
+        "sequence",
+        "transition_ids",
+        "candidate_scores",
+        "objective",
+        "explanation_codes",
+      ]) ||
+      !validToken(value.path_id) ||
+      value.rank !== expectedRank ||
+      !Array.isArray(value.sequence) ||
+      value.sequence.length < 2 ||
+      value.sequence.length > 8 ||
+      !Array.isArray(value.transition_ids) ||
+      !Array.isArray(value.candidate_scores) ||
+      value.transition_ids.length !== value.candidate_scores.length ||
+      value.sequence.length !== value.candidate_scores.length + 1 ||
+      !validCodes(value.explanation_codes)
+    ) {
+      return false;
+    }
+
+    for (let index = 0; index < value.sequence.length; index += 1) {
+      const step = value.sequence[index];
+      if (
+        !exactKeys(step, ["order_index", "track_id", "display_name", "phase_id"]) ||
+        step.order_index !== index ||
+        !validTrackId(step.track_id) ||
+        !validDisplayName(step.display_name) ||
+        !validToken(step.phase_id)
+      ) {
+        return false;
+      }
+    }
+    if (!value.transition_ids.every((item) => validToken(item))) {
+      return false;
+    }
+    if (!value.candidate_scores.every(validUnitNumber)) {
+      return false;
+    }
+    return validObjective(value.objective, value.candidate_scores.length);
+  }
+
+  function validProposal(value) {
+    if (
+      !exactKeys(value, [
+        "schema",
+        "proposal_id",
+        "status",
+        "alternatives",
+        "reason_codes",
+        "warning_codes",
+        "budget_exhausted",
+        "missing_evidence_detected",
+        "deterministic_ordering",
+        "activation_authorized",
+        "personal_dj_model_training_authorized",
+      ]) ||
+      value.schema !== "applaylist-desktop-set-proposal-r1" ||
+      !validToken(value.proposal_id) ||
+      !STATUS_VALUES.has(value.status) ||
+      !Array.isArray(value.alternatives) ||
+      value.alternatives.length > 3 ||
+      !value.alternatives.every((item, index) => validAlternative(item, index + 1)) ||
+      !validCodes(value.reason_codes) ||
+      !validCodes(value.warning_codes) ||
+      typeof value.budget_exhausted !== "boolean" ||
+      typeof value.missing_evidence_detected !== "boolean" ||
+      value.deterministic_ordering !== true ||
+      value.activation_authorized !== false ||
+      value.personal_dj_model_training_authorized !== false
+    ) {
+      return false;
+    }
+    if (["target_reached", "paths_found"].includes(value.status) && value.alternatives.length === 0) {
+      return false;
+    }
+    if (value.status === "no_eligible_path" && value.alternatives.length !== 0) {
+      return false;
+    }
+    return true;
+  }
+
+  function validInspectorTrack(value) {
+    return (
+      value !== null &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      validTrackId(value.track_id) &&
+      typeof value.title === "string" &&
+      value.title.trim().length > 0 &&
+      value.title.length <= 512 &&
+      !pathShapedText(value.title) &&
+      (value.artist === null ||
+        (typeof value.artist === "string" &&
+          value.artist.length > 0 &&
+          value.artist.length <= 512 &&
+          !pathShapedText(value.artist))) &&
+      value.status === "succeeded"
+    );
+  }
+
+  function labelForTrack(track) {
+    return track.artist ? `${track.artist} — ${track.title}` : track.title;
+  }
+
+  function setStatus(message) {
+    status.textContent = message;
+  }
+
+  function updateControls() {
+    const selected = [...selectedTrackIds].filter((trackId) => analyzedTracks.has(trackId)).sort();
+    const previousSeed = seedSelect.value;
+    seedSelect.replaceChildren();
+    for (const trackId of selected) {
+      const track = analyzedTracks.get(trackId);
+      const option = document.createElement("option");
+      option.value = trackId;
+      option.textContent = labelForTrack(track);
+      seedSelect.appendChild(option);
+    }
+    if (selected.includes(previousSeed)) {
+      seedSelect.value = previousSeed;
+    }
+
+    const maximumTarget = Math.min(8, selected.length);
+    targetInput.max = String(Math.max(3, maximumTarget));
+    if (Number(targetInput.value) > maximumTarget) {
+      targetInput.value = maximumTarget >= 3 ? String(maximumTarget) : "3";
+    }
+    seedSelect.disabled = busy || selected.length === 0;
+    targetInput.disabled = busy || selected.length < 3;
+    refreshButton.disabled = busy;
+    generateButton.disabled = busy || selected.length < 3 || typeof invoke !== "function";
+  }
+
+  function renderTrackSelection(items) {
+    analyzedTracks = new Map(
+      items
+        .filter(validInspectorTrack)
+        .map((track) => [track.track_id, { track_id: track.track_id, title: track.title, artist: track.artist }]),
+    );
+    selectedTrackIds.clear();
+    trackList.replaceChildren();
+
+    const tracks = [...analyzedTracks.values()].sort((left, right) =>
+      labelForTrack(left).localeCompare(labelForTrack(right)),
+    );
+    emptyState.hidden = tracks.length !== 0;
+
+    for (const track of tracks) {
+      const item = document.createElement("li");
+      const label = document.createElement("label");
+      const checkbox = document.createElement("input");
+      checkbox.type = "checkbox";
+      checkbox.addEventListener("change", () => {
+        if (checkbox.checked) {
+          selectedTrackIds.add(track.track_id);
+        } else {
+          selectedTrackIds.delete(track.track_id);
+        }
+        updateControls();
+      });
+      const text = document.createElement("span");
+      text.textContent = labelForTrack(track);
+      label.append(checkbox, text);
+      item.appendChild(label);
+      trackList.appendChild(item);
+    }
+    updateControls();
+  }
+
+  function appendCodes(container, headingText, codes) {
+    if (codes.length === 0) {
+      return;
+    }
+    const heading = document.createElement("h5");
+    heading.textContent = headingText;
+    const list = document.createElement("ul");
+    for (const code of codes) {
+      const item = document.createElement("li");
+      item.textContent = code;
+      list.appendChild(item);
+    }
+    container.append(heading, list);
+  }
+
+  function renderProposal(proposal) {
+    results.replaceChildren();
+
+    const summary = document.createElement("div");
+    summary.className = "proposal-summary";
+    const title = document.createElement("h3");
+    title.textContent = `Proposal ${proposal.proposal_id}`;
+    const state = document.createElement("p");
+    state.textContent = `Status: ${proposal.status}`;
+    summary.append(title, state);
+    appendCodes(summary, "Reasons", proposal.reason_codes);
+    appendCodes(summary, "Warnings", proposal.warning_codes);
+    results.appendChild(summary);
+
+    if (proposal.alternatives.length === 0) {
+      const empty = document.createElement("p");
+      empty.textContent = "No eligible bounded proposal was found for this scope.";
+      results.appendChild(empty);
+      return;
+    }
+
+    for (const alternative of proposal.alternatives) {
+      const card = document.createElement("article");
+      card.className = "proposal-alternative";
+      const heading = document.createElement("h4");
+      heading.textContent = `Alternative ${alternative.rank}`;
+      const metrics = document.createElement("p");
+      metrics.textContent =
+        `Mean ${alternative.objective.mean_candidate_score.toFixed(3)} · ` +
+        `Minimum ${alternative.objective.minimum_candidate_score.toFixed(3)} · ` +
+        `Target ${alternative.objective.target_reached ? "reached" : "partial"}`;
+
+      const ordered = document.createElement("ol");
+      for (let index = 0; index < alternative.sequence.length; index += 1) {
+        const step = alternative.sequence[index];
+        const item = document.createElement("li");
+        const score =
+          index === 0 ? "seed" : `score ${alternative.candidate_scores[index - 1].toFixed(3)}`;
+        item.textContent = `${step.display_name} — ${score}`;
+        ordered.appendChild(item);
+      }
+      card.append(heading, metrics, ordered);
+      appendCodes(card, "Path explanation", alternative.explanation_codes);
+      results.appendChild(card);
+    }
+  }
+
+  async function refreshAnalyzedTracks() {
+    if (busy || typeof invoke !== "function") {
+      return;
+    }
+    busy = true;
+    updateControls();
+    setStatus("Loading analyzed tracks…");
+    try {
+      const response = await invoke("analysis_inspector_list", { filter: "all" });
+      if (
+        response === null ||
+        typeof response !== "object" ||
+        response.filter !== "all" ||
+        !Array.isArray(response.items)
+      ) {
+        throw new Error("Invalid analysis inspector response.");
+      }
+      renderTrackSelection(response.items);
+      setStatus(
+        analyzedTracks.size >= 3
+          ? "Select 3–24 analyzed tracks, choose a seed, then generate a proposal."
+          : "At least three successful analyzed tracks are required.",
+      );
+    } catch (_error) {
+      analyzedTracks = new Map();
+      selectedTrackIds.clear();
+      trackList.replaceChildren();
+      emptyState.hidden = false;
+      setStatus("Analyzed tracks could not be loaded safely.");
+    } finally {
+      busy = false;
+      updateControls();
+    }
+  }
+
+  async function generateProposal() {
+    if (busy || typeof invoke !== "function") {
+      return;
+    }
+    const trackIds = [...selectedTrackIds].sort();
+    const seedTrackId = seedSelect.value;
+    const targetTrackCount = Number(targetInput.value);
+    if (
+      trackIds.length < 3 ||
+      trackIds.length > 24 ||
+      !trackIds.every(validTrackId) ||
+      !trackIds.includes(seedTrackId) ||
+      !Number.isInteger(targetTrackCount) ||
+      targetTrackCount < 3 ||
+      targetTrackCount > 8 ||
+      targetTrackCount > trackIds.length
+    ) {
+      setStatus("Select a valid bounded proposal scope first.");
+      return;
+    }
+
+    busy = true;
+    updateControls();
+    results.replaceChildren();
+    setStatus("Generating read-only set proposal…");
+    try {
+      const proposal = await invoke("set_proposal_generate", {
+        trackIds,
+        seedTrackId,
+        targetTrackCount,
+      });
+      if (!validProposal(proposal)) {
+        throw new Error("Invalid set proposal response.");
+      }
+      renderProposal(proposal);
+      setStatus("Set proposal generated from persisted analysis evidence.");
+    } catch (_error) {
+      setStatus("The set proposal could not be generated safely.");
+    } finally {
+      busy = false;
+      updateControls();
+    }
+  }
+
+  refreshButton.addEventListener("click", refreshAnalyzedTracks);
+  generateButton.addEventListener("click", generateProposal);
+  targetInput.addEventListener("change", updateControls);
+  updateControls();
+})();

--- a/docs/bundles/BUNDLE_56B_DESKTOP_SET_PROPOSAL_TRANSPORT_INSPECTOR.md
+++ b/docs/bundles/BUNDLE_56B_DESKTOP_SET_PROPOSAL_TRANSPORT_INSPECTOR.md
@@ -1,0 +1,164 @@
+# Bundle 56B — Desktop Set Proposal Transport + Inspector R1
+
+## Status
+
+Implementation slice for issue #130.
+
+Base branch: `feature/bundle-0-bootstrap`  
+Exact base SHA: `32e15a38696839b1e684892611e4f8ce9bd7ce4d`
+
+This bundle does not authorize merge, release, deployment, optimizer production activation, playlist mutation, or Personal DJ Model training.
+
+## Product outcome
+
+A DJ can load already-successfully analyzed local tracks, choose a seed and a bounded target track count, and inspect ranked explainable set alternatives directly in the desktop application.
+
+No terminal or CSV handoff is required.
+
+## Canonical flow
+
+```text
+renderer selected stable track IDs
+  -> set_proposal_generate
+  -> trusted Rust host
+  -> authenticated packaged sidecar
+  -> DesktopSetProposalTransport
+  -> persisted successful AnalysisEvidence + active correction overlay
+  -> path-free MusicDNA
+  -> canonical TransitionAssessment
+  -> canonical balanced Set Intelligence ranking
+  -> canonical bounded beam/lookahead optimizer
+  -> Bundle 56 renderer-safe projection
+  -> Set Proposal Inspector
+```
+
+## Bounds
+
+- selected scope: 3–24 unique stable track IDs,
+- seed track must be inside the selected scope,
+- target track count: 3–8 and no larger than the selected scope,
+- one explicit `GROOVE` preview phase,
+- neutral hold-current-energy trajectory seeded from persisted energy evidence,
+- maximum three rendered alternatives,
+- bounded beam width 8,
+- bounded maximum depth 2–7,
+- bounded expanded candidate budget 2,048.
+
+## Evidence-only authority
+
+The transport reads:
+
+- `TrackRepository` display metadata,
+- latest analysis attempt,
+- latest successful `AnalysisEvidence`,
+- active correction anchored to that exact successful evidence.
+
+The transport does **not**:
+
+- open an audio path,
+- hash or read audio bytes,
+- invoke `RoutedAnalysisService`,
+- invoke an MIR provider,
+- mutate provider evidence,
+- persist `TransitionAssessment`,
+- persist `SequenceState`,
+- persist a playlist revision.
+
+A correction changes the effective MusicDNA analysis revision used for the proposal while the underlying provider evidence remains append-only and unchanged.
+
+## Transient graph rule
+
+Transition adjacency is request-local and in memory.
+
+The canonical optimizer still owns path search and `recommend_next` remains the candidate eligibility/ranking authority. The transient repository is only a bounded `list_outgoing` adapter over canonical `TransitionAssessment` objects generated from persisted evidence.
+
+## Sidecar integration
+
+The existing packaged `applaylist-sidecar` executable remains the only packaged process boundary.
+
+`scripts/applaylist_sidecar_entry.py` installs one narrow route extension before entering the existing canonical sidecar `main()`:
+
+```text
+POST /v1/set/proposal/generate
+```
+
+The route reuses the existing startup envelope, loopback binding, random secret, readiness nonce, health proof and shutdown lifecycle.
+
+Unexpected request fields fail closed.
+
+## Renderer projection
+
+The renderer receives only Bundle 56 schema:
+
+`applaylist-desktop-set-proposal-r1`
+
+It may render:
+
+- proposal ID,
+- optimizer status,
+- ranked alternatives,
+- safe track display names and track IDs,
+- phase IDs,
+- transition IDs,
+- candidate scores,
+- objective summary,
+- bounded reason / warning codes.
+
+It never receives:
+
+- filesystem paths,
+- provider identities or versions,
+- AnalysisEvidence IDs,
+- optimizer input fingerprints,
+- sidecar port / secret / nonce / PID,
+- raw exceptions,
+- raw domain objects.
+
+`activation_authorized` and `personal_dj_model_training_authorized` must remain `false` through Python, Rust and renderer validation.
+
+## Warning compatibility boundary
+
+Canonical optimizer warnings currently include three human-readable internal warning strings. Bundle 56 accepts renderer-safe token codes only.
+
+56B therefore performs an exact allowlisted trusted-side translation:
+
+- bounded frontier prune -> `bounded_search_pruned_frontier`,
+- missing duration evidence -> `candidate_duration_evidence_missing`,
+- v1 future-feasibility limitation -> `future_feasibility_not_hard_prune_v1`.
+
+Any unknown optimizer warning fails closed instead of passing arbitrary text to the renderer.
+
+## Verification
+
+Required before review-ready status:
+
+- full Python CI on supported versions,
+- set proposal transport tests,
+- authenticated sidecar route proof,
+- renderer contract tests,
+- Desktop Sidecar Proof,
+- Desktop Rust rustfmt/check/test,
+- PR Guard,
+- zero unresolved review threads.
+
+The evidence-only regression fixture stores deliberately nonexistent audio paths. A successful proposal from that fixture proves this slice does not require audio reads.
+
+## Non-scope
+
+- accept / reject mutation,
+- reorder,
+- lock / unlock,
+- replace,
+- immutable playlist revision persistence,
+- export,
+- new analysis/provider work,
+- audio reads,
+- persistent graph storage,
+- Human DJ Review completion,
+- Personal DJ Model training,
+- optimizer production activation,
+- release/deploy/signing/notarization.
+
+## Next dependency
+
+Bundle 57 may add governed Manual Editor revision commands only after 56B transport and Inspector gates are proven.

--- a/scripts/applaylist_sidecar_entry.py
+++ b/scripts/applaylist_sidecar_entry.py
@@ -1,4 +1,8 @@
+from services.desktop.set_proposal_sidecar import install_set_proposal_sidecar
 from services.desktop.sidecar import main
+
+
+install_set_proposal_sidecar()
 
 
 if __name__ == "__main__":

--- a/services/desktop/set_proposal_sidecar.py
+++ b/services/desktop/set_proposal_sidecar.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import services.desktop.sidecar as sidecar
+from services.desktop.set_proposal_transport import (
+    DesktopSetProposalTransport,
+    DesktopSetProposalTransportError,
+)
+
+MAX_SET_PROPOSAL_REQUEST_BYTES = 64 * 1024
+_SET_PROPOSAL_ROUTE = "/v1/set/proposal/generate"
+_INSTALLED = False
+
+
+def install_set_proposal_sidecar() -> None:
+    """Extend the packaged canonical sidecar with one authenticated proposal route."""
+    global _INSTALLED
+    if _INSTALLED:
+        return
+
+    original_handler = sidecar._SidecarRequestHandler
+    original_server = sidecar._SidecarHTTPServer
+
+    class SetProposalRequestHandler(original_handler):
+        def do_POST(self) -> None:  # noqa: N802
+            if self.path == _SET_PROPOSAL_ROUTE:
+                self._handle_set_proposal_generate()
+                return
+            super().do_POST()
+
+        def _handle_set_proposal_generate(self) -> None:
+            if not self._authorized():
+                self._write_json(HTTPStatus.UNAUTHORIZED, {"error": "unauthorized"})
+                return
+            payload = self._read_json_payload(MAX_SET_PROPOSAL_REQUEST_BYTES)
+            if (
+                payload is None
+                or set(payload) != {"track_ids", "seed_track_id", "target_track_count"}
+                or not isinstance(payload.get("track_ids"), list)
+            ):
+                self._write_json(
+                    HTTPStatus.BAD_REQUEST,
+                    {"error": "invalid_set_proposal_request"},
+                )
+                return
+            try:
+                result = self.sidecar_server.set_proposal.generate(
+                    track_ids=payload["track_ids"],  # type: ignore[arg-type]
+                    seed_track_id=payload["seed_track_id"],  # type: ignore[arg-type]
+                    target_track_count=payload["target_track_count"],  # type: ignore[arg-type]
+                )
+            except DesktopSetProposalTransportError as exc:
+                status = (
+                    HTTPStatus.CONFLICT
+                    if exc.code
+                    in {
+                        "set_proposal_track_unavailable",
+                        "set_proposal_analysis_missing",
+                        "set_proposal_analysis_failed",
+                        "set_proposal_analysis_incomplete",
+                    }
+                    else HTTPStatus.BAD_REQUEST
+                )
+                self._write_json(status, {"error": exc.code})
+                return
+            except Exception:
+                self._write_json(
+                    HTTPStatus.INTERNAL_SERVER_ERROR,
+                    {"error": "set_proposal_generation_failed"},
+                )
+                return
+            self._write_json(HTTPStatus.OK, result)
+
+    sidecar._SidecarRequestHandler = SetProposalRequestHandler
+
+    class SetProposalHTTPServer(original_server):
+        def __init__(self, startup: sidecar.SidecarStartup) -> None:
+            super().__init__(startup)
+            self.set_proposal = DesktopSetProposalTransport()
+
+    sidecar._SidecarHTTPServer = SetProposalHTTPServer
+    _INSTALLED = True
+
+
+__all__ = ["MAX_SET_PROPOSAL_REQUEST_BYTES", "install_set_proposal_sidecar"]

--- a/services/desktop/set_proposal_transport.py
+++ b/services/desktop/set_proposal_transport.py
@@ -1,0 +1,512 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import replace
+
+from core.analysis.provider_contract import CanonicalAnalysisResult
+from core.intelligence.music_dna import MusicDNARevision, build_music_dna
+from core.intelligence.set_contract import (
+    EligibleLibraryScope,
+    EnergyControlPoint,
+    EnergyTrajectory,
+    PlaylistContext,
+    PlaylistIntent,
+    SequenceState,
+    SetGoal,
+    SetPhase,
+    SetPhaseType,
+    SetStep,
+)
+from core.intelligence.set_optimizer_contract import SetOptimizerPolicy, SetOptimizerResult
+from core.intelligence.transition_contract import TransitionAssessment
+from data.models.analysis_evidence_record import AnalysisEvidenceRecord
+from data.repositories.analysis_evidence_repository import AnalysisEvidenceRepository
+from data.repositories.track_repository import TrackRepository
+from services.desktop.set_proposal_projection import project_set_optimizer_result
+from services.intelligence.phase_context import transition_context_for_phase
+from services.intelligence.set_engine import balanced_set_ranking_policy_v1
+from services.intelligence.set_path_optimizer import optimize_set_lookahead
+from services.intelligence.transition_engine import assess_transition, preserve_groove_context_v1
+
+MIN_SET_PROPOSAL_TRACKS = 3
+MAX_SET_PROPOSAL_TRACKS = 24
+MIN_SET_PROPOSAL_TARGET_TRACKS = 3
+MAX_SET_PROPOSAL_TARGET_TRACKS = 8
+MAX_SET_PROPOSAL_TRACK_ID_CHARS = 256
+SET_PROPOSAL_POLICY_VERSION = "desktop-set-proposal-preview-r1"
+SET_PROPOSAL_PHASE_ID = "phase:preview-groove"
+SET_PROPOSAL_GENERATED_AT = "desktop-set-proposal-r1"
+
+_CANONICAL_WARNING_CODES = {
+    "bounded search intentionally pruned lower-priority frontier states": "bounded_search_pruned_frontier",
+    "one or more persisted outgoing edges lacked target duration evidence": "candidate_duration_evidence_missing",
+    (
+        "future feasibility is not a hard beam prune in optimizer v1 because its current "
+        "contract uses one fixed TransitionContext across the evaluated horizon"
+    ): "future_feasibility_not_hard_prune_v1",
+}
+
+
+class DesktopSetProposalTransportError(ValueError):
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+class _TransientTransitionRepository:
+    """Request-local adjacency only; never persists TransitionAssessment state."""
+
+    def __init__(self, assessments: Sequence[TransitionAssessment]) -> None:
+        self._assessments = tuple(assessments)
+
+    def list_outgoing(
+        self,
+        *,
+        source_track_id: str,
+        source_segment_id: str,
+        context_id: str | None = None,
+        context_version: str | None = None,
+        assessment_version: str | None = None,
+        policy_version: str | None = None,
+    ) -> tuple[TransitionAssessment, ...]:
+        if (context_id is None) != (context_version is None):
+            raise ValueError("context_id and context_version must be supplied together")
+        matches = [
+            item
+            for item in self._assessments
+            if item.identity.source_track_id == source_track_id
+            and item.identity.source_segment_id == source_segment_id
+            and (context_id is None or item.contextual_projection.context_id == context_id)
+            and (
+                context_version is None
+                or item.contextual_projection.context_version == context_version
+            )
+            and (
+                assessment_version is None
+                or item.identity.assessment_version == assessment_version
+            )
+            and (policy_version is None or item.identity.policy_version == policy_version)
+        ]
+        return tuple(
+            sorted(
+                matches,
+                key=lambda item: (
+                    item.identity.transition_id,
+                    item.identity.target_track_id,
+                    item.identity.target_segment_id,
+                ),
+            )
+        )
+
+
+class DesktopSetProposalTransport:
+    """Evidence-only bridge from persisted analysis truth to Bundle 56 projection."""
+
+    def __init__(
+        self,
+        *,
+        evidence_repository: AnalysisEvidenceRepository | None = None,
+        track_repository: TrackRepository | None = None,
+    ) -> None:
+        self._evidence = evidence_repository or AnalysisEvidenceRepository()
+        self._tracks = track_repository or TrackRepository()
+
+    def generate(
+        self,
+        *,
+        track_ids: Sequence[str],
+        seed_track_id: str,
+        target_track_count: int,
+    ) -> dict[str, object]:
+        scope = self._validated_track_ids(track_ids)
+        seed = self._validated_track_id(seed_track_id)
+        if seed not in scope:
+            raise DesktopSetProposalTransportError(
+                "invalid_set_proposal_request",
+                "The seed track must be inside the selected proposal scope.",
+            )
+        target = self._validated_target_track_count(target_track_count, len(scope))
+
+        revisions: dict[str, MusicDNARevision] = {}
+        durations: dict[str, float] = {}
+        labels: dict[str, str] = {}
+        for track_id in scope:
+            revision, duration, label = self._revision_for_track(track_id)
+            revisions[track_id] = revision
+            durations[track_id] = duration
+            labels[track_id] = label
+
+        request_fingerprint = self._request_fingerprint(scope, seed, target)
+        phase = SetPhase(
+            phase_id=SET_PROPOSAL_PHASE_ID,
+            phase_type=SetPhaseType.GROOVE,
+            ordinal=0,
+            target_fraction_start=0.0,
+            target_fraction_end=1.0,
+            explanation_label="Read-only desktop proposal preview",
+        )
+        seed_energy = revisions[seed].energy.baseline_energy
+        if seed_energy is None:
+            raise DesktopSetProposalTransportError(
+                "set_proposal_analysis_incomplete",
+                "The seed track is missing required energy evidence.",
+            )
+        trajectory = EnergyTrajectory(
+            trajectory_id=f"trajectory:{request_fingerprint[:24]}",
+            trajectory_version=SET_PROPOSAL_POLICY_VERSION,
+            control_points=(
+                EnergyControlPoint(
+                    normalized_set_position=0.0,
+                    target_energy=seed_energy,
+                    tolerance=0.35,
+                    phase_id=SET_PROPOSAL_PHASE_ID,
+                ),
+                EnergyControlPoint(
+                    normalized_set_position=1.0,
+                    target_energy=seed_energy,
+                    tolerance=0.35,
+                    phase_id=SET_PROPOSAL_PHASE_ID,
+                ),
+            ),
+        )
+        intent = PlaylistIntent(
+            intent_id=f"intent:{request_fingerprint[:24]}",
+            intent_version=SET_PROPOSAL_POLICY_VERSION,
+            goal=SetGoal.CLUB_FLOW,
+            eligible_library_scope=EligibleLibraryScope(
+                scope_revision=f"scope:{request_fingerprint[:24]}",
+                explicit_track_ids=scope,
+            ),
+            phase_plan=(phase,),
+            energy_trajectory=trajectory,
+            target_track_count=target,
+            allow_track_repeats=False,
+            reject_critical_warnings=True,
+        )
+        seed_revision = revisions[seed]
+        seed_segment = seed_revision.segments[0]
+        root_step = SetStep(
+            order_index=0,
+            track_id=seed,
+            segment_id=seed_segment.segment_id,
+            phase_id=SET_PROPOSAL_PHASE_ID,
+            evidence_refs=seed_revision.identity.evidence_refs,
+        )
+        root_state = SequenceState(
+            state_id=f"state:{request_fingerprint[:24]}",
+            state_version=SET_PROPOSAL_POLICY_VERSION,
+            selected_steps=(root_step,),
+            current_track_id=seed,
+            current_segment_id=seed_segment.segment_id,
+            used_track_ids=(seed,),
+            cumulative_duration_seconds=durations[seed],
+            current_energy_state=seed_energy,
+            evidence_refs=seed_revision.identity.evidence_refs,
+        )
+        root_context = PlaylistContext(
+            context_id=f"context:{request_fingerprint[:24]}",
+            context_version=SET_PROPOSAL_POLICY_VERSION,
+            current_phase_id=SET_PROPOSAL_PHASE_ID,
+            current_position_index=0,
+            elapsed_duration_seconds=durations[seed],
+            phase_progress=min(1.0, 1.0 / target),
+            current_track_id=seed,
+            current_segment_id=seed_segment.segment_id,
+            current_energy_state=seed_energy,
+            remaining_track_count=max(0, target - 1),
+            context_evidence_refs=seed_revision.identity.evidence_refs,
+        )
+        base_transition_context = preserve_groove_context_v1()
+        phase_transition_context = transition_context_for_phase(
+            phase=phase,
+            base_context=base_transition_context,
+        )
+
+        assessments: list[TransitionAssessment] = []
+        for source_id in scope:
+            source = revisions[source_id]
+            source_segment = source.segments[0]
+            for target_id in scope:
+                if target_id == source_id:
+                    continue
+                target_revision = revisions[target_id]
+                target_segment = target_revision.segments[0]
+                assessments.append(
+                    assess_transition(
+                        source=source,
+                        source_segment_id=source_segment.segment_id,
+                        target=target_revision,
+                        target_segment_id=target_segment.segment_id,
+                        context=phase_transition_context,
+                        created_at=SET_PROPOSAL_GENERATED_AT,
+                    )
+                )
+
+        repository = _TransientTransitionRepository(assessments)
+        optimizer_policy = SetOptimizerPolicy(
+            beam_width=8,
+            max_depth=target - 1,
+            per_state_candidate_limit=min(16, len(scope) - 1),
+            max_expanded_candidates=2_048,
+            alternative_limit=3,
+        )
+        result = optimize_set_lookahead(
+            repository=repository,  # type: ignore[arg-type]
+            intent=intent,
+            root_context=root_context,
+            root_state=root_state,
+            base_transition_context=base_transition_context,
+            ranking_policy=balanced_set_ranking_policy_v1(),
+            optimizer_policy=optimizer_policy,
+            target_duration_seconds_by_track=durations,
+            generated_at=SET_PROPOSAL_GENERATED_AT,
+            style_tags_by_track=None,
+            critical_warnings_by_track={track_id: () for track_id in scope},
+        )
+        safe_result = self._renderer_safe_result(result)
+        try:
+            return project_set_optimizer_result(
+                result=safe_result,
+                display_name_by_track_id=labels,
+            )
+        except ValueError as exc:
+            raise DesktopSetProposalTransportError(
+                "set_proposal_projection_failed",
+                "The set proposal could not be projected safely.",
+            ) from exc
+
+    def _revision_for_track(
+        self,
+        track_id: str,
+    ) -> tuple[MusicDNARevision, float, str]:
+        attempt = self._evidence.latest_evidence_for_track(track_id)
+        if attempt is None:
+            raise DesktopSetProposalTransportError(
+                "set_proposal_analysis_missing",
+                "Analysis evidence is missing for a selected track.",
+            )
+        if attempt.status != "succeeded":
+            raise DesktopSetProposalTransportError(
+                "set_proposal_analysis_failed",
+                "The latest analysis attempt failed for a selected track.",
+            )
+        success = self._evidence.latest_success_for_track(track_id)
+        if success is None or success.evidence_id != attempt.evidence_id:
+            raise DesktopSetProposalTransportError(
+                "set_proposal_analysis_failed",
+                "A selected track has no current successful analysis evidence.",
+            )
+        if (
+            success.provider_version is None
+            or success.algorithm_version is None
+            or success.duration_seconds is None
+            or success.duration_seconds <= 0.0
+            or success.bpm is None
+            or success.energy is None
+        ):
+            raise DesktopSetProposalTransportError(
+                "set_proposal_analysis_incomplete",
+                "A selected track is missing required analysis evidence.",
+            )
+
+        correction = self._evidence.latest_active_correction(track_id, success.evidence_id)
+        correction_values: Mapping[str, object] = {}
+        correction_id: str | None = None
+        if correction is not None:
+            try:
+                decoded = json.loads(correction.payload_json)
+            except json.JSONDecodeError as exc:
+                raise DesktopSetProposalTransportError(
+                    "set_proposal_analysis_incomplete",
+                    "A selected track has invalid correction evidence.",
+                ) from exc
+            if not isinstance(decoded, dict) or set(decoded) - {
+                "bpm",
+                "key_tonic",
+                "key_scale",
+                "camelot",
+                "energy",
+            }:
+                raise DesktopSetProposalTransportError(
+                    "set_proposal_analysis_incomplete",
+                    "A selected track has invalid correction evidence.",
+                )
+            correction_values = decoded
+            correction_id = correction.correction_id
+
+        canonical = self._canonical_result(success, correction_values)
+        analysis_revision = success.evidence_id
+        if correction_id is not None:
+            analysis_revision = f"{analysis_revision}+{correction_id}"
+        try:
+            revision = build_music_dna(
+                track_id=track_id,
+                content_identity=track_id,
+                analysis_revision=analysis_revision,
+                evidence_id=success.evidence_id,
+                input_identity=track_id,
+                canonical=canonical,
+                rhythmic_structure=None,
+                benchmark_status="desktop-preview",
+            )
+        except ValueError as exc:
+            raise DesktopSetProposalTransportError(
+                "set_proposal_analysis_incomplete",
+                "A selected track cannot form a valid Music DNA revision.",
+            ) from exc
+
+        track = self._tracks.get_by_id(track_id)
+        if track is None:
+            raise DesktopSetProposalTransportError(
+                "set_proposal_track_unavailable",
+                "A selected track is not available in the local library.",
+            )
+        title = track.title.strip() if isinstance(track.title, str) and track.title.strip() else track_id
+        artist = (
+            track.artist.strip()
+            if isinstance(track.artist, str) and track.artist.strip()
+            else None
+        )
+        label = f"{artist} — {title}" if artist is not None else title
+        return revision, float(success.duration_seconds), label
+
+    @staticmethod
+    def _canonical_result(
+        evidence: AnalysisEvidenceRecord,
+        correction: Mapping[str, object],
+    ) -> CanonicalAnalysisResult:
+        def corrected(name: str, provider_value: object) -> object:
+            return correction[name] if name in correction else provider_value
+
+        bpm = corrected("bpm", evidence.bpm)
+        energy = corrected("energy", evidence.energy)
+        tonic = corrected("key_tonic", evidence.key_tonic)
+        scale = corrected("key_scale", evidence.key_scale)
+        camelot = corrected("camelot", evidence.camelot)
+        key = None
+        if isinstance(camelot, str):
+            key = camelot
+        elif isinstance(tonic, str):
+            key = tonic if not isinstance(scale, str) else f"{tonic} {scale}"
+        return CanonicalAnalysisResult(
+            path=evidence.track_id,
+            provider=evidence.provider,
+            bpm=float(bpm) if isinstance(bpm, (int, float)) and not isinstance(bpm, bool) else None,
+            bpm_confidence=evidence.bpm_confidence,
+            key=key,
+            key_confidence=evidence.key_confidence,
+            energy=(
+                float(energy)
+                if isinstance(energy, (int, float)) and not isinstance(energy, bool)
+                else None
+            ),
+            loudness_db=evidence.loudness_db,
+            duration_seconds=evidence.duration_seconds,
+            genre_hint=evidence.genre_hint,
+            analysis_status="ok",
+            analysis_version=evidence.analysis_version,
+            key_tonic=tonic if isinstance(tonic, str) else None,
+            key_scale=scale if isinstance(scale, str) else None,
+            camelot=camelot if isinstance(camelot, str) else None,
+            beat_stability=evidence.beat_stability,
+            harmonic_ratio=evidence.harmonic_ratio,
+            percussive_ratio=evidence.percussive_ratio,
+            provider_version=evidence.provider_version,
+            algorithm_version=evidence.algorithm_version,
+            warnings=evidence.warnings,
+        )
+
+    @staticmethod
+    def _renderer_safe_result(result: SetOptimizerResult) -> SetOptimizerResult:
+        normalized: list[str] = []
+        for warning in result.warnings:
+            code = _CANONICAL_WARNING_CODES.get(warning)
+            if code is None:
+                raise DesktopSetProposalTransportError(
+                    "set_proposal_projection_failed",
+                    "The optimizer returned an unrecognized renderer warning.",
+                )
+            if code not in normalized:
+                normalized.append(code)
+        return replace(result, warnings=tuple(normalized))
+
+    @classmethod
+    def _validated_track_ids(cls, values: Sequence[str]) -> tuple[str, ...]:
+        if isinstance(values, (str, bytes)):
+            raise DesktopSetProposalTransportError(
+                "invalid_set_proposal_request",
+                "Proposal track_ids must be a bounded list.",
+            )
+        if not MIN_SET_PROPOSAL_TRACKS <= len(values) <= MAX_SET_PROPOSAL_TRACKS:
+            raise DesktopSetProposalTransportError(
+                "invalid_set_proposal_request",
+                "Proposal track_ids must contain between 3 and 24 tracks.",
+            )
+        normalized = tuple(cls._validated_track_id(value) for value in values)
+        if len(set(normalized)) != len(normalized):
+            raise DesktopSetProposalTransportError(
+                "invalid_set_proposal_request",
+                "Proposal track_ids must be unique.",
+            )
+        return tuple(sorted(normalized))
+
+    @staticmethod
+    def _validated_track_id(value: object) -> str:
+        if not isinstance(value, str):
+            raise DesktopSetProposalTransportError(
+                "invalid_set_proposal_request",
+                "The set proposal track identifier is invalid.",
+            )
+        normalized = value.strip()
+        if (
+            not normalized
+            or len(normalized) > MAX_SET_PROPOSAL_TRACK_ID_CHARS
+            or normalized != value
+            or "/" in normalized
+            or "\\" in normalized
+            or any(ord(character) < 32 or ord(character) == 127 for character in normalized)
+        ):
+            raise DesktopSetProposalTransportError(
+                "invalid_set_proposal_request",
+                "The set proposal track identifier is invalid.",
+            )
+        return normalized
+
+    @staticmethod
+    def _validated_target_track_count(value: object, scope_size: int) -> int:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise DesktopSetProposalTransportError(
+                "invalid_set_proposal_request",
+                "The set proposal target track count is invalid.",
+            )
+        if (
+            value < MIN_SET_PROPOSAL_TARGET_TRACKS
+            or value > MAX_SET_PROPOSAL_TARGET_TRACKS
+            or value > scope_size
+        ):
+            raise DesktopSetProposalTransportError(
+                "invalid_set_proposal_request",
+                "The set proposal target track count is outside the bounded scope.",
+            )
+        return value
+
+    @staticmethod
+    def _request_fingerprint(
+        scope: tuple[str, ...],
+        seed_track_id: str,
+        target_track_count: int,
+    ) -> str:
+        material = "|".join((*scope, seed_track_id, str(target_track_count), SET_PROPOSAL_POLICY_VERSION))
+        return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "DesktopSetProposalTransport",
+    "DesktopSetProposalTransportError",
+    "MAX_SET_PROPOSAL_TRACKS",
+    "MIN_SET_PROPOSAL_TRACKS",
+    "SET_PROPOSAL_POLICY_VERSION",
+]

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -12,6 +12,7 @@ fn main() {
             "analysis_inspector_get",
             "analysis_correct",
             "analysis_reanalyze",
+            "set_proposal_generate",
         ]),
     ))
     .expect("failed to configure APPLAYLIST desktop host build");

--- a/src-tauri/capabilities/main-set-proposal.json
+++ b/src-tauri/capabilities/main-set-proposal.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "main-set-proposal",
+  "description": "Allow the local main window to request only bounded read-only APPLAYLIST set proposals.",
+  "local": true,
+  "windows": [
+    "main"
+  ],
+  "platforms": [
+    "macOS"
+  ],
+  "permissions": [
+    "allow-set-proposal-generate"
+  ]
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,12 +2,14 @@ mod analysis_bridge;
 mod analysis_job;
 mod import_job;
 mod library_capability;
+mod set_proposal;
 mod sidecar_bridge;
 
 use analysis_bridge::AnalysisSidecarBridge;
 use analysis_job::AnalysisJobRegistry;
 use import_job::ImportJobRegistry;
 use library_capability::LibraryCapabilityRegistry;
+use set_proposal::SetProposalBridge;
 use sidecar_bridge::SidecarBridge;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -19,6 +21,7 @@ pub fn run() {
         .manage(AnalysisJobRegistry::default())
         .manage(SidecarBridge::from_environment())
         .manage(AnalysisSidecarBridge::from_environment())
+        .manage(SetProposalBridge::from_environment())
         .invoke_handler(tauri::generate_handler![
             library_capability::library_choose_root,
             import_job::library_import_start,
@@ -30,7 +33,8 @@ pub fn run() {
             analysis_job::analysis_inspector_list,
             analysis_job::analysis_inspector_get,
             analysis_job::analysis_correct,
-            analysis_job::analysis_reanalyze
+            analysis_job::analysis_reanalyze,
+            set_proposal::set_proposal_generate
         ])
         .run(tauri::generate_context!())
         .expect("error while running APPLAYLIST desktop host");

--- a/src-tauri/src/set_proposal.rs
+++ b/src-tauri/src/set_proposal.rs
@@ -603,15 +603,8 @@ fn validate_ready(ready: &SidecarReady, nonce: &str) -> Result<(), SetProposalBr
 }
 
 fn verify_health(port: u16, secret: &str, nonce: &str) -> Result<(), SetProposalBridgeError> {
-    let (status, body) = request_json(
-        port,
-        "GET",
-        "/v1/health",
-        secret,
-        nonce,
-        None,
-        HTTP_TIMEOUT,
-    )?;
+    let (status, body) =
+        request_json(port, "GET", "/v1/health", secret, nonce, None, HTTP_TIMEOUT)?;
     if status == 401 {
         return Err(SetProposalBridgeError::authentication_failed());
     }
@@ -814,9 +807,10 @@ mod tests {
         let safe = safe_fixture();
         assert!(parse_set_proposal(&safe).is_ok());
 
-        let escalation = String::from_utf8(safe.clone())
-            .expect("utf8")
-            .replace("\"activation_authorized\":false", "\"activation_authorized\":true");
+        let escalation = String::from_utf8(safe.clone()).expect("utf8").replace(
+            "\"activation_authorized\":false",
+            "\"activation_authorized\":true",
+        );
         assert!(parse_set_proposal(escalation.as_bytes()).is_err());
 
         let unknown = String::from_utf8(safe)

--- a/src-tauri/src/set_proposal.rs
+++ b/src-tauri/src/set_proposal.rs
@@ -88,13 +88,7 @@ impl SetProposalBridge {
     ) -> Result<DesktopSetProposalDto, SetProposalBridgeError> {
         validate_request(track_ids, seed_track_id, target_track_count)?;
         let executable = self.configured_executable(bundled_resource_dir)?;
-        let secret = random_token();
-        let nonce = random_token();
-        let mut process = SetProposalSidecarProcess::spawn(&executable, &secret, &nonce)?;
-        let ready = process.read_ready()?;
-        validate_ready(&ready, &nonce)?;
-        verify_health(ready.port, &secret, &nonce)?;
-
+        let mut session = SetProposalSidecarSession::connect(&executable)?;
         let body = serde_json::to_vec(&SetProposalRequest {
             track_ids,
             seed_track_id,
@@ -102,27 +96,19 @@ impl SetProposalBridge {
         })
         .map_err(|_| SetProposalBridgeError::request_encoding_failed())?;
 
-        let response = request_json(
-            ready.port,
-            "POST",
-            "/v1/set/proposal/generate",
-            &secret,
-            &nonce,
-            Some(&body),
-            HTTP_TIMEOUT,
-        );
+        let response = session.post("/v1/set/proposal/generate", &body);
         let result = match response {
-            Ok((200, body)) => parse_set_proposal(&body),
-            Ok((status, body)) => {
-                let error = parse_sidecar_error(&body);
+            Ok((200, response_body)) => parse_set_proposal(&response_body),
+            Ok((status, response_body)) => {
+                let sidecar_error = parse_sidecar_error(&response_body);
                 Err(SetProposalBridgeError::proposal_rejected(
                     status,
-                    error.as_deref(),
+                    sidecar_error.as_deref(),
                 ))
             }
             Err(error) => Err(error),
         };
-        process.shutdown(ready.port, &secret, &nonce);
+        session.shutdown();
         result
     }
 }
@@ -140,92 +126,96 @@ struct SetProposalBridgeError {
 }
 
 impl SetProposalBridgeError {
+    const fn new(code: &'static str, message: &'static str) -> Self {
+        Self { code, message }
+    }
+
     const fn not_configured() -> Self {
-        Self {
-            code: "desktop_set_proposal_sidecar_not_configured",
-            message: "The desktop set proposal service is not configured.",
-        }
+        Self::new(
+            "desktop_set_proposal_sidecar_not_configured",
+            "The desktop set proposal service is not configured.",
+        )
     }
 
     const fn executable_unavailable() -> Self {
-        Self {
-            code: "desktop_set_proposal_sidecar_unavailable",
-            message: "The desktop set proposal service is unavailable.",
-        }
+        Self::new(
+            "desktop_set_proposal_sidecar_unavailable",
+            "The desktop set proposal service is unavailable.",
+        )
     }
 
     const fn startup_failed() -> Self {
-        Self {
-            code: "desktop_set_proposal_sidecar_startup_failed",
-            message: "The desktop set proposal service could not start.",
-        }
+        Self::new(
+            "desktop_set_proposal_sidecar_startup_failed",
+            "The desktop set proposal service could not start.",
+        )
     }
 
     const fn readiness_failed() -> Self {
-        Self {
-            code: "desktop_set_proposal_sidecar_readiness_failed",
-            message: "The desktop set proposal service did not become ready.",
-        }
+        Self::new(
+            "desktop_set_proposal_sidecar_readiness_failed",
+            "The desktop set proposal service did not become ready.",
+        )
     }
 
     const fn authentication_failed() -> Self {
-        Self {
-            code: "desktop_set_proposal_sidecar_authentication_failed",
-            message: "The desktop set proposal service authentication failed.",
-        }
+        Self::new(
+            "desktop_set_proposal_sidecar_authentication_failed",
+            "The desktop set proposal service authentication failed.",
+        )
     }
 
     const fn request_failed() -> Self {
-        Self {
-            code: "desktop_set_proposal_request_failed",
-            message: "The desktop set proposal request failed.",
-        }
+        Self::new(
+            "desktop_set_proposal_request_failed",
+            "The desktop set proposal request failed.",
+        )
     }
 
     const fn request_encoding_failed() -> Self {
-        Self {
-            code: "desktop_set_proposal_request_encoding_failed",
-            message: "The desktop set proposal request could not be encoded.",
-        }
+        Self::new(
+            "desktop_set_proposal_request_encoding_failed",
+            "The desktop set proposal request could not be encoded.",
+        )
     }
 
     const fn invalid_request() -> Self {
-        Self {
-            code: "invalid_desktop_set_proposal_request",
-            message: "The desktop set proposal request is invalid.",
-        }
+        Self::new(
+            "invalid_desktop_set_proposal_request",
+            "The desktop set proposal request is invalid.",
+        )
     }
 
     const fn invalid_response() -> Self {
-        Self {
-            code: "desktop_set_proposal_response_invalid",
-            message: "The desktop set proposal response was invalid.",
-        }
+        Self::new(
+            "desktop_set_proposal_response_invalid",
+            "The desktop set proposal response was invalid.",
+        )
     }
 
     fn proposal_rejected(status: u16, error: Option<&str>) -> Self {
         match (status, error) {
-            (409, Some("set_proposal_analysis_missing")) => Self {
-                code: "desktop_set_proposal_analysis_missing",
-                message: "One or more selected tracks have no analysis evidence.",
-            },
-            (409, Some("set_proposal_analysis_failed")) => Self {
-                code: "desktop_set_proposal_analysis_failed",
-                message: "One or more selected tracks have a failed latest analysis.",
-            },
-            (409, Some("set_proposal_analysis_incomplete")) => Self {
-                code: "desktop_set_proposal_analysis_incomplete",
-                message: "One or more selected tracks lack required proposal evidence.",
-            },
-            (409, Some("set_proposal_track_unavailable")) => Self {
-                code: "desktop_set_proposal_track_unavailable",
-                message: "One or more selected tracks are unavailable in the local library.",
-            },
+            (409, Some("set_proposal_analysis_missing")) => Self::new(
+                "desktop_set_proposal_analysis_missing",
+                "One or more selected tracks have no analysis evidence.",
+            ),
+            (409, Some("set_proposal_analysis_failed")) => Self::new(
+                "desktop_set_proposal_analysis_failed",
+                "One or more selected tracks have a failed latest analysis.",
+            ),
+            (409, Some("set_proposal_analysis_incomplete")) => Self::new(
+                "desktop_set_proposal_analysis_incomplete",
+                "One or more selected tracks lack required proposal evidence.",
+            ),
+            (409, Some("set_proposal_track_unavailable")) => Self::new(
+                "desktop_set_proposal_track_unavailable",
+                "One or more selected tracks are unavailable in the local library.",
+            ),
             (400, Some("invalid_set_proposal_request")) => Self::invalid_request(),
-            _ => Self {
-                code: "desktop_set_proposal_rejected",
-                message: "The desktop set proposal request was rejected.",
-            },
+            _ => Self::new(
+                "desktop_set_proposal_rejected",
+                "The desktop set proposal request was rejected.",
+            ),
         }
     }
 }
@@ -316,66 +306,48 @@ struct DesktopSetProposalObjectiveDto {
     target_reached: bool,
 }
 
-struct SetProposalSidecarProcess {
+struct SetProposalSidecarSession {
     child: Child,
+    port: u16,
+    secret: String,
+    nonce: String,
 }
 
-impl SetProposalSidecarProcess {
-    fn spawn(
-        executable: &Path,
-        secret: &str,
-        nonce: &str,
-    ) -> Result<Self, SetProposalBridgeError> {
-        let mut child = Command::new(executable)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .spawn()
-            .map_err(|_| SetProposalBridgeError::startup_failed())?;
-        let envelope = serde_json::to_vec(&serde_json::json!({
-            "protocol": PROTOCOL_VERSION,
-            "secret": secret,
-            "nonce": nonce,
-        }))
-        .map_err(|_| SetProposalBridgeError::startup_failed())?;
-        let mut stdin = child
-            .stdin
-            .take()
-            .ok_or_else(SetProposalBridgeError::startup_failed)?;
-        stdin
-            .write_all(&envelope)
-            .and_then(|_| stdin.write_all(b"\n"))
-            .and_then(|_| stdin.flush())
-            .map_err(|_| SetProposalBridgeError::startup_failed())?;
-        drop(stdin);
-        Ok(Self { child })
-    }
-
-    fn read_ready(&mut self) -> Result<SidecarReady, SetProposalBridgeError> {
-        let mut stdout = self
-            .child
-            .stdout
-            .take()
-            .ok_or_else(SetProposalBridgeError::readiness_failed)?;
-        let (sender, receiver) = mpsc::sync_channel(1);
-        thread::spawn(move || {
-            let result = read_bounded_line(&mut stdout, MAX_READY_BYTES);
-            let _ = sender.send(result);
-        });
-        let line = receiver
-            .recv_timeout(READY_TIMEOUT)
-            .map_err(|_| SetProposalBridgeError::readiness_failed())?
-            .map_err(|_| SetProposalBridgeError::readiness_failed())?;
-        serde_json::from_slice(&line).map_err(|_| SetProposalBridgeError::readiness_failed())
-    }
-
-    fn shutdown(&mut self, port: u16, secret: &str, nonce: &str) {
-        let _ = request_json(
-            port,
-            "POST",
-            "/v1/shutdown",
+impl SetProposalSidecarSession {
+    fn connect(executable: &Path) -> Result<Self, SetProposalBridgeError> {
+        let secret = random_token();
+        let nonce = random_token();
+        let mut child = spawn_sidecar(executable, &secret, &nonce)?;
+        let ready = read_ready(&mut child)?;
+        validate_ready(&ready, &nonce)?;
+        verify_health(ready.port, &secret, &nonce)?;
+        Ok(Self {
+            child,
+            port: ready.port,
             secret,
             nonce,
+        })
+    }
+
+    fn post(&mut self, path: &str, body: &[u8]) -> Result<(u16, Vec<u8>), SetProposalBridgeError> {
+        request_json(
+            self.port,
+            "POST",
+            path,
+            &self.secret,
+            &self.nonce,
+            Some(body),
+            HTTP_TIMEOUT,
+        )
+    }
+
+    fn shutdown(&mut self) {
+        let _ = request_json(
+            self.port,
+            "POST",
+            "/v1/shutdown",
+            &self.secret,
+            &self.nonce,
             Some(&[]),
             HTTP_TIMEOUT,
         );
@@ -390,13 +362,60 @@ impl SetProposalSidecarProcess {
     }
 }
 
-impl Drop for SetProposalSidecarProcess {
+impl Drop for SetProposalSidecarSession {
     fn drop(&mut self) {
         if matches!(self.child.try_wait(), Ok(None)) {
             let _ = self.child.kill();
         }
         let _ = self.child.wait();
     }
+}
+
+fn spawn_sidecar(
+    executable: &Path,
+    secret: &str,
+    nonce: &str,
+) -> Result<Child, SetProposalBridgeError> {
+    let mut child = Command::new(executable)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|_| SetProposalBridgeError::startup_failed())?;
+    let envelope = serde_json::to_vec(&serde_json::json!({
+        "protocol": PROTOCOL_VERSION,
+        "secret": secret,
+        "nonce": nonce,
+    }))
+    .map_err(|_| SetProposalBridgeError::startup_failed())?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(SetProposalBridgeError::startup_failed)?;
+    stdin
+        .write_all(&envelope)
+        .and_then(|_| stdin.write_all(b"\n"))
+        .and_then(|_| stdin.flush())
+        .map_err(|_| SetProposalBridgeError::startup_failed())?;
+    drop(stdin);
+    Ok(child)
+}
+
+fn read_ready(child: &mut Child) -> Result<SidecarReady, SetProposalBridgeError> {
+    let mut stdout = child
+        .stdout
+        .take()
+        .ok_or_else(SetProposalBridgeError::readiness_failed)?;
+    let (sender, receiver) = mpsc::sync_channel(1);
+    thread::spawn(move || {
+        let result = read_bounded_line(&mut stdout, MAX_READY_BYTES);
+        let _ = sender.send(result);
+    });
+    let line = receiver
+        .recv_timeout(READY_TIMEOUT)
+        .map_err(|_| SetProposalBridgeError::readiness_failed())?
+        .map_err(|_| SetProposalBridgeError::readiness_failed())?;
+    serde_json::from_slice(&line).map_err(|_| SetProposalBridgeError::readiness_failed())
 }
 
 fn validate_request(
@@ -489,15 +508,14 @@ fn validate_set_proposal(proposal: &DesktopSetProposalDto) -> Result<(), SetProp
                 return Err(SetProposalBridgeError::invalid_response());
             }
         }
-        for transition_id in &alternative.transition_ids {
-            if !safe_token(transition_id, 256) {
-                return Err(SetProposalBridgeError::invalid_response());
-            }
-        }
         if alternative
-            .candidate_scores
+            .transition_ids
             .iter()
-            .any(|value| !unit_number(*value))
+            .any(|value| !safe_token(value, 256))
+            || alternative
+                .candidate_scores
+                .iter()
+                .any(|value| !unit_number(*value))
             || !unit_number(alternative.objective.mean_candidate_score)
             || !unit_number(alternative.objective.minimum_candidate_score)
             || !unit_number(alternative.objective.required_track_completion)
@@ -560,10 +578,7 @@ fn looks_like_absolute_path(value: &str) -> bool {
 
 fn parse_sidecar_error(body: &[u8]) -> Option<String> {
     let error = serde_json::from_slice::<SidecarError>(body).ok()?;
-    if !safe_token(&error.error, 128) {
-        return None;
-    }
-    Some(error.error)
+    safe_token(&error.error, 128).then_some(error.error)
 }
 
 fn random_token() -> String {
@@ -588,8 +603,15 @@ fn validate_ready(ready: &SidecarReady, nonce: &str) -> Result<(), SetProposalBr
 }
 
 fn verify_health(port: u16, secret: &str, nonce: &str) -> Result<(), SetProposalBridgeError> {
-    let (status, body) =
-        request_json(port, "GET", "/v1/health", secret, nonce, None, HTTP_TIMEOUT)?;
+    let (status, body) = request_json(
+        port,
+        "GET",
+        "/v1/health",
+        secret,
+        nonce,
+        None,
+        HTTP_TIMEOUT,
+    )?;
     if status == 401 {
         return Err(SetProposalBridgeError::authentication_failed());
     }
@@ -739,23 +761,8 @@ pub async fn set_proposal_generate(
 mod tests {
     use super::*;
 
-    #[test]
-    fn request_validation_is_bounded_and_path_safe() {
-        let tracks = vec![
-            "aptrack:v1:sha256:aaa".to_owned(),
-            "aptrack:v1:sha256:bbb".to_owned(),
-            "aptrack:v1:sha256:ccc".to_owned(),
-        ];
-        assert!(validate_request(&tracks, &tracks[0], 3).is_ok());
-        assert!(validate_request(&tracks, "/Users/example/a.wav", 3).is_err());
-        assert!(validate_request(&tracks, &tracks[0], 9).is_err());
-        let duplicate = vec![tracks[0].clone(), tracks[0].clone(), tracks[2].clone()];
-        assert!(validate_request(&duplicate, &tracks[0], 3).is_err());
-    }
-
-    #[test]
-    fn proposal_parser_rejects_unknown_fields_and_authority_escalation() {
-        let safe = br#"{
+    fn safe_fixture() -> Vec<u8> {
+        br#"{
           "schema":"applaylist-desktop-set-proposal-r1",
           "proposal_id":"sor_0123456789abcdef",
           "status":"target_reached",
@@ -786,18 +793,33 @@ mod tests {
           "deterministic_ordering":true,
           "activation_authorized":false,
           "personal_dj_model_training_authorized":false
-        }"#;
-        assert!(parse_set_proposal(safe).is_ok());
+        }"#
+        .to_vec()
+    }
 
-        let escalation = String::from_utf8(safe.to_vec())
+    #[test]
+    fn request_validation_is_bounded_and_path_safe() {
+        let tracks = vec![
+            "aptrack:v1:sha256:aaa".to_owned(),
+            "aptrack:v1:sha256:bbb".to_owned(),
+            "aptrack:v1:sha256:ccc".to_owned(),
+        ];
+        assert!(validate_request(&tracks, &tracks[0], 3).is_ok());
+        assert!(validate_request(&tracks, "/Users/example/a.wav", 3).is_err());
+        assert!(validate_request(&tracks, &tracks[0], 9).is_err());
+    }
+
+    #[test]
+    fn proposal_parser_rejects_unknown_fields_and_authority_escalation() {
+        let safe = safe_fixture();
+        assert!(parse_set_proposal(&safe).is_ok());
+
+        let escalation = String::from_utf8(safe.clone())
             .expect("utf8")
-            .replace(
-                "\"activation_authorized\":false",
-                "\"activation_authorized\":true",
-            );
+            .replace("\"activation_authorized\":false", "\"activation_authorized\":true");
         assert!(parse_set_proposal(escalation.as_bytes()).is_err());
 
-        let unknown = String::from_utf8(safe.to_vec())
+        let unknown = String::from_utf8(safe)
             .expect("utf8")
             .replace("\"schema\":", "\"path\":\"/tmp/a.wav\",\"schema\":");
         assert!(parse_set_proposal(unknown.as_bytes()).is_err());

--- a/src-tauri/src/set_proposal.rs
+++ b/src-tauri/src/set_proposal.rs
@@ -1,0 +1,805 @@
+use std::{
+    collections::HashSet,
+    env,
+    io::{Read, Write},
+    net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream},
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    sync::mpsc,
+    thread,
+    time::{Duration, Instant},
+};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tauri::{AppHandle, Manager, State};
+use uuid::Uuid;
+
+use crate::library_capability::DesktopHostError;
+
+const SIDECAR_EXECUTABLE_ENV: &str = "APPLAYLIST_DESKTOP_SIDECAR_EXECUTABLE";
+const BUNDLED_SIDECAR_RESOURCE: &str = "applaylist-sidecar/applaylist-sidecar";
+const PROTOCOL_VERSION: &str = "applaylist-sidecar-v1";
+const SECRET_HEADER: &str = "X-APPLAYLIST-Sidecar-Secret";
+const NONCE_HEADER: &str = "X-APPLAYLIST-Readiness-Nonce";
+const READY_TIMEOUT: Duration = Duration::from_secs(5);
+const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_READY_BYTES: usize = 8_192;
+const MAX_HTTP_RESPONSE_BYTES: u64 = 4 * 1024 * 1024;
+const MIN_SCOPE_TRACKS: usize = 3;
+const MAX_SCOPE_TRACKS: usize = 24;
+const MIN_TARGET_TRACKS: usize = 3;
+const MAX_TARGET_TRACKS: usize = 8;
+const MAX_TRACK_ID_CHARS: usize = 256;
+const MAX_DISPLAY_NAME_CHARS: usize = 512;
+
+#[derive(Debug, Clone)]
+pub struct SetProposalBridge {
+    executable: Option<PathBuf>,
+}
+
+impl SetProposalBridge {
+    pub fn from_environment() -> Self {
+        Self {
+            executable: if cfg!(debug_assertions) {
+                env::var_os(SIDECAR_EXECUTABLE_ENV).map(PathBuf::from)
+            } else {
+                None
+            },
+        }
+    }
+
+    fn configured_executable(
+        &self,
+        bundled_resource_dir: Option<&Path>,
+    ) -> Result<PathBuf, SetProposalBridgeError> {
+        if let Some(configured) = self.executable.as_ref() {
+            let canonical = configured
+                .canonicalize()
+                .map_err(|_| SetProposalBridgeError::executable_unavailable())?;
+            if !canonical.is_file() {
+                return Err(SetProposalBridgeError::executable_unavailable());
+            }
+            return Ok(canonical);
+        }
+
+        let resource_dir =
+            bundled_resource_dir.ok_or_else(SetProposalBridgeError::not_configured)?;
+        let canonical_resource_dir = resource_dir
+            .canonicalize()
+            .map_err(|_| SetProposalBridgeError::executable_unavailable())?;
+        let canonical = canonical_resource_dir
+            .join(BUNDLED_SIDECAR_RESOURCE)
+            .canonicalize()
+            .map_err(|_| SetProposalBridgeError::executable_unavailable())?;
+        if !canonical.starts_with(&canonical_resource_dir) || !canonical.is_file() {
+            return Err(SetProposalBridgeError::executable_unavailable());
+        }
+        Ok(canonical)
+    }
+
+    fn generate_with_resource_dir(
+        &self,
+        track_ids: &[String],
+        seed_track_id: &str,
+        target_track_count: usize,
+        bundled_resource_dir: Option<&Path>,
+    ) -> Result<DesktopSetProposalDto, SetProposalBridgeError> {
+        validate_request(track_ids, seed_track_id, target_track_count)?;
+        let executable = self.configured_executable(bundled_resource_dir)?;
+        let secret = random_token();
+        let nonce = random_token();
+        let mut process = SetProposalSidecarProcess::spawn(&executable, &secret, &nonce)?;
+        let ready = process.read_ready()?;
+        validate_ready(&ready, &nonce)?;
+        verify_health(ready.port, &secret, &nonce)?;
+
+        let body = serde_json::to_vec(&SetProposalRequest {
+            track_ids,
+            seed_track_id,
+            target_track_count,
+        })
+        .map_err(|_| SetProposalBridgeError::request_encoding_failed())?;
+
+        let response = request_json(
+            ready.port,
+            "POST",
+            "/v1/set/proposal/generate",
+            &secret,
+            &nonce,
+            Some(&body),
+            HTTP_TIMEOUT,
+        );
+        let result = match response {
+            Ok((200, body)) => parse_set_proposal(&body),
+            Ok((status, body)) => {
+                let error = parse_sidecar_error(&body);
+                Err(SetProposalBridgeError::proposal_rejected(
+                    status,
+                    error.as_deref(),
+                ))
+            }
+            Err(error) => Err(error),
+        };
+        process.shutdown(ready.port, &secret, &nonce);
+        result
+    }
+}
+
+impl Default for SetProposalBridge {
+    fn default() -> Self {
+        Self::from_environment()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SetProposalBridgeError {
+    code: &'static str,
+    message: &'static str,
+}
+
+impl SetProposalBridgeError {
+    const fn not_configured() -> Self {
+        Self {
+            code: "desktop_set_proposal_sidecar_not_configured",
+            message: "The desktop set proposal service is not configured.",
+        }
+    }
+
+    const fn executable_unavailable() -> Self {
+        Self {
+            code: "desktop_set_proposal_sidecar_unavailable",
+            message: "The desktop set proposal service is unavailable.",
+        }
+    }
+
+    const fn startup_failed() -> Self {
+        Self {
+            code: "desktop_set_proposal_sidecar_startup_failed",
+            message: "The desktop set proposal service could not start.",
+        }
+    }
+
+    const fn readiness_failed() -> Self {
+        Self {
+            code: "desktop_set_proposal_sidecar_readiness_failed",
+            message: "The desktop set proposal service did not become ready.",
+        }
+    }
+
+    const fn authentication_failed() -> Self {
+        Self {
+            code: "desktop_set_proposal_sidecar_authentication_failed",
+            message: "The desktop set proposal service authentication failed.",
+        }
+    }
+
+    const fn request_failed() -> Self {
+        Self {
+            code: "desktop_set_proposal_request_failed",
+            message: "The desktop set proposal request failed.",
+        }
+    }
+
+    const fn request_encoding_failed() -> Self {
+        Self {
+            code: "desktop_set_proposal_request_encoding_failed",
+            message: "The desktop set proposal request could not be encoded.",
+        }
+    }
+
+    const fn invalid_request() -> Self {
+        Self {
+            code: "invalid_desktop_set_proposal_request",
+            message: "The desktop set proposal request is invalid.",
+        }
+    }
+
+    const fn invalid_response() -> Self {
+        Self {
+            code: "desktop_set_proposal_response_invalid",
+            message: "The desktop set proposal response was invalid.",
+        }
+    }
+
+    fn proposal_rejected(status: u16, error: Option<&str>) -> Self {
+        match (status, error) {
+            (409, Some("set_proposal_analysis_missing")) => Self {
+                code: "desktop_set_proposal_analysis_missing",
+                message: "One or more selected tracks have no analysis evidence.",
+            },
+            (409, Some("set_proposal_analysis_failed")) => Self {
+                code: "desktop_set_proposal_analysis_failed",
+                message: "One or more selected tracks have a failed latest analysis.",
+            },
+            (409, Some("set_proposal_analysis_incomplete")) => Self {
+                code: "desktop_set_proposal_analysis_incomplete",
+                message: "One or more selected tracks lack required proposal evidence.",
+            },
+            (409, Some("set_proposal_track_unavailable")) => Self {
+                code: "desktop_set_proposal_track_unavailable",
+                message: "One or more selected tracks are unavailable in the local library.",
+            },
+            (400, Some("invalid_set_proposal_request")) => Self::invalid_request(),
+            _ => Self {
+                code: "desktop_set_proposal_rejected",
+                message: "The desktop set proposal request was rejected.",
+            },
+        }
+    }
+}
+
+impl From<SetProposalBridgeError> for DesktopHostError {
+    fn from(value: SetProposalBridgeError) -> Self {
+        DesktopHostError::new(value.code, value.message)
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct SetProposalRequest<'a> {
+    track_ids: &'a [String],
+    seed_track_id: &'a str,
+    target_track_count: usize,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SidecarReady {
+    event: String,
+    protocol: String,
+    host: String,
+    port: u16,
+    nonce_sha256: String,
+    process_id: u32,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct HealthResponse {
+    status: String,
+    protocol: String,
+    nonce_sha256: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SidecarError {
+    error: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct DesktopSetProposalDto {
+    schema: String,
+    proposal_id: String,
+    status: String,
+    alternatives: Vec<DesktopSetProposalAlternativeDto>,
+    reason_codes: Vec<String>,
+    warning_codes: Vec<String>,
+    budget_exhausted: bool,
+    missing_evidence_detected: bool,
+    deterministic_ordering: bool,
+    activation_authorized: bool,
+    personal_dj_model_training_authorized: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct DesktopSetProposalAlternativeDto {
+    path_id: String,
+    rank: usize,
+    sequence: Vec<DesktopSetProposalStepDto>,
+    transition_ids: Vec<String>,
+    candidate_scores: Vec<f64>,
+    objective: DesktopSetProposalObjectiveDto,
+    explanation_codes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct DesktopSetProposalStepDto {
+    order_index: usize,
+    track_id: String,
+    display_name: String,
+    phase_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct DesktopSetProposalObjectiveDto {
+    depth: usize,
+    mean_candidate_score: f64,
+    minimum_candidate_score: f64,
+    required_track_completion: f64,
+    remaining_required_count: usize,
+    target_reached: bool,
+}
+
+struct SetProposalSidecarProcess {
+    child: Child,
+}
+
+impl SetProposalSidecarProcess {
+    fn spawn(
+        executable: &Path,
+        secret: &str,
+        nonce: &str,
+    ) -> Result<Self, SetProposalBridgeError> {
+        let mut child = Command::new(executable)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|_| SetProposalBridgeError::startup_failed())?;
+        let envelope = serde_json::to_vec(&serde_json::json!({
+            "protocol": PROTOCOL_VERSION,
+            "secret": secret,
+            "nonce": nonce,
+        }))
+        .map_err(|_| SetProposalBridgeError::startup_failed())?;
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(SetProposalBridgeError::startup_failed)?;
+        stdin
+            .write_all(&envelope)
+            .and_then(|_| stdin.write_all(b"\n"))
+            .and_then(|_| stdin.flush())
+            .map_err(|_| SetProposalBridgeError::startup_failed())?;
+        drop(stdin);
+        Ok(Self { child })
+    }
+
+    fn read_ready(&mut self) -> Result<SidecarReady, SetProposalBridgeError> {
+        let mut stdout = self
+            .child
+            .stdout
+            .take()
+            .ok_or_else(SetProposalBridgeError::readiness_failed)?;
+        let (sender, receiver) = mpsc::sync_channel(1);
+        thread::spawn(move || {
+            let result = read_bounded_line(&mut stdout, MAX_READY_BYTES);
+            let _ = sender.send(result);
+        });
+        let line = receiver
+            .recv_timeout(READY_TIMEOUT)
+            .map_err(|_| SetProposalBridgeError::readiness_failed())?
+            .map_err(|_| SetProposalBridgeError::readiness_failed())?;
+        serde_json::from_slice(&line).map_err(|_| SetProposalBridgeError::readiness_failed())
+    }
+
+    fn shutdown(&mut self, port: u16, secret: &str, nonce: &str) {
+        let _ = request_json(
+            port,
+            "POST",
+            "/v1/shutdown",
+            secret,
+            nonce,
+            Some(&[]),
+            HTTP_TIMEOUT,
+        );
+        let deadline = Instant::now() + SHUTDOWN_TIMEOUT;
+        while Instant::now() < deadline {
+            match self.child.try_wait() {
+                Ok(Some(_)) => return,
+                Ok(None) => thread::sleep(Duration::from_millis(25)),
+                Err(_) => break,
+            }
+        }
+    }
+}
+
+impl Drop for SetProposalSidecarProcess {
+    fn drop(&mut self) {
+        if matches!(self.child.try_wait(), Ok(None)) {
+            let _ = self.child.kill();
+        }
+        let _ = self.child.wait();
+    }
+}
+
+fn validate_request(
+    track_ids: &[String],
+    seed_track_id: &str,
+    target_track_count: usize,
+) -> Result<(), SetProposalBridgeError> {
+    if track_ids.len() < MIN_SCOPE_TRACKS || track_ids.len() > MAX_SCOPE_TRACKS {
+        return Err(SetProposalBridgeError::invalid_request());
+    }
+    let mut unique = HashSet::with_capacity(track_ids.len());
+    for track_id in track_ids {
+        validate_track_id(track_id)?;
+        if !unique.insert(track_id.as_str()) {
+            return Err(SetProposalBridgeError::invalid_request());
+        }
+    }
+    validate_track_id(seed_track_id)?;
+    if !unique.contains(seed_track_id) {
+        return Err(SetProposalBridgeError::invalid_request());
+    }
+    if target_track_count < MIN_TARGET_TRACKS
+        || target_track_count > MAX_TARGET_TRACKS
+        || target_track_count > track_ids.len()
+    {
+        return Err(SetProposalBridgeError::invalid_request());
+    }
+    Ok(())
+}
+
+fn validate_track_id(track_id: &str) -> Result<(), SetProposalBridgeError> {
+    if track_id.is_empty()
+        || track_id.len() > MAX_TRACK_ID_CHARS
+        || track_id.trim() != track_id
+        || track_id.contains('/')
+        || track_id.contains('\\')
+        || track_id.chars().any(char::is_control)
+    {
+        return Err(SetProposalBridgeError::invalid_request());
+    }
+    Ok(())
+}
+
+fn parse_set_proposal(body: &[u8]) -> Result<DesktopSetProposalDto, SetProposalBridgeError> {
+    let proposal = serde_json::from_slice::<DesktopSetProposalDto>(body)
+        .map_err(|_| SetProposalBridgeError::invalid_response())?;
+    validate_set_proposal(&proposal)?;
+    Ok(proposal)
+}
+
+fn validate_set_proposal(proposal: &DesktopSetProposalDto) -> Result<(), SetProposalBridgeError> {
+    if proposal.schema != "applaylist-desktop-set-proposal-r1"
+        || !safe_token(&proposal.proposal_id, 256)
+        || !matches!(
+            proposal.status.as_str(),
+            "target_reached"
+                | "paths_found"
+                | "no_eligible_path"
+                | "not_proven_missing_evidence"
+                | "budget_exhausted"
+        )
+        || !proposal.deterministic_ordering
+        || proposal.activation_authorized
+        || proposal.personal_dj_model_training_authorized
+        || proposal.alternatives.len() > 3
+    {
+        return Err(SetProposalBridgeError::invalid_response());
+    }
+    validate_codes(&proposal.reason_codes)?;
+    validate_codes(&proposal.warning_codes)?;
+
+    for (index, alternative) in proposal.alternatives.iter().enumerate() {
+        if alternative.rank != index + 1
+            || !safe_token(&alternative.path_id, 256)
+            || alternative.sequence.len() < 2
+            || alternative.sequence.len() > MAX_TARGET_TRACKS
+            || alternative.transition_ids.len() != alternative.candidate_scores.len()
+            || alternative.sequence.len() != alternative.candidate_scores.len() + 1
+            || alternative.objective.depth != alternative.candidate_scores.len()
+        {
+            return Err(SetProposalBridgeError::invalid_response());
+        }
+        validate_codes(&alternative.explanation_codes)?;
+        for (step_index, step) in alternative.sequence.iter().enumerate() {
+            if step.order_index != step_index
+                || validate_track_id(&step.track_id).is_err()
+                || !safe_display_name(&step.display_name)
+                || !safe_token(&step.phase_id, 256)
+            {
+                return Err(SetProposalBridgeError::invalid_response());
+            }
+        }
+        for transition_id in &alternative.transition_ids {
+            if !safe_token(transition_id, 256) {
+                return Err(SetProposalBridgeError::invalid_response());
+            }
+        }
+        if alternative
+            .candidate_scores
+            .iter()
+            .any(|value| !unit_number(*value))
+            || !unit_number(alternative.objective.mean_candidate_score)
+            || !unit_number(alternative.objective.minimum_candidate_score)
+            || !unit_number(alternative.objective.required_track_completion)
+            || alternative.objective.remaining_required_count > MAX_SCOPE_TRACKS
+        {
+            return Err(SetProposalBridgeError::invalid_response());
+        }
+    }
+
+    if matches!(proposal.status.as_str(), "target_reached" | "paths_found")
+        && proposal.alternatives.is_empty()
+    {
+        return Err(SetProposalBridgeError::invalid_response());
+    }
+    if proposal.status == "no_eligible_path" && !proposal.alternatives.is_empty() {
+        return Err(SetProposalBridgeError::invalid_response());
+    }
+    Ok(())
+}
+
+fn validate_codes(values: &[String]) -> Result<(), SetProposalBridgeError> {
+    if values.len() > 128 || values.iter().any(|value| !safe_token(value, 128)) {
+        return Err(SetProposalBridgeError::invalid_response());
+    }
+    Ok(())
+}
+
+fn safe_token(value: &str, maximum: usize) -> bool {
+    if value.is_empty() || value.len() > maximum || value.trim() != value {
+        return false;
+    }
+    value.chars().enumerate().all(|(index, character)| {
+        character.is_ascii_alphanumeric()
+            || (index > 0 && matches!(character, '_' | '.' | ':' | '+' | '-'))
+    })
+}
+
+fn safe_display_name(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_DISPLAY_NAME_CHARS
+        && value.trim() == value
+        && !value.chars().any(char::is_control)
+        && !looks_like_absolute_path(value)
+}
+
+fn unit_number(value: f64) -> bool {
+    value.is_finite() && (0.0..=1.0).contains(&value)
+}
+
+fn looks_like_absolute_path(value: &str) -> bool {
+    if value.starts_with('/') || value.starts_with("\\\\") {
+        return true;
+    }
+    let bytes = value.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'\\' || bytes[2] == b'/')
+}
+
+fn parse_sidecar_error(body: &[u8]) -> Option<String> {
+    let error = serde_json::from_slice::<SidecarError>(body).ok()?;
+    if !safe_token(&error.error, 128) {
+        return None;
+    }
+    Some(error.error)
+}
+
+fn random_token() -> String {
+    format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple())
+}
+
+fn sha256_hex(value: &str) -> String {
+    format!("{:x}", Sha256::digest(value.as_bytes()))
+}
+
+fn validate_ready(ready: &SidecarReady, nonce: &str) -> Result<(), SetProposalBridgeError> {
+    if ready.event != "ready"
+        || ready.protocol != PROTOCOL_VERSION
+        || ready.host != "127.0.0.1"
+        || ready.port == 0
+        || ready.process_id == 0
+        || ready.nonce_sha256 != sha256_hex(nonce)
+    {
+        return Err(SetProposalBridgeError::readiness_failed());
+    }
+    Ok(())
+}
+
+fn verify_health(port: u16, secret: &str, nonce: &str) -> Result<(), SetProposalBridgeError> {
+    let (status, body) =
+        request_json(port, "GET", "/v1/health", secret, nonce, None, HTTP_TIMEOUT)?;
+    if status == 401 {
+        return Err(SetProposalBridgeError::authentication_failed());
+    }
+    if status != 200 {
+        return Err(SetProposalBridgeError::request_failed());
+    }
+    let health = serde_json::from_slice::<HealthResponse>(&body)
+        .map_err(|_| SetProposalBridgeError::readiness_failed())?;
+    if health.status != "ready"
+        || health.protocol != PROTOCOL_VERSION
+        || health.nonce_sha256 != sha256_hex(nonce)
+    {
+        return Err(SetProposalBridgeError::readiness_failed());
+    }
+    Ok(())
+}
+
+fn request_json(
+    port: u16,
+    method: &str,
+    path: &str,
+    secret: &str,
+    nonce: &str,
+    body: Option<&[u8]>,
+    read_timeout: Duration,
+) -> Result<(u16, Vec<u8>), SetProposalBridgeError> {
+    let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+    let mut stream = TcpStream::connect_timeout(&address, HTTP_TIMEOUT)
+        .map_err(|_| SetProposalBridgeError::request_failed())?;
+    stream
+        .set_read_timeout(Some(read_timeout))
+        .and_then(|_| stream.set_write_timeout(Some(HTTP_TIMEOUT)))
+        .map_err(|_| SetProposalBridgeError::request_failed())?;
+
+    let payload = body.unwrap_or(&[]);
+    let content_type = if body.is_some() {
+        "Content-Type: application/json\r\n"
+    } else {
+        ""
+    };
+    let request = format!(
+        "{method} {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\n{SECRET_HEADER}: {secret}\r\n{NONCE_HEADER}: {nonce}\r\n{content_type}Content-Length: {}\r\n\r\n",
+        payload.len()
+    );
+    stream
+        .write_all(request.as_bytes())
+        .and_then(|_| stream.write_all(payload))
+        .and_then(|_| stream.flush())
+        .map_err(|_| SetProposalBridgeError::request_failed())?;
+
+    let mut response = Vec::new();
+    stream
+        .take(MAX_HTTP_RESPONSE_BYTES + 1)
+        .read_to_end(&mut response)
+        .map_err(|_| SetProposalBridgeError::request_failed())?;
+    if response.len() as u64 > MAX_HTTP_RESPONSE_BYTES {
+        return Err(SetProposalBridgeError::request_failed());
+    }
+    parse_http_response(&response)
+}
+
+fn parse_http_response(response: &[u8]) -> Result<(u16, Vec<u8>), SetProposalBridgeError> {
+    let boundary = response
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .ok_or_else(SetProposalBridgeError::request_failed)?;
+    let headers = std::str::from_utf8(&response[..boundary])
+        .map_err(|_| SetProposalBridgeError::request_failed())?;
+    let mut lines = headers.split("\r\n");
+    let status_line = lines
+        .next()
+        .ok_or_else(SetProposalBridgeError::request_failed)?;
+    let mut status_parts = status_line.split_whitespace();
+    if status_parts.next() != Some("HTTP/1.1") {
+        return Err(SetProposalBridgeError::request_failed());
+    }
+    let status = status_parts
+        .next()
+        .and_then(|value| value.parse::<u16>().ok())
+        .ok_or_else(SetProposalBridgeError::request_failed)?;
+    let mut content_length = None;
+    for line in lines {
+        let Some((name, value)) = line.split_once(':') else {
+            return Err(SetProposalBridgeError::request_failed());
+        };
+        if name.eq_ignore_ascii_case("Content-Length") {
+            content_length = value.trim().parse::<usize>().ok();
+        }
+    }
+    let body = &response[boundary + 4..];
+    if content_length != Some(body.len()) {
+        return Err(SetProposalBridgeError::request_failed());
+    }
+    Ok((status, body.to_vec()))
+}
+
+fn read_bounded_line(reader: &mut impl Read, limit: usize) -> std::io::Result<Vec<u8>> {
+    let mut line = Vec::new();
+    for _ in 0..=limit {
+        let mut byte = [0_u8; 1];
+        let count = reader.read(&mut byte)?;
+        if count == 0 {
+            break;
+        }
+        if byte[0] == b'\n' {
+            return Ok(line);
+        }
+        line.push(byte[0]);
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        "sidecar readiness line is missing or too large",
+    ))
+}
+
+#[tauri::command]
+pub async fn set_proposal_generate(
+    track_ids: Vec<String>,
+    seed_track_id: String,
+    target_track_count: usize,
+    bridge: State<'_, SetProposalBridge>,
+    app: AppHandle,
+) -> Result<DesktopSetProposalDto, DesktopHostError> {
+    validate_request(&track_ids, &seed_track_id, target_track_count)
+        .map_err(DesktopHostError::from)?;
+    let bundled_resource_dir = app.path().resource_dir().ok();
+    let bridge = bridge.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        bridge.generate_with_resource_dir(
+            &track_ids,
+            &seed_track_id,
+            target_track_count,
+            bundled_resource_dir.as_deref(),
+        )
+    })
+    .await
+    .map_err(|_| {
+        DesktopHostError::new(
+            "desktop_set_proposal_task_failed",
+            "The desktop set proposal task failed.",
+        )
+    })?
+    .map_err(DesktopHostError::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_validation_is_bounded_and_path_safe() {
+        let tracks = vec![
+            "aptrack:v1:sha256:aaa".to_owned(),
+            "aptrack:v1:sha256:bbb".to_owned(),
+            "aptrack:v1:sha256:ccc".to_owned(),
+        ];
+        assert!(validate_request(&tracks, &tracks[0], 3).is_ok());
+        assert!(validate_request(&tracks, "/Users/example/a.wav", 3).is_err());
+        assert!(validate_request(&tracks, &tracks[0], 9).is_err());
+        let duplicate = vec![tracks[0].clone(), tracks[0].clone(), tracks[2].clone()];
+        assert!(validate_request(&duplicate, &tracks[0], 3).is_err());
+    }
+
+    #[test]
+    fn proposal_parser_rejects_unknown_fields_and_authority_escalation() {
+        let safe = br#"{
+          "schema":"applaylist-desktop-set-proposal-r1",
+          "proposal_id":"sor_0123456789abcdef",
+          "status":"target_reached",
+          "alternatives":[{
+            "path_id":"sp_0123456789abcdef",
+            "rank":1,
+            "sequence":[
+              {"order_index":0,"track_id":"track:a","display_name":"A","phase_id":"phase:preview-groove"},
+              {"order_index":1,"track_id":"track:b","display_name":"B","phase_id":"phase:preview-groove"},
+              {"order_index":2,"track_id":"track:c","display_name":"C","phase_id":"phase:preview-groove"}
+            ],
+            "transition_ids":["ta_a","ta_b"],
+            "candidate_scores":[0.8,0.7],
+            "objective":{
+              "depth":2,
+              "mean_candidate_score":0.75,
+              "minimum_candidate_score":0.7,
+              "required_track_completion":1.0,
+              "remaining_required_count":0,
+              "target_reached":true
+            },
+            "explanation_codes":["bounded_beam_lookahead_v1"]
+          }],
+          "reason_codes":["deterministic_bounded_beam_search_v1"],
+          "warning_codes":["future_feasibility_not_hard_prune_v1"],
+          "budget_exhausted":false,
+          "missing_evidence_detected":false,
+          "deterministic_ordering":true,
+          "activation_authorized":false,
+          "personal_dj_model_training_authorized":false
+        }"#;
+        assert!(parse_set_proposal(safe).is_ok());
+
+        let escalation = String::from_utf8(safe.to_vec())
+            .expect("utf8")
+            .replace(
+                "\"activation_authorized\":false",
+                "\"activation_authorized\":true",
+            );
+        assert!(parse_set_proposal(escalation.as_bytes()).is_err());
+
+        let unknown = String::from_utf8(safe.to_vec())
+            .expect("utf8")
+            .replace("\"schema\":", "\"path\":\"/tmp/a.wav\",\"schema\":");
+        assert!(parse_set_proposal(unknown.as_bytes()).is_err());
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,7 +19,8 @@
     "security": {
       "csp": "default-src 'self'; connect-src 'none'; img-src 'self' data:; style-src 'self'; script-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'none'; form-action 'none'",
       "capabilities": [
-        "main-library-root"
+        "main-library-root",
+        "main-set-proposal"
       ]
     },
     "withGlobalTauri": true

--- a/tests/test_desktop_set_proposal_renderer.py
+++ b/tests/test_desktop_set_proposal_renderer.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HTML = ROOT / "desktop" / "host-proof" / "index.html"
+JS = ROOT / "desktop" / "host-proof" / "set-proposal.js"
+CSS = ROOT / "desktop" / "host-proof" / "set-proposal.css"
+BUILD_RS = ROOT / "src-tauri" / "build.rs"
+LIB_RS = ROOT / "src-tauri" / "src" / "lib.rs"
+TAURI_CONF = ROOT / "src-tauri" / "tauri.conf.json"
+CAPABILITY = ROOT / "src-tauri" / "capabilities" / "main-set-proposal.json"
+RUST = ROOT / "src-tauri" / "src" / "set_proposal.rs"
+
+
+def test_set_proposal_renderer_is_external_strict_and_dom_safe() -> None:
+    html = HTML.read_text(encoding="utf-8")
+    js = JS.read_text(encoding="utf-8")
+    css = CSS.read_text(encoding="utf-8")
+
+    assert '<script src="./set-proposal.js" defer></script>' in html
+    assert '<link rel="stylesheet" href="./set-proposal.css">' in html
+    assert css.strip()
+    for required in (
+        'id="set-proposal"',
+        'id="set-proposal-refresh"',
+        'id="set-proposal-track-list"',
+        'id="set-proposal-seed"',
+        'id="set-proposal-target"',
+        'id="set-proposal-generate"',
+        'id="set-proposal-results"',
+    ):
+        assert required in html
+
+    assert ".innerHTML" not in js
+    assert "insertAdjacentHTML" not in js
+    assert "document.createElement" in js
+    assert ".textContent" in js
+    assert 'invoke("analysis_inspector_list", { filter: "all" })' in js
+    assert 'invoke("set_proposal_generate", {' in js
+    assert "validProposal" in js
+    assert "exactKeys(value" in js
+    assert 'value.schema !== "applaylist-desktop-set-proposal-r1"' in js
+    assert "value.deterministic_ordering !== true" in js
+    assert "value.activation_authorized !== false" in js
+    assert "value.personal_dj_model_training_authorized !== false" in js
+
+
+def test_set_proposal_renderer_has_no_network_filesystem_or_sidecar_authority() -> None:
+    js = JS.read_text(encoding="utf-8")
+    for forbidden in (
+        "fetch(",
+        "XMLHttpRequest",
+        "WebSocket",
+        "__TAURI__.fs",
+        "__TAURI__.shell",
+        "__TAURI__.http",
+        "plugin:fs",
+        "plugin:shell",
+        "/v1/set/",
+        "/v1/analysis/",
+        "X-APPLAYLIST-Sidecar-Secret",
+        "X-APPLAYLIST-Readiness-Nonce",
+        "127.0.0.1",
+        "process_id",
+        "nonce_sha256",
+        "input_fingerprint",
+        "evidence_id",
+    ):
+        assert forbidden not in js
+
+
+def test_set_proposal_tauri_surface_is_separate_and_narrow() -> None:
+    build_rs = BUILD_RS.read_text(encoding="utf-8")
+    lib_rs = LIB_RS.read_text(encoding="utf-8")
+    rust = RUST.read_text(encoding="utf-8")
+    conf = json.loads(TAURI_CONF.read_text(encoding="utf-8"))
+    capability = json.loads(CAPABILITY.read_text(encoding="utf-8"))
+
+    assert '"set_proposal_generate"' in build_rs
+    assert "set_proposal::set_proposal_generate" in lib_rs
+    assert ".manage(SetProposalBridge::from_environment())" in lib_rs
+    assert capability["permissions"] == ["allow-set-proposal-generate"]
+    assert set(conf["app"]["security"]["capabilities"]) == {
+        "main-library-root",
+        "main-set-proposal",
+    }
+
+    assert "#[serde(deny_unknown_fields)]" in rust
+    assert '"/v1/set/proposal/generate"' in rust
+    assert 'BUNDLED_SIDECAR_RESOURCE: &str = "applaylist-sidecar/applaylist-sidecar"' in rust
+    assert "stderr(Stdio::null())" in rust
+    assert 'ready.host != "127.0.0.1"' in rust
+    assert "proposal.activation_authorized" in rust
+    assert "proposal.personal_dj_model_training_authorized" in rust

--- a/tests/test_desktop_set_proposal_transport.py
+++ b/tests/test_desktop_set_proposal_transport.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from core.config.settings import get_settings
+from data.models.track_record import TrackRecord
+from data.repositories.analysis_evidence_repository import AnalysisEvidenceRepository
+from data.repositories.track_repository import TrackRepository
+from services.desktop.set_proposal_transport import (
+    DesktopSetProposalTransport,
+    DesktopSetProposalTransportError,
+)
+from tests.test_desktop_readiness_sidecar import NONCE, SECRET, _finish, _request
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _track_id(character: str) -> str:
+    return f"aptrack:v1:sha256:{character * 64}"
+
+
+def _configure_database(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    database = (tmp_path / "set-proposal.db").resolve()
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{database}")
+    get_settings.cache_clear()
+    return database
+
+
+def _seed_tracks(
+    *,
+    count: int = 4,
+    missing_energy_index: int | None = None,
+) -> tuple[str, ...]:
+    tracks = TrackRepository()
+    evidence = AnalysisEvidenceRepository()
+    ids: list[str] = []
+    for index in range(count):
+        character = chr(ord("a") + index)
+        track_id = _track_id(character)
+        ids.append(track_id)
+        tracks.upsert(
+            TrackRecord(
+                track_id=track_id,
+                path=f"/definitely/not-present/audio-{index}.wav",
+                title=f"Track {index + 1}",
+                artist="Fixture Artist",
+                duration_seconds=300.0 + index,
+            )
+        )
+        evidence.append_evidence(
+            track_id=track_id,
+            provider="fixture-provider",
+            analysis_version="canonical-mir-v1",
+            provider_version="fixture-1",
+            algorithm_version="fixture-algorithm-1",
+            bpm=128.0 + index * 0.5,
+            bpm_confidence=0.95,
+            key_tonic="A",
+            key_scale="minor",
+            camelot="8A",
+            key_confidence=0.9,
+            energy=None if missing_energy_index == index else 0.50 + index * 0.04,
+            loudness_db=-8.0 + index * 0.2,
+            duration_seconds=300.0 + index,
+            beat_stability=0.92,
+            harmonic_ratio=0.48,
+            percussive_ratio=0.76,
+        )
+    return tuple(ids)
+
+
+def test_set_proposal_is_deterministic_evidence_only_and_path_safe(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_database(monkeypatch, tmp_path)
+    track_ids = _seed_tracks()
+    transport = DesktopSetProposalTransport()
+
+    first = transport.generate(
+        track_ids=track_ids,
+        seed_track_id=track_ids[0],
+        target_track_count=3,
+    )
+    second = transport.generate(
+        track_ids=tuple(reversed(track_ids)),
+        seed_track_id=track_ids[0],
+        target_track_count=3,
+    )
+
+    assert first == second
+    assert first["schema"] == "applaylist-desktop-set-proposal-r1"
+    assert first["status"] == "target_reached"
+    assert first["activation_authorized"] is False
+    assert first["personal_dj_model_training_authorized"] is False
+    assert first["deterministic_ordering"] is True
+    assert first["alternatives"]
+
+    sequence = first["alternatives"][0]["sequence"]
+    assert sequence[0]["track_id"] == track_ids[0]
+    assert len(sequence) == 3
+
+    encoded = json.dumps(first, sort_keys=True)
+    assert "/definitely/not-present" not in encoded
+    assert "fixture-provider" not in encoded
+    assert "fixture-algorithm" not in encoded
+    assert "evidence_id" not in encoded
+    assert "input_fingerprint" not in encoded
+    assert "future_feasibility_not_hard_prune_v1" in encoded
+
+
+def test_active_correction_changes_revision_without_overwriting_provider_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_database(monkeypatch, tmp_path)
+    track_ids = _seed_tracks()
+    transport = DesktopSetProposalTransport()
+    evidence = AnalysisEvidenceRepository()
+
+    before = transport.generate(
+        track_ids=track_ids,
+        seed_track_id=track_ids[0],
+        target_track_count=3,
+    )
+    base = evidence.latest_success_for_track(track_ids[1])
+    assert base is not None
+    original_bpm = base.bpm
+
+    correction = evidence.append_correction(
+        track_id=track_ids[1],
+        base_evidence_id=base.evidence_id,
+        values={"bpm": 129.25, "energy": 0.61},
+        reason="desktop proposal correction fixture",
+    )
+    assert correction.base_evidence_id == base.evidence_id
+
+    after = transport.generate(
+        track_ids=track_ids,
+        seed_track_id=track_ids[0],
+        target_track_count=3,
+    )
+
+    assert after["proposal_id"] != before["proposal_id"]
+    persisted_base = evidence.get_evidence(base.evidence_id)
+    assert persisted_base is not None
+    assert persisted_base.bpm == original_bpm
+
+
+def test_latest_failed_or_incomplete_analysis_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_database(monkeypatch, tmp_path)
+    track_ids = _seed_tracks()
+    evidence = AnalysisEvidenceRepository()
+    evidence.append_evidence(
+        track_id=track_ids[2],
+        provider="fixture-provider",
+        analysis_version="canonical-mir-v1",
+        status="failed",
+        error_code="fixture_failure",
+        error_detail="bounded fixture failure",
+    )
+
+    with pytest.raises(DesktopSetProposalTransportError) as failed:
+        DesktopSetProposalTransport().generate(
+            track_ids=track_ids,
+            seed_track_id=track_ids[0],
+            target_track_count=3,
+        )
+    assert failed.value.code == "set_proposal_analysis_failed"
+
+    get_settings.cache_clear()
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{(tmp_path / 'incomplete.db').resolve()}")
+    get_settings.cache_clear()
+    incomplete_ids = _seed_tracks(missing_energy_index=1)
+    with pytest.raises(DesktopSetProposalTransportError) as incomplete:
+        DesktopSetProposalTransport().generate(
+            track_ids=incomplete_ids,
+            seed_track_id=incomplete_ids[0],
+            target_track_count=3,
+        )
+    assert incomplete.value.code == "set_proposal_analysis_incomplete"
+
+
+def test_set_proposal_input_bounds_reject_paths_duplicates_and_invalid_target() -> None:
+    validate = DesktopSetProposalTransport._validated_track_ids
+    with pytest.raises(DesktopSetProposalTransportError):
+        validate(["track:a", "track:b", "/Users/example/a.wav"])
+    with pytest.raises(DesktopSetProposalTransportError):
+        validate(["track:a", "track:a", "track:c"])
+    with pytest.raises(DesktopSetProposalTransportError):
+        DesktopSetProposalTransport._validated_target_track_count(9, 12)
+
+
+def _start_extended_sidecar(database: Path) -> tuple[subprocess.Popen[str], dict]:
+    process = subprocess.Popen(
+        [sys.executable, "-m", "scripts.applaylist_sidecar_entry"],
+        cwd=ROOT,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        bufsize=1,
+        env={
+            **os.environ,
+            "DATABASE_URL": f"sqlite:///{database}",
+            "PYTHONUNBUFFERED": "1",
+        },
+    )
+    assert process.stdin is not None
+    assert process.stdout is not None
+    process.stdin.write(
+        json.dumps(
+            {
+                "protocol": "applaylist-sidecar-v1",
+                "secret": SECRET,
+                "nonce": NONCE,
+            },
+            separators=(",", ":"),
+        )
+        + "\n"
+    )
+    process.stdin.flush()
+    ready_line = process.stdout.readline()
+    if not ready_line:
+        stderr = process.stderr.read() if process.stderr is not None else ""
+        raise AssertionError(f"extended sidecar did not become ready: {stderr}")
+    return process, json.loads(ready_line)
+
+
+def test_authenticated_sidecar_set_proposal_endpoint_is_strict_and_path_safe(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    database = _configure_database(monkeypatch, tmp_path)
+    track_ids = _seed_tracks()
+    process, ready = _start_extended_sidecar(database)
+    body = json.dumps(
+        {
+            "track_ids": list(track_ids),
+            "seed_track_id": track_ids[0],
+            "target_track_count": 3,
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+    try:
+        status, payload = _request(
+            ready,
+            method="POST",
+            path="/v1/set/proposal/generate",
+            secret="X" * 48,
+            body=body,
+        )
+        assert status == 401
+        assert payload == {"error": "unauthorized"}
+
+        status, payload = _request(
+            ready,
+            method="POST",
+            path="/v1/set/proposal/generate",
+            body=json.dumps(
+                {
+                    "track_ids": list(track_ids),
+                    "seed_track_id": track_ids[0],
+                    "target_track_count": 3,
+                    "path": "/must/not/pass",
+                }
+            ).encode("utf-8"),
+        )
+        assert status == 400
+        assert payload == {"error": "invalid_set_proposal_request"}
+
+        status, proposal = _request(
+            ready,
+            method="POST",
+            path="/v1/set/proposal/generate",
+            body=body,
+        )
+        assert status == 200
+        assert proposal["schema"] == "applaylist-desktop-set-proposal-r1"
+        assert proposal["activation_authorized"] is False
+
+        encoded = json.dumps(proposal, sort_keys=True)
+        assert "/definitely/not-present" not in encoded
+        assert SECRET not in encoded
+        assert NONCE not in encoded
+        assert "fixture-provider" not in encoded
+        assert "evidence_id" not in encoded
+
+        status, shutdown = _request(ready, method="POST", path="/v1/shutdown")
+        assert status == 202
+        assert shutdown == {"status": "shutting_down"}
+        _finish(process)
+    finally:
+        if process.poll() is None:
+            process.kill()
+            _finish(process)

--- a/tests/test_desktop_set_proposal_transport.py
+++ b/tests/test_desktop_set_proposal_transport.py
@@ -115,7 +115,7 @@ def test_set_proposal_is_deterministic_evidence_only_and_path_safe(
     assert "future_feasibility_not_hard_prune_v1" in encoded
 
 
-def test_active_correction_changes_revision_without_overwriting_provider_evidence(
+def test_active_correction_changes_path_revision_without_overwriting_provider_evidence(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -147,7 +147,9 @@ def test_active_correction_changes_revision_without_overwriting_provider_evidenc
         target_track_count=3,
     )
 
-    assert after["proposal_id"] != before["proposal_id"]
+    before_path = before["alternatives"][0]["path_id"]
+    after_path = after["alternatives"][0]["path_id"]
+    assert after_path != before_path
     persisted_base = evidence.get_evidence(base.evidence_id)
     assert persisted_base is not None
     assert persisted_base.bpm == original_bpm
@@ -178,7 +180,8 @@ def test_latest_failed_or_incomplete_analysis_fails_closed(
     assert failed.value.code == "set_proposal_analysis_failed"
 
     get_settings.cache_clear()
-    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{(tmp_path / 'incomplete.db').resolve()}")
+    incomplete_database = (tmp_path / "incomplete.db").resolve()
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{incomplete_database}")
     get_settings.cache_clear()
     incomplete_ids = _seed_tracks(missing_energy_index=1)
     with pytest.raises(DesktopSetProposalTransportError) as incomplete:


### PR DESCRIPTION
Supersedes draft PR #131. The original implementation is preserved; this replacement only corrects the repository branch-naming boundary and carries focused CI fixes without force rewrite.

## Summary

Implements Bundle 56B on top of merged Bundle 56 canonical state.

The desktop application can request a bounded, read-only Set Proposal from already-persisted analysis evidence and inspect ranked explainable alternatives without terminal or CSV handoff.

Related issue: #130.

## Exact identity

- base branch: `feature/bundle-0-bootstrap`
- exact base SHA: `32e15a38696839b1e684892611e4f8ce9bd7ce4d`
- head branch: `feature/bundle-56-desktop-set-proposal-transport-inspector-r1`
- exact head SHA: `e26f5583cc20c6dfa3e11c1b7108e72daa0128d2`
- compare: 3 commits ahead / 0 behind / 14 changed files
- merge base equals exact canonical base

## Product flow

```text
renderer selected stable track IDs
  -> set_proposal_generate
  -> trusted Rust host
  -> authenticated packaged sidecar
  -> persisted successful AnalysisEvidence + active correction overlay
  -> path-free MusicDNA
  -> canonical TransitionAssessment
  -> canonical balanced Set Intelligence ranking
  -> canonical bounded beam/lookahead optimizer
  -> Bundle 56 renderer-safe projection
  -> Set Proposal Inspector
```

## Bounds

- selected scope: 3–24 unique stable track IDs
- seed must be inside scope
- target track count: 3–8 and <= selected scope
- one explicit GROOVE preview phase
- neutral hold-current-energy trajectory
- max 3 renderer alternatives
- transient request-local transition adjacency only
- no persistent TransitionAssessment or SequenceState mutation

## Evidence and authority

The transport reads only persisted track metadata, the latest successful/current analysis evidence, and an active correction anchored to that evidence.

It does not open or hash audio, invoke MIR providers, overwrite provider evidence, persist optimizer state, persist a playlist revision, or add a second source of truth.

Regression fixtures deliberately store nonexistent audio paths; successful proposal generation therefore proves the proposal path is evidence-only.

## Security

- one existing packaged `applaylist-sidecar` process boundary remains authoritative
- one authenticated endpoint is added: `POST /v1/set/proposal/generate`
- existing secret + readiness nonce + loopback health/shutdown lifecycle is retained
- renderer has no network/filesystem/shell/sidecar credential authority
- Rust and renderer validate the nested Bundle 56 DTO fail-closed
- filesystem paths, provider internals, AnalysisEvidence IDs, optimizer fingerprints and raw exceptions do not reach the renderer
- `activation_authorized=false`
- `personal_dj_model_training_authorized=false`

## Compatibility fix

Canonical optimizer warnings include three internal human-readable strings while Bundle 56 accepts bounded token codes only. 56B uses an exact allowlisted trusted-side mapping to:

- `bounded_search_pruned_frontier`
- `candidate_duration_evidence_missing`
- `future_feasibility_not_hard_prune_v1`

Unknown optimizer warnings fail closed.

## Verification

Superseded PR #131 provided the first-pass diagnostics on implementation SHA `a11a92db24e08480c1473fdfafe8ee1f2cc55590`:

- Desktop Sidecar Proof: SUCCESS
- Python compile: SUCCESS
- Python critical lint: SUCCESS
- Python 3.12: 391 passed / 1 failed
- sole Python failure was a Bundle 56B correction-lineage assertion and was corrected in `d808a74a126291e27e5170900dbf1cd421f6a40f`
- PR Guard branch naming is corrected by this replacement branch
- `## Bundle Context` metadata requirement is now present
- Rust formatter-only diffs are corrected in `e26f5583cc20c6dfa3e11c1b7108e72daa0128d2`

Required fresh exact-head gates before any merge authorization:

- Python CI 3.11 / 3.12
- full pytest suite
- Bundle 56B transport + authenticated sidecar regressions
- renderer contract tests
- Desktop Sidecar Proof
- Desktop Rust rustfmt/check/test
- PR Guard
- zero unresolved review threads

## Bundle Context

Bundle 56 is already canonical and provides the renderer-safe `SetOptimizerResult` projection. Bundle 56B is the next bounded desktop vertical slice: it connects the existing renderer/Tauri/sidecar trust boundary to canonical evidence-backed Set Intelligence and exposes a read-only Inspector. It does not add playlist editing authority, a new optimizer, a second transition authority, provider execution, or production activation.

The governed dependency remains:

```text
Bundle 56 safe projection
  -> Bundle 56B desktop transport + inspector
  -> later governed accept/reorder/lock/replace revision commands
  -> later interoperability/export slice
```

Human DJ Review remains separately incomplete/deferred and is not converted into Personal DJ Model training data by this bundle.

## Non-scope

- accept/reorder/lock/replace mutations
- playlist revision persistence
- export
- new MIR/provider work
- audio reads
- Human DJ Review completion claim
- Personal DJ Model training
- production optimizer activation
- release/deploy/signing/notarization

`MERGE_AUTHORIZATION=NO`
`RELEASE_AUTHORIZATION=NO`
`DEPLOY_AUTHORIZATION=NO`
`PRODUCTION_EFFECTS=NO`
