### PR TITLE
Bundle 58: governed PlaylistRevision interoperability export R1

### DIFF
--- a/desktop/host-proof/index.html
+++ b/desktop/host-proof/index.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="./set-proposal.css">
   <link rel="stylesheet" href="./playlist-editor.css">
   <script src="./app.js" defer></script>
+  <script src="./playlist-export.js" defer></script>
   <script src="./playlist-editor.js" defer></script>
   <script src="./set-proposal.js" defer></script>
 </head>
@@ -160,6 +161,20 @@
       <div id="playlist-editor-source"></div>
       <div id="playlist-editor-current"></div>
       <div id="playlist-editor-history"></div>
+    </section>
+
+    <section id="playlist-export" aria-labelledby="playlist-export-heading">
+      <h2 id="playlist-export-heading">Playlist Export</h2>
+      <p>Export one explicitly selected immutable revision as UTF-8 M3U8. File paths stay inside the trusted sidecar/Tauri boundary and are never rendered here.</p>
+      <div class="actions">
+        <label for="playlist-export-revision">Revision</label>
+        <select id="playlist-export-revision" disabled></select>
+        <button id="playlist-export-preview" type="button" disabled>Preview export</button>
+        <button id="playlist-export-write" type="button" disabled>Export M3U8…</button>
+      </div>
+      <p id="playlist-export-status" class="status">Accept a Set Proposal revision to enable export.</p>
+      <div id="playlist-export-preview-result"></div>
+      <div id="playlist-export-receipt"></div>
     </section>
   </main>
 </body>

--- a/desktop/host-proof/playlist-export.js
+++ b/desktop/host-proof/playlist-export.js
@@ -1,0 +1,391 @@
+(() => {
+  "use strict";
+
+  const tauriCore = window.__TAURI__?.core;
+  const originalInvoke = tauriCore?.invoke;
+  const section = document.getElementById("playlist-export");
+  const status = document.getElementById("playlist-export-status");
+  const revisionSelect = document.getElementById("playlist-export-revision");
+  const previewButton = document.getElementById("playlist-export-preview");
+  const exportButton = document.getElementById("playlist-export-write");
+  const previewNode = document.getElementById("playlist-export-preview-result");
+  const receiptNode = document.getElementById("playlist-export-receipt");
+
+  if (
+    !section ||
+    !status ||
+    !revisionSelect ||
+    !previewButton ||
+    !exportButton ||
+    !previewNode ||
+    !receiptNode ||
+    typeof originalInvoke !== "function"
+  ) {
+    return;
+  }
+
+  const TOKEN = /^[A-Za-z0-9][A-Za-z0-9_.:+-]{0,255}$/;
+  const OPERATIONS = new Set(["accept", "reorder", "lock", "replace"]);
+  let trustedHistory = null;
+  let trustedPreview = null;
+  let busy = false;
+
+  function exactKeys(value, keys) {
+    if (value === null || typeof value !== "object" || Array.isArray(value)) {
+      return false;
+    }
+    const actual = Object.keys(value).sort();
+    const expected = [...keys].sort();
+    return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+  }
+
+  function validToken(value) {
+    return typeof value === "string" && TOKEN.test(value) && !value.includes("/") && !value.includes("\\");
+  }
+
+  function pathShaped(value) {
+    return value.startsWith("/") || value.startsWith("\\\\") || /^[A-Za-z]:[\\/]/.test(value);
+  }
+
+  function validDisplayName(value) {
+    return (
+      typeof value === "string" &&
+      value.length > 0 &&
+      value.length <= 512 &&
+      value.trim() === value &&
+      !/[\u0000-\u001f\u007f]/.test(value) &&
+      !pathShaped(value)
+    );
+  }
+
+  function validFilename(value) {
+    return (
+      typeof value === "string" &&
+      value.length > 0 &&
+      value.length <= 128 &&
+      value.endsWith(".m3u8") &&
+      value.trim() === value &&
+      !value.includes("/") &&
+      !value.includes("\\") &&
+      !/[\u0000-\u001f\u007f]/.test(value)
+    );
+  }
+
+  function validRevision(value) {
+    if (
+      !exactKeys(value, [
+        "schema",
+        "playlist_id",
+        "revision_id",
+        "parent_revision_id",
+        "revision_index",
+        "source_proposal_id",
+        "source_path_id",
+        "operation",
+        "content_fingerprint",
+        "created_at",
+        "sequence",
+        "personal_dj_model_training_authorized",
+        "production_activation_authorized",
+      ]) ||
+      value.schema !== "applaylist-desktop-playlist-revision-r1" ||
+      !validToken(value.playlist_id) ||
+      !validToken(value.revision_id) ||
+      !(value.parent_revision_id === null || validToken(value.parent_revision_id)) ||
+      !Number.isInteger(value.revision_index) ||
+      value.revision_index < 0 ||
+      !validToken(value.source_proposal_id) ||
+      !validToken(value.source_path_id) ||
+      !OPERATIONS.has(value.operation) ||
+      typeof value.content_fingerprint !== "string" ||
+      !/^[0-9a-f]{64}$/.test(value.content_fingerprint) ||
+      typeof value.created_at !== "string" ||
+      value.created_at.length === 0 ||
+      value.created_at.length > 64 ||
+      !Array.isArray(value.sequence) ||
+      value.sequence.length < 3 ||
+      value.sequence.length > 8 ||
+      value.personal_dj_model_training_authorized !== false ||
+      value.production_activation_authorized !== false
+    ) {
+      return false;
+    }
+    const ids = new Set();
+    return value.sequence.every((item, index) => {
+      if (
+        !exactKeys(item, ["order_index", "track_id", "display_name", "locked"]) ||
+        item.order_index !== index ||
+        !validToken(item.track_id) ||
+        !validDisplayName(item.display_name) ||
+        typeof item.locked !== "boolean" ||
+        ids.has(item.track_id)
+      ) {
+        return false;
+      }
+      ids.add(item.track_id);
+      return true;
+    });
+  }
+
+  function validHistory(value) {
+    if (
+      !exactKeys(value, [
+        "schema",
+        "playlist_id",
+        "current_revision_id",
+        "revisions",
+        "history_truncated",
+        "personal_dj_model_training_authorized",
+        "production_activation_authorized",
+      ]) ||
+      value.schema !== "applaylist-desktop-playlist-history-r1" ||
+      !validToken(value.playlist_id) ||
+      !validToken(value.current_revision_id) ||
+      !Array.isArray(value.revisions) ||
+      value.revisions.length < 1 ||
+      value.revisions.length > 100 ||
+      value.revisions.some((revision) => !validRevision(revision) || revision.playlist_id !== value.playlist_id) ||
+      value.revisions[value.revisions.length - 1].revision_id !== value.current_revision_id ||
+      typeof value.history_truncated !== "boolean" ||
+      value.personal_dj_model_training_authorized !== false ||
+      value.production_activation_authorized !== false
+    ) {
+      return false;
+    }
+    return value.revisions.every(
+      (revision, index) => index === 0 || revision.revision_index === value.revisions[index - 1].revision_index + 1,
+    );
+  }
+
+  function validPreview(value) {
+    if (
+      !exactKeys(value, [
+        "schema",
+        "revision_id",
+        "playlist_id",
+        "revision_index",
+        "format",
+        "suggested_filename",
+        "track_count",
+        "sequence",
+        "personal_dj_model_training_authorized",
+        "production_activation_authorized",
+      ]) ||
+      value.schema !== "applaylist-desktop-playlist-export-preview-r1" ||
+      !validToken(value.revision_id) ||
+      !validToken(value.playlist_id) ||
+      !Number.isInteger(value.revision_index) ||
+      value.revision_index < 0 ||
+      value.format !== "m3u8" ||
+      !validFilename(value.suggested_filename) ||
+      !Number.isInteger(value.track_count) ||
+      value.track_count < 3 ||
+      value.track_count > 8 ||
+      !Array.isArray(value.sequence) ||
+      value.sequence.length !== value.track_count ||
+      value.personal_dj_model_training_authorized !== false ||
+      value.production_activation_authorized !== false
+    ) {
+      return false;
+    }
+    const ids = new Set();
+    return value.sequence.every((item, index) => {
+      if (
+        !exactKeys(item, ["order_index", "track_id", "display_name", "locked"]) ||
+        item.order_index !== index ||
+        !validToken(item.track_id) ||
+        !validDisplayName(item.display_name) ||
+        typeof item.locked !== "boolean" ||
+        ids.has(item.track_id)
+      ) {
+        return false;
+      }
+      ids.add(item.track_id);
+      return true;
+    });
+  }
+
+  function validReceipt(value) {
+    return (
+      exactKeys(value, [
+        "revision_id",
+        "format",
+        "filename",
+        "track_count",
+        "content_sha256",
+        "bytes_written",
+        "personal_dj_model_training_authorized",
+        "production_activation_authorized",
+      ]) &&
+      validToken(value.revision_id) &&
+      value.format === "m3u8" &&
+      validFilename(value.filename) &&
+      Number.isInteger(value.track_count) &&
+      value.track_count >= 3 &&
+      value.track_count <= 8 &&
+      typeof value.content_sha256 === "string" &&
+      /^[0-9a-f]{64}$/.test(value.content_sha256) &&
+      Number.isInteger(value.bytes_written) &&
+      value.bytes_written > 0 &&
+      value.bytes_written <= 131072 &&
+      value.personal_dj_model_training_authorized === false &&
+      value.production_activation_authorized === false
+    );
+  }
+
+  function setStatus(message) {
+    status.textContent = message;
+  }
+
+  function setHistory(history) {
+    trustedHistory = history;
+    trustedPreview = null;
+    revisionSelect.replaceChildren();
+    for (const revision of history.revisions) {
+      const option = document.createElement("option");
+      option.value = revision.revision_id;
+      option.textContent = `#${revision.revision_index} ${revision.operation} · ${revision.revision_id}`;
+      option.selected = revision.revision_id === history.current_revision_id;
+      revisionSelect.appendChild(option);
+    }
+    revisionSelect.disabled = false;
+    previewButton.disabled = false;
+    exportButton.disabled = true;
+    previewNode.replaceChildren();
+    receiptNode.replaceChildren();
+    setStatus("Choose an immutable revision and preview its M3U8 export.");
+  }
+
+  async function observedInvoke(command, args) {
+    const result = await originalInvoke(command, args);
+    if (command === "playlist_editor_history" && validHistory(result)) {
+      setHistory(result);
+    }
+    return result;
+  }
+
+  try {
+    tauriCore.invoke = observedInvoke;
+  } catch (_error) {
+    setStatus("Playlist export history capture is unavailable in this desktop host.");
+    return;
+  }
+  if (tauriCore.invoke !== observedInvoke) {
+    setStatus("Playlist export history capture is unavailable in this desktop host.");
+    return;
+  }
+
+  revisionSelect.addEventListener("change", () => {
+    trustedPreview = null;
+    exportButton.disabled = true;
+    previewNode.replaceChildren();
+    receiptNode.replaceChildren();
+    setStatus("Preview the selected immutable revision before export.");
+  });
+
+  previewButton.addEventListener("click", async () => {
+    if (busy || !trustedHistory || !validToken(revisionSelect.value)) {
+      return;
+    }
+    busy = true;
+    previewButton.disabled = true;
+    exportButton.disabled = true;
+    setStatus("Building renderer-safe export preview…");
+    try {
+      const preview = await originalInvoke("playlist_export_preview", {
+        revisionId: revisionSelect.value,
+      });
+      if (!validPreview(preview) || preview.revision_id !== revisionSelect.value) {
+        throw new Error("Invalid export preview response.");
+      }
+      trustedPreview = preview;
+      renderPreview(preview);
+      exportButton.disabled = false;
+      setStatus("Preview verified. Export writes only after the native save dialog is confirmed.");
+    } catch (_error) {
+      trustedPreview = null;
+      previewNode.replaceChildren();
+      setStatus("The selected revision could not be prepared for export safely.");
+    } finally {
+      busy = false;
+      previewButton.disabled = false;
+    }
+  });
+
+  exportButton.addEventListener("click", async () => {
+    if (
+      busy ||
+      !trustedPreview ||
+      trustedPreview.revision_id !== revisionSelect.value ||
+      !validToken(revisionSelect.value)
+    ) {
+      return;
+    }
+    busy = true;
+    previewButton.disabled = true;
+    exportButton.disabled = true;
+    receiptNode.replaceChildren();
+    setStatus("Choose a new .m3u8 file in the native save dialog…");
+    try {
+      const receipt = await originalInvoke("playlist_export_m3u8", {
+        revisionId: revisionSelect.value,
+      });
+      if (receipt === null) {
+        setStatus("Export canceled. No file was written.");
+        return;
+      }
+      if (!validReceipt(receipt) || receipt.revision_id !== revisionSelect.value) {
+        throw new Error("Invalid export receipt response.");
+      }
+      renderReceipt(receipt);
+      setStatus("M3U8 export completed from the exact immutable revision.");
+    } catch (_error) {
+      setStatus("The export was rejected safely. No successful receipt was produced.");
+    } finally {
+      busy = false;
+      previewButton.disabled = false;
+      exportButton.disabled = trustedPreview === null;
+    }
+  });
+
+  function renderPreview(preview) {
+    previewNode.replaceChildren();
+    const heading = document.createElement("h3");
+    heading.textContent = `Export preview · revision #${preview.revision_index}`;
+    const metadata = document.createElement("p");
+    metadata.textContent = `${preview.format.toUpperCase()} · ${preview.track_count} tracks · ${preview.suggested_filename}`;
+    const list = document.createElement("ol");
+    for (const item of preview.sequence) {
+      const row = document.createElement("li");
+      row.textContent = `${item.display_name}${item.locked ? " · locked" : ""}`;
+      list.appendChild(row);
+    }
+    previewNode.append(heading, metadata, list);
+  }
+
+  function renderReceipt(receipt) {
+    receiptNode.replaceChildren();
+    const heading = document.createElement("h3");
+    heading.textContent = "Export receipt";
+    const list = document.createElement("dl");
+    for (const [label, value] of [
+      ["Revision", receipt.revision_id],
+      ["Format", receipt.format],
+      ["File", receipt.filename],
+      ["Tracks", String(receipt.track_count)],
+      ["Bytes", String(receipt.bytes_written)],
+      ["SHA-256", receipt.content_sha256],
+    ]) {
+      const term = document.createElement("dt");
+      term.textContent = label;
+      const description = document.createElement("dd");
+      description.textContent = value;
+      list.append(term, description);
+    }
+    receiptNode.append(heading, list);
+  }
+
+  revisionSelect.disabled = true;
+  previewButton.disabled = true;
+  exportButton.disabled = true;
+})();

--- a/docs/bundles/BUNDLE_58_PLAYLIST_REVISION_EXPORT_R1.md
+++ b/docs/bundles/BUNDLE_58_PLAYLIST_REVISION_EXPORT_R1.md
@@ -1,0 +1,164 @@
+# Bundle 58 — Governed PlaylistRevision Export R1
+
+## Status
+
+Implementation slice. Merge, release, deploy, production optimizer activation, Personal DJ Model training, vendor database mutation, and cloud upload remain unauthorized.
+
+## Canonical dependency
+
+- base branch: `feature/bundle-0-bootstrap`
+- exact base SHA: `abaf82716f112f2b40193a6b2a181536cd941641`
+- source authority: immutable Bundle 57 `PlaylistRevision`
+
+## User outcome
+
+A DJ can select one exact immutable playlist revision in the desktop shell, inspect a renderer-safe export preview, explicitly choose a destination through the native save dialog, and export a UTF-8 M3U8 file.
+
+No terminal or CSV handoff is required.
+
+## Authority model
+
+```text
+PlaylistRevisionRepository
+  -> exact revision_id
+  -> DesktopPlaylistExportTransport
+      -> preview (renderer-safe)
+      -> material (authenticated/private)
+  -> PlaylistExportBridge
+  -> native save dialog
+  -> bounded atomic local write
+  -> renderer-safe receipt
+```
+
+The revision ledger remains the only playlist revision authority. Export is a read-only projection and never updates or deletes revision rows.
+
+## R1 interoperability format
+
+Generic UTF-8 M3U8 only.
+
+The material contains:
+
+- `#EXTM3U`
+- one `#EXTINF` row per revision item
+- the revision display label
+- the canonical local TrackRecord path
+- exact immutable revision order
+
+The export does not copy, transcode, hash, or read audio bytes.
+
+Vendor-specific rekordbox, Traktor, and Serato database mutation is outside R1.
+
+## Privacy and path boundary
+
+Private filesystem paths are resolved from `TrackRepository` only inside the authenticated sidecar.
+
+The renderer-safe preview contains only:
+
+- revision ID
+- playlist ID
+- revision index
+- `m3u8` format
+- safe suggested filename
+- bounded ordered track IDs/display labels/lock state
+- training/activation flags fixed to false
+
+The private material additionally contains M3U8 text, SHA-256, and byte count. It is consumed by Rust and is never returned by a Tauri renderer command.
+
+The successful renderer receipt contains only:
+
+- revision ID
+- format
+- safe output filename (basename only)
+- track count
+- M3U8 content SHA-256
+- bytes written
+- training/activation flags fixed to false
+
+No output directory or source audio path is returned to JavaScript.
+
+## Native write boundary
+
+`playlist_export_m3u8`:
+
+1. fetches authenticated private material for one explicit revision ID;
+2. validates exact private response shape;
+3. recomputes SHA-256 and byte count;
+4. verifies M3U8 structure and local path existence without reading audio bytes;
+5. opens the native save dialog;
+6. returns `None` on user cancel with no write;
+7. enforces `.m3u8`;
+8. rejects an already-existing target instead of silently overwriting it;
+9. writes a bounded temporary file in the selected directory;
+10. syncs and renames it to the selected target;
+11. returns only a renderer-safe receipt.
+
+## Sidecar routes
+
+Authenticated POST only:
+
+- `/v1/playlist/export/preview`
+- `/v1/playlist/export/material`
+
+Exact request body:
+
+```json
+{"revision_id":"prv_..."}
+```
+
+Unknown fields fail closed.
+
+## Tauri commands
+
+- `playlist_export_preview`
+- `playlist_export_m3u8`
+
+They are isolated in `main-playlist-export` capability.
+
+## Failure model
+
+Fail closed on:
+
+- unknown/missing revision
+- malformed revision sequence
+- missing local TrackRecord
+- relative, unavailable, newline/null/control-character path
+- invalid display content
+- oversized M3U8 material
+- material digest/byte-count mismatch
+- malformed private material
+- invalid target extension/directory
+- existing target
+- write/rename failure
+
+## Explicit non-effects
+
+Every preview/material/receipt keeps:
+
+```text
+personal_dj_model_training_authorized = false
+production_activation_authorized      = false
+```
+
+Bundle 58 does not:
+
+- run MIR providers
+- read/hash audio bytes
+- rerun optimizer or TransitionAssessment
+- mutate PlaylistRevision history
+- train preference models
+- activate production optimization
+- write rekordbox/Traktor/Serato databases
+- upload/sync to cloud
+- release/deploy/sign/notarize the application
+
+## Required merge gates
+
+- exact base/merge-base identity
+- full Python CI 3.11 and 3.12
+- export transport + authenticated sidecar regression tests
+- renderer path/privacy contract tests
+- Desktop Rust rustfmt/check/test
+- Desktop Sidecar Proof on Ubuntu and macOS
+- PR Guard
+- zero unresolved review threads
+- exact-head evidence recorded in PR before merge authorization

--- a/scripts/applaylist_sidecar_entry.py
+++ b/scripts/applaylist_sidecar_entry.py
@@ -1,10 +1,12 @@
 from services.desktop.playlist_editor_sidecar import install_playlist_editor_sidecar
+from services.desktop.playlist_export_sidecar import install_playlist_export_sidecar
 from services.desktop.set_proposal_sidecar import install_set_proposal_sidecar
 from services.desktop.sidecar import main
 
 
 install_set_proposal_sidecar()
 install_playlist_editor_sidecar()
+install_playlist_export_sidecar()
 
 
 if __name__ == "__main__":

--- a/services/desktop/playlist_export_sidecar.py
+++ b/services/desktop/playlist_export_sidecar.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import services.desktop.sidecar as sidecar
+from services.desktop.playlist_export_transport import (
+    DesktopPlaylistExportTransport,
+    DesktopPlaylistExportTransportError,
+)
+
+MAX_PLAYLIST_EXPORT_REQUEST_BYTES = 8 * 1024
+_INSTALLED = False
+
+_ROUTES = {
+    "/v1/playlist/export/preview": "preview",
+    "/v1/playlist/export/material": "material",
+}
+
+_CONFLICT_CODES = {
+    "playlist_export_revision_not_found",
+    "playlist_export_track_missing",
+    "playlist_export_track_unavailable",
+}
+
+
+def install_playlist_export_sidecar() -> None:
+    """Extend the authenticated sidecar with read-only immutable revision export routes."""
+    global _INSTALLED
+    if _INSTALLED:
+        return
+
+    original_handler = sidecar._SidecarRequestHandler
+    original_server = sidecar._SidecarHTTPServer
+
+    class PlaylistExportRequestHandler(original_handler):
+        def do_POST(self) -> None:  # noqa: N802
+            operation = _ROUTES.get(self.path)
+            if operation is None:
+                super().do_POST()
+                return
+            self._handle_playlist_export(operation)
+
+        def _handle_playlist_export(self, operation: str) -> None:
+            if not self._authorized():
+                self._write_json(HTTPStatus.UNAUTHORIZED, {"error": "unauthorized"})
+                return
+            payload = self._read_json_payload(MAX_PLAYLIST_EXPORT_REQUEST_BYTES)
+            if payload is None or set(payload) != {"revision_id"}:
+                self._write_json(
+                    HTTPStatus.BAD_REQUEST,
+                    {"error": "invalid_playlist_export_request"},
+                )
+                return
+            try:
+                method = getattr(self.sidecar_server.playlist_export, operation)
+                result = method(revision_id=payload["revision_id"])
+            except DesktopPlaylistExportTransportError as exc:
+                status = (
+                    HTTPStatus.CONFLICT if exc.code in _CONFLICT_CODES else HTTPStatus.BAD_REQUEST
+                )
+                self._write_json(status, {"error": exc.code})
+                return
+            except Exception:
+                self._write_json(
+                    HTTPStatus.INTERNAL_SERVER_ERROR,
+                    {"error": "playlist_export_operation_failed"},
+                )
+                return
+            self._write_json(HTTPStatus.OK, result)
+
+    sidecar._SidecarRequestHandler = PlaylistExportRequestHandler
+
+    class PlaylistExportHTTPServer(original_server):
+        def __init__(self, startup: sidecar.SidecarStartup) -> None:
+            super().__init__(startup)
+            self.playlist_export = DesktopPlaylistExportTransport()
+
+    sidecar._SidecarHTTPServer = PlaylistExportHTTPServer
+    _INSTALLED = True
+
+
+__all__ = ["MAX_PLAYLIST_EXPORT_REQUEST_BYTES", "install_playlist_export_sidecar"]

--- a/services/desktop/playlist_export_transport.py
+++ b/services/desktop/playlist_export_transport.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from data.repositories.playlist_revision_repository import PlaylistRevisionRepository
+from data.repositories.track_repository import TrackRepository
+
+_MAX_EXPORT_BYTES = 128 * 1024
+_FORMAT = "m3u8"
+_PREVIEW_SCHEMA = "applaylist-desktop-playlist-export-preview-r1"
+_MATERIAL_SCHEMA = "applaylist-desktop-playlist-export-material-r1"
+
+
+class DesktopPlaylistExportTransportError(ValueError):
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+class DesktopPlaylistExportTransport:
+    """Read-only export projection over one exact immutable PlaylistRevision."""
+
+    def __init__(
+        self,
+        *,
+        revisions: PlaylistRevisionRepository | None = None,
+        tracks: TrackRepository | None = None,
+    ) -> None:
+        self.revisions = revisions or PlaylistRevisionRepository()
+        self.tracks = tracks or TrackRepository()
+
+    def preview(self, *, revision_id: str) -> dict[str, object]:
+        revision = self._revision(revision_id)
+        items = self._items(revision)
+        return {
+            "schema": _PREVIEW_SCHEMA,
+            "revision_id": revision["revision_id"],
+            "playlist_id": revision["playlist_id"],
+            "revision_index": revision["revision_index"],
+            "format": _FORMAT,
+            "suggested_filename": self._suggested_filename(str(revision["revision_id"])),
+            "track_count": len(items),
+            "sequence": tuple(
+                {
+                    "order_index": int(item["order_index"]),
+                    "track_id": str(item["track_id"]),
+                    "display_name": str(item["display_name"]),
+                    "locked": bool(item["locked"]),
+                }
+                for item in items
+            ),
+            "personal_dj_model_training_authorized": False,
+            "production_activation_authorized": False,
+        }
+
+    def material(self, *, revision_id: str) -> dict[str, object]:
+        revision = self._revision(revision_id)
+        items = self._items(revision)
+        lines = ["#EXTM3U"]
+        for item in items:
+            track_id = str(item["track_id"])
+            display_name = self._line_value(str(item["display_name"]), "display name")
+            record = self.tracks.get_by_id(track_id)
+            if record is None:
+                raise DesktopPlaylistExportTransportError(
+                    "playlist_export_track_missing",
+                    "A revision track is not present in the local track registry.",
+                )
+            canonical_path = self._canonical_track_path(record.path)
+            duration = -1
+            if record.duration_seconds is not None and record.duration_seconds >= 0:
+                duration = int(round(record.duration_seconds))
+            lines.append(f"#EXTINF:{duration},{display_name}")
+            lines.append(canonical_path)
+        content = "\n".join(lines) + "\n"
+        encoded = content.encode("utf-8")
+        if len(encoded) > _MAX_EXPORT_BYTES:
+            raise DesktopPlaylistExportTransportError(
+                "playlist_export_too_large",
+                "The export exceeds the bounded M3U8 size limit.",
+            )
+        digest = hashlib.sha256(encoded).hexdigest()
+        return {
+            "schema": _MATERIAL_SCHEMA,
+            "revision_id": revision["revision_id"],
+            "playlist_id": revision["playlist_id"],
+            "revision_index": revision["revision_index"],
+            "format": _FORMAT,
+            "suggested_filename": self._suggested_filename(str(revision["revision_id"])),
+            "track_count": len(items),
+            "content_utf8": content,
+            "content_sha256": digest,
+            "byte_count": len(encoded),
+            "personal_dj_model_training_authorized": False,
+            "production_activation_authorized": False,
+        }
+
+    def _revision(self, revision_id: str) -> dict[str, object]:
+        token = self._token(revision_id)
+        revision = self.revisions.get_revision(token)
+        if revision is None:
+            raise DesktopPlaylistExportTransportError(
+                "playlist_export_revision_not_found",
+                "The requested immutable playlist revision was not found.",
+            )
+        if revision.get("personal_dj_model_training_authorized") is not False:
+            raise DesktopPlaylistExportTransportError(
+                "playlist_export_revision_invalid",
+                "The revision training boundary is invalid.",
+            )
+        if revision.get("production_activation_authorized") is not False:
+            raise DesktopPlaylistExportTransportError(
+                "playlist_export_revision_invalid",
+                "The revision activation boundary is invalid.",
+            )
+        return revision
+
+    @staticmethod
+    def _items(revision: dict[str, object]) -> tuple[dict[str, object], ...]:
+        raw = revision.get("items")
+        if not isinstance(raw, (tuple, list)) or not 3 <= len(raw) <= 8:
+            raise DesktopPlaylistExportTransportError(
+                "playlist_export_revision_invalid",
+                "The revision sequence is invalid.",
+            )
+        result: list[dict[str, object]] = []
+        for index, item in enumerate(raw):
+            if not isinstance(item, dict) or set(item) != {
+                "order_index",
+                "track_id",
+                "display_name",
+                "locked",
+            }:
+                raise DesktopPlaylistExportTransportError(
+                    "playlist_export_revision_invalid",
+                    "The revision sequence is invalid.",
+                )
+            if item["order_index"] != index:
+                raise DesktopPlaylistExportTransportError(
+                    "playlist_export_revision_invalid",
+                    "The revision order is invalid.",
+                )
+            result.append(item)
+        return tuple(result)
+
+    @staticmethod
+    def _token(value: str) -> str:
+        if not isinstance(value, str) or not value or value.strip() != value or len(value) > 256:
+            raise DesktopPlaylistExportTransportError(
+                "invalid_playlist_export_request",
+                "The export revision identity is invalid.",
+            )
+        if "/" in value or "\\" in value or any(ch.isspace() or ord(ch) < 32 for ch in value):
+            raise DesktopPlaylistExportTransportError(
+                "invalid_playlist_export_request",
+                "The export revision identity is invalid.",
+            )
+        return value
+
+    @classmethod
+    def _canonical_track_path(cls, raw_path: str) -> str:
+        value = cls._line_value(raw_path, "track path")
+        candidate = Path(value)
+        if not candidate.is_absolute():
+            raise DesktopPlaylistExportTransportError(
+                "playlist_export_track_path_invalid",
+                "A revision track path is not absolute.",
+            )
+        try:
+            canonical = candidate.resolve(strict=True)
+        except (OSError, RuntimeError) as exc:
+            raise DesktopPlaylistExportTransportError(
+                "playlist_export_track_unavailable",
+                "A revision track file is unavailable.",
+            ) from exc
+        if not canonical.is_file():
+            raise DesktopPlaylistExportTransportError(
+                "playlist_export_track_unavailable",
+                "A revision track file is unavailable.",
+            )
+        return cls._line_value(str(canonical), "canonical track path")
+
+    @staticmethod
+    def _line_value(value: str, label: str) -> str:
+        if not isinstance(value, str) or not value or len(value) > 4096:
+            raise DesktopPlaylistExportTransportError(
+                "playlist_export_content_invalid",
+                f"The {label} is invalid.",
+            )
+        if "\r" in value or "\n" in value or "\x00" in value:
+            raise DesktopPlaylistExportTransportError(
+                "playlist_export_content_invalid",
+                f"The {label} contains a forbidden line break or null byte.",
+            )
+        if any(ord(ch) < 32 or ord(ch) == 127 for ch in value):
+            raise DesktopPlaylistExportTransportError(
+                "playlist_export_content_invalid",
+                f"The {label} contains a forbidden control character.",
+            )
+        return value
+
+    @staticmethod
+    def _suggested_filename(revision_id: str) -> str:
+        safe = "".join(ch for ch in revision_id if ch.isascii() and (ch.isalnum() or ch in "_-"))
+        if not safe:
+            safe = "playlist-revision"
+        return f"APPLAYLIST_{safe[:96]}.m3u8"
+
+
+__all__ = [
+    "DesktopPlaylistExportTransport",
+    "DesktopPlaylistExportTransportError",
+]

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -18,6 +18,8 @@ fn main() {
             "playlist_editor_lock",
             "playlist_editor_replace",
             "playlist_editor_history",
+            "playlist_export_preview",
+            "playlist_export_m3u8",
         ]),
     ))
     .expect("failed to configure APPLAYLIST desktop host build");

--- a/src-tauri/capabilities/main-playlist-export.json
+++ b/src-tauri/capabilities/main-playlist-export.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "main-playlist-export",
+  "description": "Allow the local main window to preview and explicitly export one immutable APPLAYLIST playlist revision as M3U8.",
+  "local": true,
+  "windows": [
+    "main"
+  ],
+  "platforms": [
+    "macOS"
+  ],
+  "permissions": [
+    "allow-playlist-export-preview",
+    "allow-playlist-export-m3u8"
+  ]
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod analysis_job;
 mod import_job;
 mod library_capability;
 mod playlist_editor;
+mod playlist_export;
 mod set_proposal;
 mod sidecar_bridge;
 
@@ -11,6 +12,7 @@ use analysis_job::AnalysisJobRegistry;
 use import_job::ImportJobRegistry;
 use library_capability::LibraryCapabilityRegistry;
 use playlist_editor::PlaylistEditorBridge;
+use playlist_export::PlaylistExportBridge;
 use set_proposal::SetProposalBridge;
 use sidecar_bridge::SidecarBridge;
 
@@ -25,6 +27,7 @@ pub fn run() {
         .manage(AnalysisSidecarBridge::from_environment())
         .manage(SetProposalBridge::from_environment())
         .manage(PlaylistEditorBridge::from_environment())
+        .manage(PlaylistExportBridge::from_environment())
         .invoke_handler(tauri::generate_handler![
             library_capability::library_choose_root,
             import_job::library_import_start,
@@ -42,7 +45,9 @@ pub fn run() {
             playlist_editor::playlist_editor_reorder,
             playlist_editor::playlist_editor_lock,
             playlist_editor::playlist_editor_replace,
-            playlist_editor::playlist_editor_history
+            playlist_editor::playlist_editor_history,
+            playlist_export::playlist_export_preview,
+            playlist_export::playlist_export_m3u8
         ])
         .run(tauri::generate_context!())
         .expect("error while running APPLAYLIST desktop host");

--- a/src-tauri/src/playlist_export.rs
+++ b/src-tauri/src/playlist_export.rs
@@ -1,0 +1,817 @@
+use std::{
+    env,
+    fs::{self, OpenOptions},
+    io::{Read, Write},
+    net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream},
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    sync::mpsc,
+    thread,
+    time::{Duration, Instant},
+};
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use tauri::{AppHandle, Manager, State};
+use tauri_plugin_dialog::DialogExt;
+use uuid::Uuid;
+
+use crate::library_capability::DesktopHostError;
+
+const SIDECAR_EXECUTABLE_ENV: &str = "APPLAYLIST_DESKTOP_SIDECAR_EXECUTABLE";
+const BUNDLED_SIDECAR_RESOURCE: &str = "applaylist-sidecar/applaylist-sidecar";
+const PROTOCOL_VERSION: &str = "applaylist-sidecar-v1";
+const SECRET_HEADER: &str = "X-APPLAYLIST-Sidecar-Secret";
+const NONCE_HEADER: &str = "X-APPLAYLIST-Readiness-Nonce";
+const READY_TIMEOUT: Duration = Duration::from_secs(5);
+const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_READY_BYTES: usize = 8_192;
+const MAX_HTTP_RESPONSE_BYTES: u64 = 4 * 1024 * 1024;
+const MAX_EXPORT_BYTES: usize = 128 * 1024;
+const MAX_TOKEN: usize = 256;
+
+#[derive(Debug, Clone)]
+pub struct PlaylistExportBridge {
+    executable: Option<PathBuf>,
+}
+
+impl PlaylistExportBridge {
+    pub fn from_environment() -> Self {
+        Self {
+            executable: if cfg!(debug_assertions) {
+                env::var_os(SIDECAR_EXECUTABLE_ENV).map(PathBuf::from)
+            } else {
+                None
+            },
+        }
+    }
+
+    fn executable(&self, resource_dir: Option<&Path>) -> Result<PathBuf, ExportError> {
+        if let Some(path) = self.executable.as_ref() {
+            let canonical = path
+                .canonicalize()
+                .map_err(|_| ExportError::unavailable())?;
+            return canonical
+                .is_file()
+                .then_some(canonical)
+                .ok_or_else(ExportError::unavailable);
+        }
+        let root = resource_dir.ok_or_else(ExportError::not_configured)?;
+        let root = root
+            .canonicalize()
+            .map_err(|_| ExportError::unavailable())?;
+        let binary = root
+            .join(BUNDLED_SIDECAR_RESOURCE)
+            .canonicalize()
+            .map_err(|_| ExportError::unavailable())?;
+        if !binary.starts_with(&root) || !binary.is_file() {
+            return Err(ExportError::unavailable());
+        }
+        Ok(binary)
+    }
+
+    fn request(
+        &self,
+        path: &str,
+        revision_id: &str,
+        resource_dir: Option<&Path>,
+    ) -> Result<Vec<u8>, ExportError> {
+        let executable = self.executable(resource_dir)?;
+        let mut session = Session::connect(&executable)?;
+        let body = serde_json::to_vec(&json!({"revision_id": revision_id}))
+            .map_err(|_| ExportError::request_failed())?;
+        let response = session.post(path, &body);
+        session.shutdown();
+        let (status, bytes) = response?;
+        if status != 200 {
+            let code = serde_json::from_slice::<serde_json::Value>(&bytes)
+                .ok()
+                .and_then(|value| {
+                    value
+                        .get("error")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_owned)
+                });
+            return Err(ExportError::rejected(code.as_deref()));
+        }
+        Ok(bytes)
+    }
+}
+
+impl Default for PlaylistExportBridge {
+    fn default() -> Self {
+        Self::from_environment()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ExportError {
+    code: &'static str,
+    message: &'static str,
+}
+
+impl ExportError {
+    const fn new(code: &'static str, message: &'static str) -> Self {
+        Self { code, message }
+    }
+    const fn not_configured() -> Self {
+        Self::new(
+            "desktop_playlist_export_sidecar_not_configured",
+            "The playlist export service is not configured.",
+        )
+    }
+    const fn unavailable() -> Self {
+        Self::new(
+            "desktop_playlist_export_sidecar_unavailable",
+            "The playlist export service is unavailable.",
+        )
+    }
+    const fn startup_failed() -> Self {
+        Self::new(
+            "desktop_playlist_export_sidecar_startup_failed",
+            "The playlist export service could not start.",
+        )
+    }
+    const fn readiness_failed() -> Self {
+        Self::new(
+            "desktop_playlist_export_sidecar_readiness_failed",
+            "The playlist export service did not become ready.",
+        )
+    }
+    const fn request_failed() -> Self {
+        Self::new(
+            "desktop_playlist_export_request_failed",
+            "The playlist export request failed.",
+        )
+    }
+    const fn invalid_request() -> Self {
+        Self::new(
+            "invalid_playlist_export_request",
+            "The playlist export request is invalid.",
+        )
+    }
+    const fn invalid_response() -> Self {
+        Self::new(
+            "desktop_playlist_export_response_invalid",
+            "The playlist export response is invalid.",
+        )
+    }
+    const fn invalid_target() -> Self {
+        Self::new(
+            "playlist_export_target_invalid",
+            "The selected export target is invalid.",
+        )
+    }
+    const fn target_exists() -> Self {
+        Self::new(
+            "playlist_export_target_exists",
+            "The selected export target already exists; choose a new file name.",
+        )
+    }
+    const fn write_failed() -> Self {
+        Self::new(
+            "playlist_export_write_failed",
+            "The playlist export file could not be written.",
+        )
+    }
+    fn rejected(code: Option<&str>) -> Self {
+        match code {
+            Some("playlist_export_revision_not_found") => Self::new(
+                "playlist_export_revision_not_found",
+                "The selected playlist revision was not found.",
+            ),
+            Some("playlist_export_track_missing") => Self::new(
+                "playlist_export_track_missing",
+                "A revision track is missing from the local track registry.",
+            ),
+            Some("playlist_export_track_unavailable") => Self::new(
+                "playlist_export_track_unavailable",
+                "A revision track file is unavailable.",
+            ),
+            Some("playlist_export_track_path_invalid") => Self::new(
+                "playlist_export_track_path_invalid",
+                "A revision track path is invalid.",
+            ),
+            Some("playlist_export_content_invalid") => Self::new(
+                "playlist_export_content_invalid",
+                "The export material contains invalid content.",
+            ),
+            Some("playlist_export_too_large") => Self::new(
+                "playlist_export_too_large",
+                "The export exceeds the bounded size limit.",
+            ),
+            Some("invalid_playlist_export_request") => Self::invalid_request(),
+            _ => Self::new(
+                "desktop_playlist_export_rejected",
+                "The playlist export request was rejected.",
+            ),
+        }
+    }
+}
+
+impl From<ExportError> for DesktopHostError {
+    fn from(value: ExportError) -> Self {
+        DesktopHostError::new(value.code, value.message)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExportSequenceItem {
+    order_index: usize,
+    track_id: String,
+    display_name: String,
+    locked: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlaylistExportPreview {
+    schema: String,
+    revision_id: String,
+    playlist_id: String,
+    revision_index: usize,
+    format: String,
+    suggested_filename: String,
+    track_count: usize,
+    sequence: Vec<ExportSequenceItem>,
+    personal_dj_model_training_authorized: bool,
+    production_activation_authorized: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PlaylistExportMaterial {
+    schema: String,
+    revision_id: String,
+    playlist_id: String,
+    revision_index: usize,
+    format: String,
+    suggested_filename: String,
+    track_count: usize,
+    content_utf8: String,
+    content_sha256: String,
+    byte_count: usize,
+    personal_dj_model_training_authorized: bool,
+    production_activation_authorized: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct PlaylistExportReceipt {
+    revision_id: String,
+    format: String,
+    filename: String,
+    track_count: usize,
+    content_sha256: String,
+    bytes_written: usize,
+    personal_dj_model_training_authorized: bool,
+    production_activation_authorized: bool,
+}
+
+struct Session {
+    child: Child,
+    port: u16,
+    secret: String,
+    nonce: String,
+}
+
+impl Session {
+    fn connect(executable: &Path) -> Result<Self, ExportError> {
+        let secret = random_token();
+        let nonce = random_token();
+        let mut child = Command::new(executable)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|_| ExportError::startup_failed())?;
+        let envelope = serde_json::to_vec(&json!({
+            "protocol": PROTOCOL_VERSION,
+            "secret": secret,
+            "nonce": nonce
+        }))
+        .map_err(|_| ExportError::startup_failed())?;
+        let mut stdin = child.stdin.take().ok_or_else(ExportError::startup_failed)?;
+        stdin
+            .write_all(&envelope)
+            .and_then(|_| stdin.write_all(b"\n"))
+            .and_then(|_| stdin.flush())
+            .map_err(|_| ExportError::startup_failed())?;
+        drop(stdin);
+        let line = read_ready(&mut child)?;
+        let ready: serde_json::Value =
+            serde_json::from_slice(&line).map_err(|_| ExportError::readiness_failed())?;
+        let port = validate_ready(&ready, &nonce)?;
+        let (status, health) = request_json(port, "GET", "/v1/health", &secret, &nonce, None)?;
+        if status != 200 {
+            return Err(ExportError::readiness_failed());
+        }
+        let health: serde_json::Value =
+            serde_json::from_slice(&health).map_err(|_| ExportError::readiness_failed())?;
+        let nonce_hash = sha256_hex(nonce.as_bytes());
+        if health.get("status").and_then(serde_json::Value::as_str) != Some("ready")
+            || health.get("protocol").and_then(serde_json::Value::as_str) != Some(PROTOCOL_VERSION)
+            || health.get("nonce_sha256").and_then(serde_json::Value::as_str)
+                != Some(nonce_hash.as_str())
+        {
+            return Err(ExportError::readiness_failed());
+        }
+        Ok(Self {
+            child,
+            port,
+            secret,
+            nonce,
+        })
+    }
+
+    fn post(&mut self, path: &str, body: &[u8]) -> Result<(u16, Vec<u8>), ExportError> {
+        request_json(
+            self.port,
+            "POST",
+            path,
+            &self.secret,
+            &self.nonce,
+            Some(body),
+        )
+    }
+
+    fn shutdown(&mut self) {
+        let _ = request_json(
+            self.port,
+            "POST",
+            "/v1/shutdown",
+            &self.secret,
+            &self.nonce,
+            Some(&[]),
+        );
+        let deadline = Instant::now() + SHUTDOWN_TIMEOUT;
+        while Instant::now() < deadline {
+            match self.child.try_wait() {
+                Ok(Some(_)) => return,
+                Ok(None) => thread::sleep(Duration::from_millis(25)),
+                Err(_) => break,
+            }
+        }
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        if matches!(self.child.try_wait(), Ok(None)) {
+            let _ = self.child.kill();
+        }
+        let _ = self.child.wait();
+    }
+}
+
+fn read_ready(child: &mut Child) -> Result<Vec<u8>, ExportError> {
+    let mut stdout = child
+        .stdout
+        .take()
+        .ok_or_else(ExportError::readiness_failed)?;
+    let (sender, receiver) = mpsc::sync_channel(1);
+    thread::spawn(move || {
+        let mut line = Vec::new();
+        let result = (|| -> std::io::Result<Vec<u8>> {
+            for _ in 0..=MAX_READY_BYTES {
+                let mut byte = [0_u8; 1];
+                if stdout.read(&mut byte)? == 0 {
+                    break;
+                }
+                if byte[0] == b'\n' {
+                    return Ok(line);
+                }
+                line.push(byte[0]);
+            }
+            Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "invalid readiness line",
+            ))
+        })();
+        let _ = sender.send(result);
+    });
+    receiver
+        .recv_timeout(READY_TIMEOUT)
+        .map_err(|_| ExportError::readiness_failed())?
+        .map_err(|_| ExportError::readiness_failed())
+}
+
+fn validate_ready(value: &serde_json::Value, nonce: &str) -> Result<u16, ExportError> {
+    let nonce_hash = sha256_hex(nonce.as_bytes());
+    if value.get("event").and_then(serde_json::Value::as_str) != Some("ready")
+        || value.get("protocol").and_then(serde_json::Value::as_str) != Some(PROTOCOL_VERSION)
+        || value.get("host").and_then(serde_json::Value::as_str) != Some("127.0.0.1")
+        || value.get("nonce_sha256").and_then(serde_json::Value::as_str)
+            != Some(nonce_hash.as_str())
+        || value
+            .get("process_id")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0)
+            == 0
+    {
+        return Err(ExportError::readiness_failed());
+    }
+    value
+        .get("port")
+        .and_then(serde_json::Value::as_u64)
+        .filter(|port| (1..=u16::MAX as u64).contains(port))
+        .map(|port| port as u16)
+        .ok_or_else(ExportError::readiness_failed)
+}
+
+fn request_json(
+    port: u16,
+    method: &str,
+    path: &str,
+    secret: &str,
+    nonce: &str,
+    body: Option<&[u8]>,
+) -> Result<(u16, Vec<u8>), ExportError> {
+    let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+    let mut stream = TcpStream::connect_timeout(&address, HTTP_TIMEOUT)
+        .map_err(|_| ExportError::request_failed())?;
+    stream
+        .set_read_timeout(Some(HTTP_TIMEOUT))
+        .map_err(|_| ExportError::request_failed())?;
+    stream
+        .set_write_timeout(Some(HTTP_TIMEOUT))
+        .map_err(|_| ExportError::request_failed())?;
+    let payload = body.unwrap_or(&[]);
+    let content_type = if body.is_some() {
+        "Content-Type: application/json\r\n"
+    } else {
+        ""
+    };
+    let request = format!(
+        "{method} {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\n{SECRET_HEADER}: {secret}\r\n{NONCE_HEADER}: {nonce}\r\n{content_type}Content-Length: {}\r\n\r\n",
+        payload.len()
+    );
+    stream
+        .write_all(request.as_bytes())
+        .and_then(|_| stream.write_all(payload))
+        .and_then(|_| stream.flush())
+        .map_err(|_| ExportError::request_failed())?;
+    let mut response = Vec::new();
+    stream
+        .take(MAX_HTTP_RESPONSE_BYTES + 1)
+        .read_to_end(&mut response)
+        .map_err(|_| ExportError::request_failed())?;
+    if response.len() as u64 > MAX_HTTP_RESPONSE_BYTES {
+        return Err(ExportError::request_failed());
+    }
+    let boundary = response
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .ok_or_else(ExportError::request_failed)?;
+    let headers =
+        std::str::from_utf8(&response[..boundary]).map_err(|_| ExportError::request_failed())?;
+    let mut lines = headers.split("\r\n");
+    let mut parts = lines
+        .next()
+        .ok_or_else(ExportError::request_failed)?
+        .split_whitespace();
+    if parts.next() != Some("HTTP/1.1") {
+        return Err(ExportError::request_failed());
+    }
+    let status = parts
+        .next()
+        .and_then(|value| value.parse::<u16>().ok())
+        .ok_or_else(ExportError::request_failed)?;
+    let mut length = None;
+    for line in lines {
+        let Some((name, value)) = line.split_once(':') else {
+            return Err(ExportError::request_failed());
+        };
+        if name.eq_ignore_ascii_case("Content-Length") {
+            length = value.trim().parse::<usize>().ok();
+        }
+    }
+    let body = &response[boundary + 4..];
+    if length != Some(body.len()) {
+        return Err(ExportError::request_failed());
+    }
+    Ok((status, body.to_vec()))
+}
+
+fn random_token() -> String {
+    format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple())
+}
+
+fn sha256_hex(value: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(value))
+}
+
+fn token(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_TOKEN
+        && value.trim() == value
+        && !value.contains('/')
+        && !value.contains('\\')
+        && !value.chars().any(char::is_whitespace)
+        && !value.chars().any(char::is_control)
+}
+
+fn display(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 512
+        && value.trim() == value
+        && !value.chars().any(char::is_control)
+        && !value.starts_with('/')
+        && !value.starts_with("\\\\")
+        && !(value.len() >= 3
+            && value.as_bytes()[0].is_ascii_alphabetic()
+            && value.as_bytes()[1] == b':'
+            && matches!(value.as_bytes()[2], b'/' | b'\\'))
+}
+
+fn safe_filename(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 128
+        && value.ends_with(".m3u8")
+        && value.trim() == value
+        && !value.contains('/')
+        && !value.contains('\\')
+        && !value.chars().any(char::is_control)
+}
+
+fn digest(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn validate_preview(value: &PlaylistExportPreview) -> Result<(), ExportError> {
+    if value.schema != "applaylist-desktop-playlist-export-preview-r1"
+        || !token(&value.revision_id)
+        || !token(&value.playlist_id)
+        || value.format != "m3u8"
+        || !safe_filename(&value.suggested_filename)
+        || !(3..=8).contains(&value.track_count)
+        || value.track_count != value.sequence.len()
+        || value.personal_dj_model_training_authorized
+        || value.production_activation_authorized
+    {
+        return Err(ExportError::invalid_response());
+    }
+    for (position, item) in value.sequence.iter().enumerate() {
+        if item.order_index != position || !token(&item.track_id) || !display(&item.display_name) {
+            return Err(ExportError::invalid_response());
+        }
+    }
+    Ok(())
+}
+
+fn validate_material(value: &PlaylistExportMaterial) -> Result<(), ExportError> {
+    if value.schema != "applaylist-desktop-playlist-export-material-r1"
+        || !token(&value.revision_id)
+        || !token(&value.playlist_id)
+        || value.format != "m3u8"
+        || !safe_filename(&value.suggested_filename)
+        || !(3..=8).contains(&value.track_count)
+        || value.personal_dj_model_training_authorized
+        || value.production_activation_authorized
+        || value.byte_count == 0
+        || value.byte_count > MAX_EXPORT_BYTES
+        || value.content_utf8.as_bytes().len() != value.byte_count
+        || !digest(&value.content_sha256)
+        || sha256_hex(value.content_utf8.as_bytes()) != value.content_sha256
+    {
+        return Err(ExportError::invalid_response());
+    }
+    let lines: Vec<&str> = value.content_utf8.lines().collect();
+    if lines.first().copied() != Some("#EXTM3U") || lines.len() != 1 + value.track_count * 2 {
+        return Err(ExportError::invalid_response());
+    }
+    for pair in lines[1..].chunks_exact(2) {
+        if !pair[0].starts_with("#EXTINF:")
+            || pair[0].chars().any(char::is_control)
+            || pair[1].is_empty()
+            || !Path::new(pair[1]).is_absolute()
+            || !Path::new(pair[1]).is_file()
+            || pair[1].chars().any(char::is_control)
+        {
+            return Err(ExportError::invalid_response());
+        }
+    }
+    Ok(())
+}
+
+fn normalize_target(mut target: PathBuf) -> Result<PathBuf, ExportError> {
+    let extension = target.extension().and_then(|value| value.to_str());
+    match extension {
+        None => {
+            target.set_extension("m3u8");
+        }
+        Some(value) if value.eq_ignore_ascii_case("m3u8") => {}
+        Some(_) => return Err(ExportError::invalid_target()),
+    }
+    let parent = target.parent().ok_or_else(ExportError::invalid_target)?;
+    if !parent.is_dir() || target.file_name().and_then(|value| value.to_str()).is_none() {
+        return Err(ExportError::invalid_target());
+    }
+    if target.exists() {
+        return Err(ExportError::target_exists());
+    }
+    Ok(target)
+}
+
+fn write_atomic(target: &Path, content: &[u8]) -> Result<(), ExportError> {
+    let parent = target.parent().ok_or_else(ExportError::invalid_target)?;
+    let temporary = parent.join(format!(
+        ".applaylist-export-{}.tmp",
+        Uuid::new_v4().simple()
+    ));
+    let result = (|| -> std::io::Result<()> {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)?;
+        file.write_all(content)?;
+        file.sync_all()?;
+        drop(file);
+        fs::rename(&temporary, target)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+        return Err(ExportError::write_failed());
+    }
+    Ok(())
+}
+
+async fn request_bytes(
+    bridge: State<'_, PlaylistExportBridge>,
+    app: &AppHandle,
+    path: &'static str,
+    revision_id: String,
+) -> Result<Vec<u8>, DesktopHostError> {
+    if !token(&revision_id) {
+        return Err(ExportError::invalid_request().into());
+    }
+    let resource_dir = app.path().resource_dir().ok();
+    let bridge = bridge.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        bridge.request(path, &revision_id, resource_dir.as_deref())
+    })
+    .await
+    .map_err(|_| {
+        DesktopHostError::new(
+            "desktop_playlist_export_task_failed",
+            "The playlist export task failed.",
+        )
+    })?
+    .map_err(DesktopHostError::from)
+}
+
+#[tauri::command]
+pub async fn playlist_export_preview(
+    revision_id: String,
+    bridge: State<'_, PlaylistExportBridge>,
+    app: AppHandle,
+) -> Result<PlaylistExportPreview, DesktopHostError> {
+    let bytes = request_bytes(
+        bridge,
+        &app,
+        "/v1/playlist/export/preview",
+        revision_id,
+    )
+    .await?;
+    let preview: PlaylistExportPreview =
+        serde_json::from_slice(&bytes).map_err(|_| ExportError::invalid_response())?;
+    validate_preview(&preview).map_err(DesktopHostError::from)?;
+    Ok(preview)
+}
+
+#[tauri::command]
+pub async fn playlist_export_m3u8(
+    revision_id: String,
+    bridge: State<'_, PlaylistExportBridge>,
+    app: AppHandle,
+) -> Result<Option<PlaylistExportReceipt>, DesktopHostError> {
+    let bytes = request_bytes(
+        bridge,
+        &app,
+        "/v1/playlist/export/material",
+        revision_id,
+    )
+    .await?;
+    let material: PlaylistExportMaterial =
+        serde_json::from_slice(&bytes).map_err(|_| ExportError::invalid_response())?;
+    validate_material(&material).map_err(DesktopHostError::from)?;
+
+    let Some(selected) = app
+        .dialog()
+        .file()
+        .set_file_name(&material.suggested_filename)
+        .add_filter("M3U8 playlist", &["m3u8"])
+        .blocking_save_file()
+    else {
+        return Ok(None);
+    };
+    let selected_path = selected
+        .into_path()
+        .map_err(|_| DesktopHostError::from(ExportError::invalid_target()))?;
+    let target = normalize_target(selected_path).map_err(DesktopHostError::from)?;
+    write_atomic(&target, material.content_utf8.as_bytes()).map_err(DesktopHostError::from)?;
+    let filename = target
+        .file_name()
+        .and_then(|value| value.to_str())
+        .filter(|value| safe_filename(value))
+        .ok_or_else(|| DesktopHostError::from(ExportError::invalid_target()))?
+        .to_owned();
+
+    Ok(Some(PlaylistExportReceipt {
+        revision_id: material.revision_id,
+        format: material.format,
+        filename,
+        track_count: material.track_count,
+        content_sha256: material.content_sha256,
+        bytes_written: material.byte_count,
+        personal_dj_model_training_authorized: false,
+        production_activation_authorized: false,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preview_validation_rejects_path_leakage_and_authority_escalation() {
+        let valid = serde_json::from_value::<PlaylistExportPreview>(json!({
+            "schema":"applaylist-desktop-playlist-export-preview-r1",
+            "revision_id":"prv_abc",
+            "playlist_id":"plr_abc",
+            "revision_index":2,
+            "format":"m3u8",
+            "suggested_filename":"APPLAYLIST_prv_abc.m3u8",
+            "track_count":3,
+            "sequence":[
+                {"order_index":0,"track_id":"track:a","display_name":"A","locked":false},
+                {"order_index":1,"track_id":"track:b","display_name":"B","locked":true},
+                {"order_index":2,"track_id":"track:c","display_name":"C","locked":false}
+            ],
+            "personal_dj_model_training_authorized":false,
+            "production_activation_authorized":false
+        }))
+        .expect("valid preview");
+        assert!(validate_preview(&valid).is_ok());
+
+        let escalated = serde_json::from_value::<PlaylistExportPreview>(json!({
+            "schema":"applaylist-desktop-playlist-export-preview-r1",
+            "revision_id":"prv_abc",
+            "playlist_id":"plr_abc",
+            "revision_index":2,
+            "format":"m3u8",
+            "suggested_filename":"APPLAYLIST_prv_abc.m3u8",
+            "track_count":3,
+            "sequence":[
+                {"order_index":0,"track_id":"track:a","display_name":"A","locked":false},
+                {"order_index":1,"track_id":"track:b","display_name":"B","locked":true},
+                {"order_index":2,"track_id":"track:c","display_name":"C","locked":false}
+            ],
+            "personal_dj_model_training_authorized":false,
+            "production_activation_authorized":true
+        }))
+        .expect("shape valid");
+        assert!(validate_preview(&escalated).is_err());
+
+        assert!(serde_json::from_value::<PlaylistExportPreview>(json!({
+            "schema":"applaylist-desktop-playlist-export-preview-r1",
+            "revision_id":"prv_abc",
+            "playlist_id":"plr_abc",
+            "revision_index":2,
+            "format":"m3u8",
+            "suggested_filename":"APPLAYLIST_prv_abc.m3u8",
+            "track_count":3,
+            "sequence":[
+                {"order_index":0,"track_id":"track:a","display_name":"A","locked":false},
+                {"order_index":1,"track_id":"track:b","display_name":"B","locked":true},
+                {"order_index":2,"track_id":"track:c","display_name":"C","locked":false}
+            ],
+            "path":"/tmp/leak.m3u8",
+            "personal_dj_model_training_authorized":false,
+            "production_activation_authorized":false
+        }))
+        .is_err());
+    }
+
+    #[test]
+    fn target_normalization_enforces_m3u8_and_non_overwrite() {
+        let root = std::env::temp_dir().join(format!(
+            "applaylist-export-target-{}",
+            Uuid::new_v4().simple()
+        ));
+        fs::create_dir_all(&root).expect("create target root");
+        let without_extension = normalize_target(root.join("playlist")).expect("normalize target");
+        assert_eq!(without_extension.extension().and_then(|v| v.to_str()), Some("m3u8"));
+        assert!(normalize_target(root.join("playlist.txt")).is_err());
+        fs::write(root.join("exists.m3u8"), b"existing").expect("write existing");
+        assert!(normalize_target(root.join("exists.m3u8")).is_err());
+        let _ = fs::remove_dir_all(root);
+    }
+}

--- a/src-tauri/src/playlist_export.rs
+++ b/src-tauri/src/playlist_export.rs
@@ -314,7 +314,9 @@ impl Session {
         let nonce_hash = sha256_hex(nonce.as_bytes());
         if health.get("status").and_then(serde_json::Value::as_str) != Some("ready")
             || health.get("protocol").and_then(serde_json::Value::as_str) != Some(PROTOCOL_VERSION)
-            || health.get("nonce_sha256").and_then(serde_json::Value::as_str)
+            || health
+                .get("nonce_sha256")
+                .and_then(serde_json::Value::as_str)
                 != Some(nonce_hash.as_str())
         {
             return Err(ExportError::readiness_failed());
@@ -404,7 +406,9 @@ fn validate_ready(value: &serde_json::Value, nonce: &str) -> Result<u16, ExportE
     if value.get("event").and_then(serde_json::Value::as_str) != Some("ready")
         || value.get("protocol").and_then(serde_json::Value::as_str) != Some(PROTOCOL_VERSION)
         || value.get("host").and_then(serde_json::Value::as_str) != Some("127.0.0.1")
-        || value.get("nonce_sha256").and_then(serde_json::Value::as_str)
+        || value
+            .get("nonce_sha256")
+            .and_then(serde_json::Value::as_str)
             != Some(nonce_hash.as_str())
         || value
             .get("process_id")
@@ -610,7 +614,12 @@ fn normalize_target(mut target: PathBuf) -> Result<PathBuf, ExportError> {
         Some(_) => return Err(ExportError::invalid_target()),
     }
     let parent = target.parent().ok_or_else(ExportError::invalid_target)?;
-    if !parent.is_dir() || target.file_name().and_then(|value| value.to_str()).is_none() {
+    if !parent.is_dir()
+        || target
+            .file_name()
+            .and_then(|value| value.to_str())
+            .is_none()
+    {
         return Err(ExportError::invalid_target());
     }
     if target.exists() {
@@ -673,13 +682,7 @@ pub async fn playlist_export_preview(
     bridge: State<'_, PlaylistExportBridge>,
     app: AppHandle,
 ) -> Result<PlaylistExportPreview, DesktopHostError> {
-    let bytes = request_bytes(
-        bridge,
-        &app,
-        "/v1/playlist/export/preview",
-        revision_id,
-    )
-    .await?;
+    let bytes = request_bytes(bridge, &app, "/v1/playlist/export/preview", revision_id).await?;
     let preview: PlaylistExportPreview =
         serde_json::from_slice(&bytes).map_err(|_| ExportError::invalid_response())?;
     validate_preview(&preview).map_err(DesktopHostError::from)?;
@@ -692,13 +695,7 @@ pub async fn playlist_export_m3u8(
     bridge: State<'_, PlaylistExportBridge>,
     app: AppHandle,
 ) -> Result<Option<PlaylistExportReceipt>, DesktopHostError> {
-    let bytes = request_bytes(
-        bridge,
-        &app,
-        "/v1/playlist/export/material",
-        revision_id,
-    )
-    .await?;
+    let bytes = request_bytes(bridge, &app, "/v1/playlist/export/material", revision_id).await?;
     let material: PlaylistExportMaterial =
         serde_json::from_slice(&bytes).map_err(|_| ExportError::invalid_response())?;
     validate_material(&material).map_err(DesktopHostError::from)?;
@@ -808,7 +805,10 @@ mod tests {
         ));
         fs::create_dir_all(&root).expect("create target root");
         let without_extension = normalize_target(root.join("playlist")).expect("normalize target");
-        assert_eq!(without_extension.extension().and_then(|v| v.to_str()), Some("m3u8"));
+        assert_eq!(
+            without_extension.extension().and_then(|v| v.to_str()),
+            Some("m3u8")
+        );
         assert!(normalize_target(root.join("playlist.txt")).is_err());
         fs::write(root.join("exists.m3u8"), b"existing").expect("write existing");
         assert!(normalize_target(root.join("exists.m3u8")).is_err());

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,8 @@
       "capabilities": [
         "main-library-root",
         "main-set-proposal",
-        "main-playlist-editor"
+        "main-playlist-editor",
+        "main-playlist-export"
       ]
     },
     "withGlobalTauri": true

--- a/tests/test_desktop_playlist_export_renderer.py
+++ b/tests/test_desktop_playlist_export_renderer.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HTML = ROOT / "desktop" / "host-proof" / "index.html"
+JS = ROOT / "desktop" / "host-proof" / "playlist-export.js"
+BUILD_RS = ROOT / "src-tauri" / "build.rs"
+LIB_RS = ROOT / "src-tauri" / "src" / "lib.rs"
+TAURI_CONF = ROOT / "src-tauri" / "tauri.conf.json"
+CAPABILITY = ROOT / "src-tauri" / "capabilities" / "main-playlist-export.json"
+RUST = ROOT / "src-tauri" / "src" / "playlist_export.rs"
+
+
+def test_playlist_export_renderer_is_strict_path_safe_and_dom_only() -> None:
+    html = HTML.read_text(encoding="utf-8")
+    js = JS.read_text(encoding="utf-8")
+
+    assert '<script src="./playlist-export.js" defer></script>' in html
+    for required in (
+        'id="playlist-export"',
+        'id="playlist-export-revision"',
+        'id="playlist-export-preview"',
+        'id="playlist-export-write"',
+        'id="playlist-export-preview-result"',
+        'id="playlist-export-receipt"',
+    ):
+        assert required in html
+
+    assert 'originalInvoke("playlist_export_preview", {' in js
+    assert 'originalInvoke("playlist_export_m3u8", {' in js
+    assert "applaylist-desktop-playlist-export-preview-r1" in js
+    assert "validReceipt" in js
+    assert "exactKeys" in js
+    assert "document.createElement" in js
+    assert ".textContent" in js
+    assert ".innerHTML" not in js
+    assert "insertAdjacentHTML" not in js
+
+    for forbidden in (
+        "fetch(",
+        "XMLHttpRequest",
+        "WebSocket",
+        "__TAURI__.fs",
+        "__TAURI__.shell",
+        "__TAURI__.http",
+        "plugin:fs",
+        "plugin:shell",
+        "/v1/playlist/export/material",
+        "content_utf8",
+        "X-APPLAYLIST-Sidecar-Secret",
+        "X-APPLAYLIST-Readiness-Nonce",
+        "127.0.0.1",
+        "process_id",
+        "nonce_sha256",
+    ):
+        assert forbidden not in js
+
+
+def test_playlist_export_tauri_surface_is_narrow_and_private_material_stays_in_rust() -> None:
+    build = BUILD_RS.read_text(encoding="utf-8")
+    lib = LIB_RS.read_text(encoding="utf-8")
+    rust = RUST.read_text(encoding="utf-8")
+    capability = json.loads(CAPABILITY.read_text(encoding="utf-8"))
+    config = json.loads(TAURI_CONF.read_text(encoding="utf-8"))
+
+    for command in ("playlist_export_preview", "playlist_export_m3u8"):
+        assert command in build
+        assert f"playlist_export::{command}" in lib
+        assert f"allow-{command.replace('_', '-')}" in capability["permissions"]
+
+    assert ".manage(PlaylistExportBridge::from_environment())" in lib
+    assert capability["permissions"] == [
+        "allow-playlist-export-preview",
+        "allow-playlist-export-m3u8",
+    ]
+    assert "main-playlist-export" in config["app"]["security"]["capabilities"]
+    assert "#[serde(deny_unknown_fields)]" in rust
+    assert '"/v1/playlist/export/preview"' in rust
+    assert '"/v1/playlist/export/material"' in rust
+    assert "blocking_save_file" in rust
+    assert "write_atomic" in rust
+    assert "content_utf8" in rust
+    assert "PlaylistExportReceipt" in rust
+    assert "personal_dj_model_training_authorized: false" in rust
+    assert "production_activation_authorized: false" in rust

--- a/tests/test_desktop_playlist_export_transport.py
+++ b/tests/test_desktop_playlist_export_transport.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from data.models.track_record import TrackRecord
+from data.repositories.playlist_revision_repository import PlaylistRevisionRepository
+from data.repositories.track_repository import TrackRepository
+from services.desktop.playlist_export_transport import (
+    DesktopPlaylistExportTransport,
+    DesktopPlaylistExportTransportError,
+)
+from tests.test_desktop_readiness_sidecar import _finish, _request
+from tests.test_desktop_set_proposal_transport import (
+    _configure_database,
+    _start_extended_sidecar,
+    _track_id,
+)
+
+
+def _seed_export_revision(tmp_path: Path) -> tuple[dict[str, object], tuple[Path, ...]]:
+    repository = TrackRepository()
+    items: list[tuple[str, str]] = []
+    paths: list[Path] = []
+    for index in range(3):
+        path = (tmp_path / f"audio-{index}.wav").resolve()
+        path.write_bytes(b"fixture-not-read-by-export")
+        paths.append(path)
+        track_id = _track_id(chr(ord("a") + index))
+        label = f"Fixture Artist – Track {index + 1}"
+        repository.upsert(
+            TrackRecord(
+                track_id=track_id,
+                path=str(path),
+                title=f"Track {index + 1}",
+                artist="Fixture Artist",
+                duration_seconds=300.2 + index,
+            )
+        )
+        items.append((track_id, label))
+    revision = PlaylistRevisionRepository().append_root(
+        source_proposal_id="spr_fixture",
+        source_path_id="spp_fixture",
+        items=items,
+        operation_metadata={"fixture": "bundle58"},
+    )
+    return revision, tuple(paths)
+
+
+def test_export_preview_is_renderer_safe_and_material_is_deterministic(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_database(monkeypatch, tmp_path)
+    revision, paths = _seed_export_revision(tmp_path)
+    transport = DesktopPlaylistExportTransport()
+    ledger = PlaylistRevisionRepository()
+    before_count = ledger.count_revisions(str(revision["playlist_id"]))
+
+    preview = transport.preview(revision_id=str(revision["revision_id"]))
+    first = transport.material(revision_id=str(revision["revision_id"]))
+    second = transport.material(revision_id=str(revision["revision_id"]))
+
+    assert first == second
+    assert preview["schema"] == "applaylist-desktop-playlist-export-preview-r1"
+    assert preview["revision_id"] == revision["revision_id"]
+    assert preview["track_count"] == 3
+    assert preview["format"] == "m3u8"
+    assert str(preview["suggested_filename"]).endswith(".m3u8")
+    assert preview["personal_dj_model_training_authorized"] is False
+    assert preview["production_activation_authorized"] is False
+
+    preview_json = json.dumps(preview, ensure_ascii=False, sort_keys=True)
+    for path in paths:
+        assert str(path) not in preview_json
+    assert "content_utf8" not in preview_json
+
+    content = str(first["content_utf8"])
+    assert content.startswith("#EXTM3U\n")
+    assert [line for line in content.splitlines() if not line.startswith("#")] == [
+        str(path.resolve()) for path in paths
+    ]
+    assert "Fixture Artist – Track 1" in content
+    assert first["byte_count"] == len(content.encode("utf-8"))
+    assert first["content_sha256"] == hashlib.sha256(content.encode("utf-8")).hexdigest()
+    assert first["personal_dj_model_training_authorized"] is False
+    assert first["production_activation_authorized"] is False
+    assert ledger.count_revisions(str(revision["playlist_id"])) == before_count
+
+
+def test_export_fails_closed_for_missing_revision_track_or_path_injection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_database(monkeypatch, tmp_path)
+    revision, paths = _seed_export_revision(tmp_path)
+    transport = DesktopPlaylistExportTransport()
+
+    with pytest.raises(DesktopPlaylistExportTransportError) as missing_revision:
+        transport.preview(revision_id="prv_missing")
+    assert missing_revision.value.code == "playlist_export_revision_not_found"
+
+    paths[1].unlink()
+    with pytest.raises(DesktopPlaylistExportTransportError) as missing_file:
+        transport.material(revision_id=str(revision["revision_id"]))
+    assert missing_file.value.code == "playlist_export_track_unavailable"
+
+    track_id = str(revision["items"][0]["track_id"])
+    record = TrackRepository().get_by_id(track_id)
+    assert record is not None
+    TrackRepository().upsert(
+        TrackRecord(
+            track_id=record.track_id,
+            path="/tmp/APPLAYLIST-bad\npath.wav",
+            title=record.title,
+            artist=record.artist,
+            duration_seconds=record.duration_seconds,
+        )
+    )
+    with pytest.raises(DesktopPlaylistExportTransportError) as injected:
+        transport.material(revision_id=str(revision["revision_id"]))
+    assert injected.value.code == "playlist_export_content_invalid"
+
+
+def test_authenticated_playlist_export_routes_are_strict_and_preview_path_safe(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    database = _configure_database(monkeypatch, tmp_path)
+    revision, paths = _seed_export_revision(tmp_path)
+    process, ready = _start_extended_sidecar(database)
+    body = json.dumps({"revision_id": revision["revision_id"]}).encode("utf-8")
+    try:
+        status, payload = _request(
+            ready,
+            method="POST",
+            path="/v1/playlist/export/preview",
+            secret="X" * 48,
+            body=body,
+        )
+        assert status == 401
+        assert payload == {"error": "unauthorized"}
+
+        status, payload = _request(
+            ready,
+            method="POST",
+            path="/v1/playlist/export/preview",
+            body=json.dumps(
+                {"revision_id": revision["revision_id"], "path": "/must/not/pass"}
+            ).encode("utf-8"),
+        )
+        assert status == 400
+        assert payload == {"error": "invalid_playlist_export_request"}
+
+        status, preview = _request(
+            ready,
+            method="POST",
+            path="/v1/playlist/export/preview",
+            body=body,
+        )
+        assert status == 200
+        encoded_preview = json.dumps(preview, sort_keys=True)
+        for path in paths:
+            assert str(path) not in encoded_preview
+        assert "content_utf8" not in preview
+
+        status, material = _request(
+            ready,
+            method="POST",
+            path="/v1/playlist/export/material",
+            body=body,
+        )
+        assert status == 200
+        assert material["schema"] == "applaylist-desktop-playlist-export-material-r1"
+        assert material["revision_id"] == revision["revision_id"]
+        assert material["content_utf8"].startswith("#EXTM3U\n")
+        assert material["byte_count"] == len(material["content_utf8"].encode("utf-8"))
+
+        status, shutdown = _request(ready, method="POST", path="/v1/shutdown")
+        assert status == 202
+        assert shutdown == {"status": "shutting_down"}
+        _finish(process)
+    finally:
+        if process.poll() is None:
+            process.kill()
+            _finish(process)

--- a/tests/test_desktop_set_proposal_renderer.py
+++ b/tests/test_desktop_set_proposal_renderer.py
@@ -86,6 +86,7 @@ def test_set_proposal_tauri_surface_is_separate_and_narrow() -> None:
         "main-library-root",
         "main-set-proposal",
         "main-playlist-editor",
+        "main-playlist-export",
     }
 
     assert "#[serde(deny_unknown_fields)]" in rust


### PR DESCRIPTION
Closes #135 when merged.

## Summary

Adds governed desktop export from one explicitly selected immutable Bundle 57 `PlaylistRevision`.

R1 exports generic UTF-8 M3U8 only. Vendor database mutation for rekordbox/Traktor/Serato remains out of scope.

## Exact identity

- base branch: `feature/bundle-0-bootstrap`
- exact base SHA: `abaf82716f112f2b40193a6b2a181536cd941641`
- head branch: `feature/bundle-58-playlist-revision-export-r1`
- exact head SHA: `d02b553ee25c17531bd1a9ddc490646dc3252152`
- compare: 15 commits ahead / 0 behind / 14 changed files
- merge base equals exact canonical base `abaf82716f112f2b40193a6b2a181536cd941641`

## Product flow

```text
immutable PlaylistRevision
  -> explicit revision selection
  -> renderer-safe export preview
  -> authenticated private path/material resolution
  -> Rust private material validation
  -> native save dialog
  -> bounded temp-file + rename write
  -> renderer-safe receipt
```

## Privacy / authority boundary

- `PlaylistRevisionRepository` remains sole playlist revision authority
- exact `revision_id` is required; no implicit current-head substitution
- source audio filesystem paths are resolved privately from `TrackRepository`
- renderer preview contains no source path and no raw M3U8 content
- private `/v1/playlist/export/material` response is consumed only inside the Rust bridge
- renderer has no fs/shell/http plugin authority
- sidecar does not receive an arbitrary output path and does not write export files
- Rust opens the native save dialog and performs the only output write
- successful receipt returns basename only, never output directory

## M3U8 R1

- UTF-8 `#EXTM3U`
- one `#EXTINF` + canonical local TrackRecord path per immutable revision item
- exact revision order preserved
- newline/null/control-character injection rejected
- missing TrackRecord/path fails closed
- material bounded to 128 KiB
- deterministic content SHA-256 and byte count

## Native write semantics

- explicit native save dialog
- cancel => `None`, no write
- `.m3u8` enforced
- existing target rejected instead of silent overwrite
- temporary file created in selected directory
- file synced then renamed to target
- renderer receives only revision ID, format, safe filename, track count, content SHA-256, byte count, and false authority flags

## Verification

Exact-head verification for `d02b553ee25c17531bd1a9ddc490646dc3252152`:

- PR Guard #272: SUCCESS
- CI #740: SUCCESS
- Python 3.11: compile PASS, critical lint PASS, `404 passed, 6 warnings in 35.49s`
- Python 3.11 evidence artifact ID `9349451952`, SHA-256 `3edf27c5182a024c307fd495c4e09b45a47f30947f963e85e0811f6a2ddb86b4`
- Python 3.12: compile PASS, critical lint PASS, `404 passed, 5 warnings in 44.29s`
- Python 3.12 evidence artifact ID `9349454986`, SHA-256 `0b464fcce80b40b227e3fdb7110cf1ce6868e058fc34958bb83eb18b9feacaf6`
- Desktop Rust #82: SUCCESS — rustfmt, compile-only bundled resource fixture, Cargo check and Cargo test all PASS
- Desktop Sidecar Proof #57: SUCCESS — Ubuntu and macOS sidecar unit/process tests, target-native build, packaged smoke, manifest verification and proof upload all PASS
- Linux packaged proof artifact ID `9349463932`, SHA-256 `a03b6618bf5083cd60cb790c54db99d2b8601c4580f1483ef3d46987d9c16dcd`
- macOS packaged proof artifact ID `9349505799`, SHA-256 `bf65318bd2e73ccdf6234d57235f9bb33491244bbb9a623d68f885f9553df4b0`
- unresolved review threads: `0`
- submitted reviews: `0`
- GitHub compare: 15 commits ahead / 0 behind; merge base is exact canonical base

First-pass head `cca317502d0985f2b52ff6f13ca815003ecce0c7` had one mechanical Desktop Rust `rustfmt --check` failure before Cargo check/test. It was fixed with the forward-only formatting commit `d02b553ee25c17531bd1a9ddc490646dc3252152`; no history rewrite or force push was used. Python CI and PR Guard had already passed on the first head.

## Bundle Context

Bundle 57 is canonical at `abaf82716f112f2b40193a6b2a181536cd941641` and provides immutable append-only playlist revisions. Bundle 58 adds the first interoperability/export projection from that authority boundary.

Future vendor-specific adapters may consume the same immutable revision/export contract but must not bypass it.

## Non-scope

- rekordbox database/XML mutation
- Traktor `collection.nml` mutation
- Serato database mutation
- audio copy/transcode/read/hash
- relative-path relocation
- cloud upload/sync
- optimizer rerun
- Personal DJ Model training
- production optimizer activation
- release/deploy/signing/notarization

`MERGE_AUTHORIZATION=NO`
`RELEASE_AUTHORIZATION=NO`
`DEPLOY_AUTHORIZATION=NO`
`PRODUCTION_EFFECTS=LOCAL_EXPLICIT_EXPORT_ONLY`