### PR TITLE
Bundle 59: PlaylistRevision JSON evidence export + path verification R1

### DIFF
--- a/data/repositories/transition_evidence_index.py
+++ b/data/repositories/transition_evidence_index.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+
+from data.connection import get_sqlite_connection
+from data.repositories.music_intelligence_repository import MusicIntelligenceRepository
+
+_MAX_RESULTS = 16
+
+
+class TransitionEvidenceIndex:
+    """Read-only metadata index over canonical persisted TransitionAssessment snapshots."""
+
+    def __init__(self, *, repository: MusicIntelligenceRepository | None = None) -> None:
+        self.repository = repository or MusicIntelligenceRepository()
+
+    def list_pair_snapshots(
+        self,
+        *,
+        source_track_id: str,
+        target_track_id: str,
+        limit: int = _MAX_RESULTS,
+    ) -> tuple[dict[str, object], ...]:
+        source = self._token(source_track_id)
+        target = self._token(target_track_id)
+        if not isinstance(limit, int) or isinstance(limit, bool) or not 1 <= limit <= _MAX_RESULTS:
+            raise ValueError("transition evidence limit must be 1..16")
+        self.repository.ensure_schema()
+        with get_sqlite_connection() as conn:
+            rows = conn.execute(
+                '''
+                SELECT snapshot_id, transition_id, source_segment_id, target_segment_id,
+                       assessment_version, policy_version, context_id, context_version,
+                       payload_json, payload_sha256, created_at
+                FROM transition_assessment_snapshots
+                WHERE source_track_id = ? AND target_track_id = ?
+                ORDER BY created_at DESC, snapshot_id DESC
+                LIMIT ?
+                ''',
+                (source, target, limit),
+            ).fetchall()
+        result: list[dict[str, object]] = []
+        for row in rows:
+            payload = str(row["payload_json"])
+            digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+            expected = str(row["payload_sha256"])
+            if digest != expected:
+                raise RuntimeError("stored TransitionAssessment metadata failed integrity verification")
+            result.append(
+                {
+                    "snapshot_id": str(row["snapshot_id"]),
+                    "transition_id": str(row["transition_id"]),
+                    "source_segment_id": str(row["source_segment_id"]),
+                    "target_segment_id": str(row["target_segment_id"]),
+                    "assessment_version": str(row["assessment_version"]),
+                    "policy_version": str(row["policy_version"]),
+                    "context_id": str(row["context_id"]),
+                    "context_version": str(row["context_version"]),
+                    "payload_sha256": expected,
+                    "created_at": str(row["created_at"]),
+                }
+            )
+        return tuple(result)
+
+    @staticmethod
+    def _token(value: str) -> str:
+        if not isinstance(value, str) or not value or value.strip() != value or len(value) > 256:
+            raise ValueError("invalid transition evidence track identity")
+        if "/" in value or "\\" in value or any(ch.isspace() or ord(ch) < 32 for ch in value):
+            raise ValueError("invalid transition evidence track identity")
+        return value
+
+
+__all__ = ["TransitionEvidenceIndex"]

--- a/desktop/host-proof/index.html
+++ b/desktop/host-proof/index.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="./playlist-editor.css">
   <script src="./app.js" defer></script>
   <script src="./playlist-export.js" defer></script>
+  <script src="./playlist-evidence-export.js" defer></script>
   <script src="./playlist-editor.js" defer></script>
   <script src="./set-proposal.js" defer></script>
 </head>
@@ -175,6 +176,20 @@
       <p id="playlist-export-status" class="status">Accept a Set Proposal revision to enable export.</p>
       <div id="playlist-export-preview-result"></div>
       <div id="playlist-export-receipt"></div>
+    </section>
+
+    <section id="playlist-evidence-export" aria-labelledby="playlist-evidence-export-heading">
+      <h2 id="playlist-evidence-export-heading">JSON Evidence Export</h2>
+      <p>Export a machine-readable evidence companion for one exact immutable revision. The preview verifies current M3U8 path validity without exposing filesystem paths.</p>
+      <div class="actions">
+        <label for="playlist-evidence-revision">Revision</label>
+        <select id="playlist-evidence-revision" disabled></select>
+        <button id="playlist-evidence-preview" type="button" disabled>Preview evidence</button>
+        <button id="playlist-evidence-write" type="button" disabled>Export JSON evidence…</button>
+      </div>
+      <p id="playlist-evidence-status" class="status">Accept a Set Proposal revision to enable evidence export.</p>
+      <div id="playlist-evidence-preview-result"></div>
+      <div id="playlist-evidence-receipt"></div>
     </section>
   </main>
 </body>

--- a/desktop/host-proof/playlist-evidence-export.js
+++ b/desktop/host-proof/playlist-evidence-export.js
@@ -1,0 +1,400 @@
+(() => {
+  "use strict";
+
+  const tauriCore = window.__TAURI__?.core;
+  const originalInvoke = tauriCore?.invoke;
+  const section = document.getElementById("playlist-evidence-export");
+  const status = document.getElementById("playlist-evidence-status");
+  const revisionSelect = document.getElementById("playlist-evidence-revision");
+  const previewButton = document.getElementById("playlist-evidence-preview");
+  const exportButton = document.getElementById("playlist-evidence-write");
+  const previewNode = document.getElementById("playlist-evidence-preview-result");
+  const receiptNode = document.getElementById("playlist-evidence-receipt");
+
+  if (
+    !section ||
+    !status ||
+    !revisionSelect ||
+    !previewButton ||
+    !exportButton ||
+    !previewNode ||
+    !receiptNode ||
+    typeof originalInvoke !== "function"
+  ) {
+    return;
+  }
+
+  const TOKEN = /^[A-Za-z0-9][A-Za-z0-9_.:+-]{0,255}$/;
+  const OPERATIONS = new Set(["accept", "reorder", "lock", "replace"]);
+  let trustedHistory = null;
+  let trustedPreview = null;
+  let busy = false;
+
+  function exactKeys(value, keys) {
+    if (value === null || typeof value !== "object" || Array.isArray(value)) {
+      return false;
+    }
+    const actual = Object.keys(value).sort();
+    const expected = [...keys].sort();
+    return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+  }
+
+  function validToken(value) {
+    return typeof value === "string" && TOKEN.test(value) && !value.includes("/") && !value.includes("\\");
+  }
+
+  function pathShaped(value) {
+    return value.startsWith("/") || value.startsWith("\\\\") || /^[A-Za-z]:[\\/]/.test(value);
+  }
+
+  function validDisplayName(value) {
+    return (
+      typeof value === "string" &&
+      value.length > 0 &&
+      value.length <= 512 &&
+      value.trim() === value &&
+      !/[\u0000-\u001f\u007f]/.test(value) &&
+      !pathShaped(value)
+    );
+  }
+
+  function validJsonFilename(value) {
+    return (
+      typeof value === "string" &&
+      value.length > 0 &&
+      value.length <= 128 &&
+      value.endsWith(".json") &&
+      value.trim() === value &&
+      !value.includes("/") &&
+      !value.includes("\\") &&
+      !/[\u0000-\u001f\u007f]/.test(value)
+    );
+  }
+
+  function validDigest(value) {
+    return typeof value === "string" && /^[0-9a-f]{64}$/.test(value);
+  }
+
+  function validRevision(value) {
+    if (
+      !exactKeys(value, [
+        "schema",
+        "playlist_id",
+        "revision_id",
+        "parent_revision_id",
+        "revision_index",
+        "source_proposal_id",
+        "source_path_id",
+        "operation",
+        "content_fingerprint",
+        "created_at",
+        "sequence",
+        "personal_dj_model_training_authorized",
+        "production_activation_authorized",
+      ]) ||
+      value.schema !== "applaylist-desktop-playlist-revision-r1" ||
+      !validToken(value.playlist_id) ||
+      !validToken(value.revision_id) ||
+      !(value.parent_revision_id === null || validToken(value.parent_revision_id)) ||
+      !Number.isInteger(value.revision_index) ||
+      value.revision_index < 0 ||
+      !validToken(value.source_proposal_id) ||
+      !validToken(value.source_path_id) ||
+      !OPERATIONS.has(value.operation) ||
+      !validDigest(value.content_fingerprint) ||
+      typeof value.created_at !== "string" ||
+      value.created_at.length === 0 ||
+      value.created_at.length > 64 ||
+      !Array.isArray(value.sequence) ||
+      value.sequence.length < 3 ||
+      value.sequence.length > 8 ||
+      value.personal_dj_model_training_authorized !== false ||
+      value.production_activation_authorized !== false
+    ) {
+      return false;
+    }
+    const ids = new Set();
+    return value.sequence.every((item, index) => {
+      if (
+        !exactKeys(item, ["order_index", "track_id", "display_name", "locked"]) ||
+        item.order_index !== index ||
+        !validToken(item.track_id) ||
+        !validDisplayName(item.display_name) ||
+        typeof item.locked !== "boolean" ||
+        ids.has(item.track_id)
+      ) {
+        return false;
+      }
+      ids.add(item.track_id);
+      return true;
+    });
+  }
+
+  function validHistory(value) {
+    if (
+      !exactKeys(value, [
+        "schema",
+        "playlist_id",
+        "current_revision_id",
+        "revisions",
+        "history_truncated",
+        "personal_dj_model_training_authorized",
+        "production_activation_authorized",
+      ]) ||
+      value.schema !== "applaylist-desktop-playlist-history-r1" ||
+      !validToken(value.playlist_id) ||
+      !validToken(value.current_revision_id) ||
+      !Array.isArray(value.revisions) ||
+      value.revisions.length < 1 ||
+      value.revisions.length > 100 ||
+      value.revisions.some((revision) => !validRevision(revision) || revision.playlist_id !== value.playlist_id) ||
+      value.revisions[value.revisions.length - 1].revision_id !== value.current_revision_id ||
+      typeof value.history_truncated !== "boolean" ||
+      value.personal_dj_model_training_authorized !== false ||
+      value.production_activation_authorized !== false
+    ) {
+      return false;
+    }
+    return value.revisions.every(
+      (revision, index) => index === 0 || revision.revision_index === value.revisions[index - 1].revision_index + 1,
+    );
+  }
+
+  function validPreview(value) {
+    return (
+      exactKeys(value, [
+        "schema",
+        "revision_id",
+        "playlist_id",
+        "revision_index",
+        "format",
+        "suggested_filename",
+        "track_count",
+        "analysis_evidence_count",
+        "transition_pair_count",
+        "transition_evidence_pair_count",
+        "m3u8_path_valid",
+        "m3u8_content_sha256",
+        "personal_dj_model_training_authorized",
+        "production_activation_authorized",
+      ]) &&
+      value.schema === "applaylist-desktop-playlist-evidence-preview-r1" &&
+      validToken(value.revision_id) &&
+      validToken(value.playlist_id) &&
+      Number.isInteger(value.revision_index) &&
+      value.revision_index >= 0 &&
+      value.format === "json" &&
+      validJsonFilename(value.suggested_filename) &&
+      Number.isInteger(value.track_count) &&
+      value.track_count >= 3 &&
+      value.track_count <= 8 &&
+      Number.isInteger(value.analysis_evidence_count) &&
+      value.analysis_evidence_count >= 0 &&
+      value.analysis_evidence_count <= value.track_count &&
+      Number.isInteger(value.transition_pair_count) &&
+      value.transition_pair_count === value.track_count - 1 &&
+      Number.isInteger(value.transition_evidence_pair_count) &&
+      value.transition_evidence_pair_count >= 0 &&
+      value.transition_evidence_pair_count <= value.transition_pair_count &&
+      value.m3u8_path_valid === true &&
+      validDigest(value.m3u8_content_sha256) &&
+      value.personal_dj_model_training_authorized === false &&
+      value.production_activation_authorized === false
+    );
+  }
+
+  function validReceipt(value) {
+    return (
+      exactKeys(value, [
+        "revision_id",
+        "format",
+        "filename",
+        "track_count",
+        "content_sha256",
+        "bytes_written",
+        "m3u8_path_valid",
+        "m3u8_content_sha256",
+        "personal_dj_model_training_authorized",
+        "production_activation_authorized",
+      ]) &&
+      validToken(value.revision_id) &&
+      value.format === "json" &&
+      validJsonFilename(value.filename) &&
+      Number.isInteger(value.track_count) &&
+      value.track_count >= 3 &&
+      value.track_count <= 8 &&
+      validDigest(value.content_sha256) &&
+      Number.isInteger(value.bytes_written) &&
+      value.bytes_written > 0 &&
+      value.bytes_written <= 262144 &&
+      value.m3u8_path_valid === true &&
+      validDigest(value.m3u8_content_sha256) &&
+      value.personal_dj_model_training_authorized === false &&
+      value.production_activation_authorized === false
+    );
+  }
+
+  function setStatus(message) {
+    status.textContent = message;
+  }
+
+  function setHistory(history) {
+    trustedHistory = history;
+    trustedPreview = null;
+    revisionSelect.replaceChildren();
+    for (const revision of history.revisions) {
+      const option = document.createElement("option");
+      option.value = revision.revision_id;
+      option.textContent = `#${revision.revision_index} ${revision.operation} · ${revision.revision_id}`;
+      option.selected = revision.revision_id === history.current_revision_id;
+      revisionSelect.appendChild(option);
+    }
+    revisionSelect.disabled = false;
+    previewButton.disabled = false;
+    exportButton.disabled = true;
+    previewNode.replaceChildren();
+    receiptNode.replaceChildren();
+    setStatus("Choose an immutable revision and preview its JSON evidence companion.");
+  }
+
+  async function observedInvoke(command, args) {
+    const result = await originalInvoke(command, args);
+    if (command === "playlist_editor_history" && validHistory(result)) {
+      setHistory(result);
+    }
+    return result;
+  }
+
+  try {
+    tauriCore.invoke = observedInvoke;
+  } catch (_error) {
+    setStatus("JSON evidence export history capture is unavailable in this desktop host.");
+    return;
+  }
+  if (tauriCore.invoke !== observedInvoke) {
+    setStatus("JSON evidence export history capture is unavailable in this desktop host.");
+    return;
+  }
+
+  revisionSelect.addEventListener("change", () => {
+    trustedPreview = null;
+    exportButton.disabled = true;
+    previewNode.replaceChildren();
+    receiptNode.replaceChildren();
+    setStatus("Preview the selected immutable revision before JSON evidence export.");
+  });
+
+  previewButton.addEventListener("click", async () => {
+    if (busy || !trustedHistory || !validToken(revisionSelect.value)) {
+      return;
+    }
+    busy = true;
+    previewButton.disabled = true;
+    exportButton.disabled = true;
+    setStatus("Verifying path state and building evidence preview…");
+    try {
+      const preview = await originalInvoke("playlist_evidence_preview", {
+        revisionId: revisionSelect.value,
+      });
+      if (!validPreview(preview) || preview.revision_id !== revisionSelect.value) {
+        throw new Error("Invalid evidence preview response.");
+      }
+      trustedPreview = preview;
+      renderPreview(preview);
+      exportButton.disabled = false;
+      setStatus("Evidence preview verified. JSON export remains an explicit local save action.");
+    } catch (_error) {
+      trustedPreview = null;
+      previewNode.replaceChildren();
+      setStatus("The selected revision could not produce a path-valid evidence preview.");
+    } finally {
+      busy = false;
+      previewButton.disabled = false;
+    }
+  });
+
+  exportButton.addEventListener("click", async () => {
+    if (
+      busy ||
+      !trustedPreview ||
+      trustedPreview.revision_id !== revisionSelect.value ||
+      !validToken(revisionSelect.value)
+    ) {
+      return;
+    }
+    busy = true;
+    previewButton.disabled = true;
+    exportButton.disabled = true;
+    receiptNode.replaceChildren();
+    setStatus("Choose a new .json file in the native save dialog…");
+    try {
+      const receipt = await originalInvoke("playlist_evidence_export_json", {
+        revisionId: revisionSelect.value,
+      });
+      if (receipt === null) {
+        setStatus("JSON evidence export canceled. No file was written.");
+        return;
+      }
+      if (!validReceipt(receipt) || receipt.revision_id !== revisionSelect.value) {
+        throw new Error("Invalid evidence export receipt response.");
+      }
+      renderReceipt(receipt);
+      setStatus("JSON evidence export completed for the exact immutable revision.");
+    } catch (_error) {
+      setStatus("The JSON evidence export was rejected safely. No successful receipt was produced.");
+    } finally {
+      busy = false;
+      previewButton.disabled = false;
+      exportButton.disabled = trustedPreview === null;
+    }
+  });
+
+  function renderPreview(preview) {
+    previewNode.replaceChildren();
+    const heading = document.createElement("h3");
+    heading.textContent = `Evidence preview · revision #${preview.revision_index}`;
+    const metadata = document.createElement("dl");
+    for (const [label, value] of [
+      ["File", preview.suggested_filename],
+      ["Tracks", String(preview.track_count)],
+      ["Analysis evidence", `${preview.analysis_evidence_count}/${preview.track_count}`],
+      ["Transition pairs with evidence", `${preview.transition_evidence_pair_count}/${preview.transition_pair_count}`],
+      ["M3U8 path verification", preview.m3u8_path_valid ? "valid" : "invalid"],
+      ["M3U8 SHA-256", preview.m3u8_content_sha256],
+    ]) {
+      const term = document.createElement("dt");
+      term.textContent = label;
+      const description = document.createElement("dd");
+      description.textContent = value;
+      metadata.append(term, description);
+    }
+    previewNode.append(heading, metadata);
+  }
+
+  function renderReceipt(receipt) {
+    receiptNode.replaceChildren();
+    const heading = document.createElement("h3");
+    heading.textContent = "JSON evidence receipt";
+    const list = document.createElement("dl");
+    for (const [label, value] of [
+      ["Revision", receipt.revision_id],
+      ["File", receipt.filename],
+      ["Tracks", String(receipt.track_count)],
+      ["Bytes", String(receipt.bytes_written)],
+      ["JSON SHA-256", receipt.content_sha256],
+      ["M3U8 path verification", receipt.m3u8_path_valid ? "valid" : "invalid"],
+      ["M3U8 SHA-256", receipt.m3u8_content_sha256],
+    ]) {
+      const term = document.createElement("dt");
+      term.textContent = label;
+      const description = document.createElement("dd");
+      description.textContent = value;
+      list.append(term, description);
+    }
+    receiptNode.append(heading, list);
+  }
+
+  revisionSelect.disabled = true;
+  previewButton.disabled = true;
+  exportButton.disabled = true;
+})();

--- a/docs/bundles/BUNDLE_59_JSON_EVIDENCE_EXPORT_R1.md
+++ b/docs/bundles/BUNDLE_59_JSON_EVIDENCE_EXPORT_R1.md
@@ -1,0 +1,214 @@
+# Bundle 59 — PlaylistRevision JSON Evidence Export + Path Verification R1
+
+## Status
+
+Implementation slice. Merge, release, deploy, production optimizer activation, Personal DJ Model training, vendor database mutation, cloud upload, selected-transition editor UI, and regeneration around locks remain unauthorized.
+
+## Canonical dependency
+
+- base branch: `feature/bundle-0-bootstrap`
+- exact base SHA: `35be83c47d2d367a60f6ac7140f0f9cd1b5fb52a`
+- source playlist authority: immutable Bundle 57 `PlaylistRevision`
+- path-validity authority: canonical Bundle 58 M3U8 material projection over `TrackRepository`
+- analysis authority: persisted `AnalysisEvidenceRepository`
+- transition authority: persisted `TransitionAssessment` snapshots exposed read-only through `TransitionEvidenceIndex`
+
+## User outcome
+
+A DJ can select one exact immutable playlist revision, inspect a renderer-safe evidence preview, and explicitly save a deterministic JSON evidence companion through the native desktop save dialog.
+
+The JSON export is designed as the machine-readable companion to the canonical M3U8 export. It records revision lineage, ordered track evidence, adjacent persisted transition evidence metadata, and proof that the same revision is currently path-valid for M3U8 export.
+
+## Authority model
+
+```text
+PlaylistRevisionRepository
+  -> exact revision_id
+  -> Bundle 58 M3U8 material projection
+      -> TrackRepository path-validity verification
+      -> M3U8 SHA-256 + byte count only
+  -> AnalysisEvidenceRepository
+      -> latest successful persisted evidence per revision track
+      -> active correction only when bound to that evidence
+  -> TransitionEvidenceIndex
+      -> read-only metadata from persisted TransitionAssessment snapshots
+  -> deterministic canonical JSON
+  -> authenticated private sidecar material
+  -> trusted Rust validation
+  -> native save dialog
+  -> bounded atomic local write
+  -> renderer-safe receipt
+```
+
+No component in Bundle 59 may append, update, delete, regenerate, or reinterpret playlist, analysis, correction, or transition evidence.
+
+## JSON evidence document
+
+Schema:
+
+`applaylist-playlist-revision-evidence-r1`
+
+Top-level fields:
+
+- exact revision identity and immutable fingerprint
+- bounded parent lineage ending at the explicitly selected revision
+- exact ordered track IDs, display labels and lock state
+- latest successful persisted analysis evidence for each track, or explicit `missing`
+- active correction only when it references that exact successful evidence
+- adjacent transition-pair evidence metadata from canonical persisted TransitionAssessment snapshots, or explicit `missing`
+- M3U8 verification summary: `path_valid`, track count, M3U8 content SHA-256 and byte count
+- Personal DJ Model training authorization fixed to false
+- production activation authorization fixed to false
+
+The evidence document deliberately contains no source filesystem paths, output paths, sidecar credentials, raw exceptions, audio bytes, or raw M3U8 material.
+
+## Transition evidence rule
+
+Bundle 59 does not create or recompute TransitionAssessment.
+
+For each adjacent track pair in the selected immutable revision:
+
+- persisted matching snapshots are exposed only as bounded identity/provenance metadata;
+- stored snapshot payload SHA-256 is reverified before metadata is returned;
+- if no persisted snapshot exists, status is `missing`;
+- missing transition evidence is never silently synthesized.
+
+## Path verification rule
+
+Bundle 59 reuses `DesktopPlaylistExportTransport.material()` from Bundle 58 as the path verification oracle.
+
+That means the JSON evidence export succeeds only if the same exact revision currently satisfies Bundle 58 path rules:
+
+- every track resolves through `TrackRepository`;
+- every path is absolute and canonicalizable;
+- every referenced file exists and is a file;
+- newline/null/control-character path injection is rejected;
+- audio bytes are not read or hashed.
+
+Only the M3U8 SHA-256, byte count, track count, format, and `path_valid=true` are copied into the JSON evidence document. Raw paths and M3U8 text are discarded from the evidence projection.
+
+## Determinism
+
+For identical persisted playlist revision, TrackRepository path state, AnalysisEvidence/correction state, and TransitionAssessment snapshot state, JSON bytes are deterministic:
+
+- UTF-8
+- sorted JSON object keys
+- compact separators
+- one final newline
+- SHA-256 over exact emitted bytes
+
+Material is bounded to 256 KiB.
+
+## Sidecar routes
+
+Authenticated POST only:
+
+- `/v1/playlist/evidence/preview`
+- `/v1/playlist/evidence/material`
+
+Exact request body:
+
+```json
+{"revision_id":"prv_..."}
+```
+
+Unknown fields fail closed.
+
+## Desktop commands
+
+- `playlist_evidence_preview`
+- `playlist_evidence_export_json`
+
+They are isolated in `main-playlist-evidence-export` capability.
+
+The private material route is never exposed directly to renderer JavaScript.
+
+## Native write boundary
+
+`playlist_evidence_export_json`:
+
+1. fetches authenticated private material for one explicit revision ID;
+2. validates strict material DTO shape;
+3. recomputes JSON SHA-256 and byte count;
+4. parses and validates the evidence document identity and path-verification proof;
+5. rejects forbidden path-key shapes in the evidence document;
+6. opens native save dialog;
+7. returns `None` on cancel with no write;
+8. enforces `.json`;
+9. rejects an existing target instead of silently overwriting it;
+10. writes a bounded temporary file in the selected directory;
+11. syncs and renames it to the target;
+12. returns only a renderer-safe receipt.
+
+## Renderer-safe preview
+
+Preview contains only:
+
+- revision ID / playlist ID / revision index
+- JSON format + safe suggested filename
+- track count
+- count of tracks with persisted analysis evidence
+- adjacent transition pair count
+- count of adjacent pairs with persisted transition evidence
+- `m3u8_path_valid=true`
+- M3U8 content SHA-256
+- false authority flags
+
+No source path, output directory or JSON material is returned.
+
+## Renderer-safe receipt
+
+Successful receipt contains only:
+
+- revision ID
+- `json` format
+- safe output basename
+- track count
+- JSON SHA-256
+- bytes written
+- M3U8 path-valid flag
+- M3U8 SHA-256
+- false authority flags
+
+## Explicit non-effects
+
+Bundle 59 does not:
+
+- read/hash/copy/transcode audio bytes
+- call MIR providers
+- append or modify AnalysisEvidence/corrections
+- create or recompute TransitionAssessment
+- rerun optimizer
+- mutate PlaylistRevision history
+- train Personal DJ Model
+- activate production optimization
+- mutate rekordbox/Traktor/Serato databases
+- upload/sync to cloud
+- release/deploy/sign/notarize the application
+
+## Required merge gates
+
+- exact base / merge-base identity
+- full Python CI 3.11 and 3.12
+- deterministic JSON evidence transport tests
+- authenticated sidecar strict-body/auth/path privacy tests
+- path-invalid fail-closed regression
+- renderer no-path/no-network authority tests
+- Desktop Rust rustfmt/check/test
+- Desktop Sidecar Proof Ubuntu + macOS
+- PR Guard
+- zero unresolved review threads
+- exact-head evidence recorded in PR before merge authorization
+
+## Next dependency
+
+After Bundle 59, the R4 interoperability track can add the first documented vendor adapter guidance over the canonical pair:
+
+```text
+immutable PlaylistRevision
+  -> M3U8
+  -> JSON evidence companion
+  -> vendor-specific read/write-neutral interoperability adapter
+```
+
+Vendor database mutation remains a separate authorization boundary.

--- a/scripts/applaylist_sidecar_entry.py
+++ b/scripts/applaylist_sidecar_entry.py
@@ -1,4 +1,7 @@
 from services.desktop.playlist_editor_sidecar import install_playlist_editor_sidecar
+from services.desktop.playlist_evidence_export_sidecar import (
+    install_playlist_evidence_export_sidecar,
+)
 from services.desktop.playlist_export_sidecar import install_playlist_export_sidecar
 from services.desktop.set_proposal_sidecar import install_set_proposal_sidecar
 from services.desktop.sidecar import main
@@ -7,6 +10,7 @@ from services.desktop.sidecar import main
 install_set_proposal_sidecar()
 install_playlist_editor_sidecar()
 install_playlist_export_sidecar()
+install_playlist_evidence_export_sidecar()
 
 
 if __name__ == "__main__":

--- a/services/desktop/playlist_evidence_export_sidecar.py
+++ b/services/desktop/playlist_evidence_export_sidecar.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import services.desktop.sidecar as sidecar
+from services.desktop.playlist_evidence_export_transport import (
+    DesktopPlaylistEvidenceExportError,
+    DesktopPlaylistEvidenceExportTransport,
+)
+
+MAX_PLAYLIST_EVIDENCE_EXPORT_REQUEST_BYTES = 8 * 1024
+_INSTALLED = False
+
+_ROUTES = {
+    "/v1/playlist/evidence/preview": "preview",
+    "/v1/playlist/evidence/material": "material",
+}
+
+_CONFLICT_CODES = {
+    "playlist_evidence_revision_not_found",
+    "playlist_export_revision_not_found",
+    "playlist_export_track_missing",
+    "playlist_export_track_unavailable",
+}
+
+
+def install_playlist_evidence_export_sidecar() -> None:
+    """Extend the authenticated sidecar with deterministic JSON evidence export routes."""
+    global _INSTALLED
+    if _INSTALLED:
+        return
+
+    original_handler = sidecar._SidecarRequestHandler
+    original_server = sidecar._SidecarHTTPServer
+
+    class PlaylistEvidenceExportRequestHandler(original_handler):
+        def do_POST(self) -> None:  # noqa: N802
+            operation = _ROUTES.get(self.path)
+            if operation is None:
+                super().do_POST()
+                return
+            self._handle_playlist_evidence_export(operation)
+
+        def _handle_playlist_evidence_export(self, operation: str) -> None:
+            if not self._authorized():
+                self._write_json(HTTPStatus.UNAUTHORIZED, {"error": "unauthorized"})
+                return
+            payload = self._read_json_payload(MAX_PLAYLIST_EVIDENCE_EXPORT_REQUEST_BYTES)
+            if payload is None or set(payload) != {"revision_id"}:
+                self._write_json(
+                    HTTPStatus.BAD_REQUEST,
+                    {"error": "invalid_playlist_evidence_export_request"},
+                )
+                return
+            try:
+                method = getattr(self.sidecar_server.playlist_evidence_export, operation)
+                result = method(revision_id=payload["revision_id"])
+            except DesktopPlaylistEvidenceExportError as exc:
+                status = HTTPStatus.CONFLICT if exc.code in _CONFLICT_CODES else HTTPStatus.BAD_REQUEST
+                self._write_json(status, {"error": exc.code})
+                return
+            except Exception:
+                self._write_json(
+                    HTTPStatus.INTERNAL_SERVER_ERROR,
+                    {"error": "playlist_evidence_export_operation_failed"},
+                )
+                return
+            self._write_json(HTTPStatus.OK, result)
+
+    sidecar._SidecarRequestHandler = PlaylistEvidenceExportRequestHandler
+
+    class PlaylistEvidenceExportHTTPServer(original_server):
+        def __init__(self, startup: sidecar.SidecarStartup) -> None:
+            super().__init__(startup)
+            self.playlist_evidence_export = DesktopPlaylistEvidenceExportTransport()
+
+    sidecar._SidecarHTTPServer = PlaylistEvidenceExportHTTPServer
+    _INSTALLED = True
+
+
+__all__ = [
+    "MAX_PLAYLIST_EVIDENCE_EXPORT_REQUEST_BYTES",
+    "install_playlist_evidence_export_sidecar",
+]

--- a/services/desktop/playlist_evidence_export_transport.py
+++ b/services/desktop/playlist_evidence_export_transport.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict
+
+from data.repositories.analysis_evidence_repository import AnalysisEvidenceRepository
+from data.repositories.playlist_revision_repository import PlaylistRevisionRepository
+from data.repositories.transition_evidence_index import TransitionEvidenceIndex
+from services.desktop.playlist_export_transport import (
+    DesktopPlaylistExportTransport,
+    DesktopPlaylistExportTransportError,
+)
+
+_MAX_JSON_BYTES = 256 * 1024
+_PREVIEW_SCHEMA = "applaylist-desktop-playlist-evidence-preview-r1"
+_MATERIAL_SCHEMA = "applaylist-desktop-playlist-evidence-material-r1"
+_DOCUMENT_SCHEMA = "applaylist-playlist-revision-evidence-r1"
+_FORMAT = "json"
+
+
+class DesktopPlaylistEvidenceExportError(ValueError):
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+class DesktopPlaylistEvidenceExportTransport:
+    """Deterministic evidence companion for one exact immutable PlaylistRevision."""
+
+    def __init__(
+        self,
+        *,
+        revisions: PlaylistRevisionRepository | None = None,
+        analysis: AnalysisEvidenceRepository | None = None,
+        transitions: TransitionEvidenceIndex | None = None,
+        m3u8: DesktopPlaylistExportTransport | None = None,
+    ) -> None:
+        self.revisions = revisions or PlaylistRevisionRepository()
+        self.analysis = analysis or AnalysisEvidenceRepository()
+        self.transitions = transitions or TransitionEvidenceIndex()
+        self.m3u8 = m3u8 or DesktopPlaylistExportTransport(revisions=self.revisions)
+
+    def preview(self, *, revision_id: str) -> dict[str, object]:
+        document, verification = self._document(revision_id)
+        tracks = document["tracks"]
+        transitions = document["adjacent_transitions"]
+        assert isinstance(tracks, list)
+        assert isinstance(transitions, list)
+        return {
+            "schema": _PREVIEW_SCHEMA,
+            "revision_id": document["revision"]["revision_id"],
+            "playlist_id": document["revision"]["playlist_id"],
+            "revision_index": document["revision"]["revision_index"],
+            "format": _FORMAT,
+            "suggested_filename": self._suggested_filename(str(document["revision"]["revision_id"])),
+            "track_count": len(tracks),
+            "analysis_evidence_count": sum(1 for item in tracks if item["analysis"]["status"] == "present"),
+            "transition_pair_count": len(transitions),
+            "transition_evidence_pair_count": sum(1 for item in transitions if item["status"] == "present"),
+            "m3u8_path_valid": verification["path_valid"],
+            "m3u8_content_sha256": verification["content_sha256"],
+            "personal_dj_model_training_authorized": False,
+            "production_activation_authorized": False,
+        }
+
+    def material(self, *, revision_id: str) -> dict[str, object]:
+        document, verification = self._document(revision_id)
+        content = json.dumps(
+            document,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ) + "\n"
+        encoded = content.encode("utf-8")
+        if len(encoded) > _MAX_JSON_BYTES:
+            raise DesktopPlaylistEvidenceExportError(
+                "playlist_evidence_export_too_large",
+                "The JSON evidence export exceeds the bounded size limit.",
+            )
+        digest = hashlib.sha256(encoded).hexdigest()
+        revision = document["revision"]
+        return {
+            "schema": _MATERIAL_SCHEMA,
+            "revision_id": revision["revision_id"],
+            "playlist_id": revision["playlist_id"],
+            "revision_index": revision["revision_index"],
+            "format": _FORMAT,
+            "suggested_filename": self._suggested_filename(str(revision["revision_id"])),
+            "track_count": len(document["tracks"]),
+            "m3u8_path_valid": verification["path_valid"],
+            "m3u8_content_sha256": verification["content_sha256"],
+            "content_utf8": content,
+            "content_sha256": digest,
+            "byte_count": len(encoded),
+            "personal_dj_model_training_authorized": False,
+            "production_activation_authorized": False,
+        }
+
+    def _document(self, revision_id: str) -> tuple[dict[str, object], dict[str, object]]:
+        revision = self._revision(revision_id)
+        items = self._items(revision)
+        try:
+            m3u8 = self.m3u8.material(revision_id=str(revision["revision_id"]))
+        except DesktopPlaylistExportTransportError as exc:
+            raise DesktopPlaylistEvidenceExportError(exc.code, exc.message) from exc
+        verification = {
+            "path_valid": True,
+            "format": "m3u8",
+            "track_count": int(m3u8["track_count"]),
+            "content_sha256": str(m3u8["content_sha256"]),
+            "byte_count": int(m3u8["byte_count"]),
+        }
+        tracks: list[dict[str, object]] = []
+        for item in items:
+            track_id = str(item["track_id"])
+            evidence = self.analysis.latest_success_for_track(track_id)
+            if evidence is None:
+                analysis: dict[str, object] = {"status": "missing"}
+            else:
+                correction = self.analysis.latest_active_correction(track_id, evidence.evidence_id)
+                analysis = {
+                    "status": "present",
+                    "evidence_id": evidence.evidence_id,
+                    "provider": evidence.provider,
+                    "analysis_version": evidence.analysis_version,
+                    "provider_version": evidence.provider_version,
+                    "algorithm_version": evidence.algorithm_version,
+                    "bpm": evidence.bpm,
+                    "bpm_confidence": evidence.bpm_confidence,
+                    "key_tonic": evidence.key_tonic,
+                    "key_scale": evidence.key_scale,
+                    "camelot": evidence.camelot,
+                    "key_confidence": evidence.key_confidence,
+                    "energy": evidence.energy,
+                    "loudness_db": evidence.loudness_db,
+                    "duration_seconds": evidence.duration_seconds,
+                    "warnings": list(evidence.warnings),
+                    "created_at": evidence.created_at,
+                    "active_correction": (
+                        None
+                        if correction is None
+                        else {
+                            "correction_id": correction.correction_id,
+                            "base_evidence_id": correction.base_evidence_id,
+                            "payload": json.loads(correction.payload_json),
+                            "reason": correction.reason,
+                            "created_at": correction.created_at,
+                        }
+                    ),
+                }
+            tracks.append(
+                {
+                    "order_index": int(item["order_index"]),
+                    "track_id": track_id,
+                    "display_name": str(item["display_name"]),
+                    "locked": bool(item["locked"]),
+                    "analysis": analysis,
+                }
+            )
+
+        adjacent: list[dict[str, object]] = []
+        for index in range(len(items) - 1):
+            source = str(items[index]["track_id"])
+            target = str(items[index + 1]["track_id"])
+            snapshots = self.transitions.list_pair_snapshots(
+                source_track_id=source,
+                target_track_id=target,
+            )
+            adjacent.append(
+                {
+                    "order_index": index,
+                    "source_track_id": source,
+                    "target_track_id": target,
+                    "status": "present" if snapshots else "missing",
+                    "snapshots": [dict(snapshot) for snapshot in snapshots],
+                }
+            )
+
+        lineage = self._lineage(revision)
+        document = {
+            "schema": _DOCUMENT_SCHEMA,
+            "revision": {
+                "revision_id": str(revision["revision_id"]),
+                "playlist_id": str(revision["playlist_id"]),
+                "parent_revision_id": revision["parent_revision_id"],
+                "revision_index": int(revision["revision_index"]),
+                "source_proposal_id": str(revision["source_proposal_id"]),
+                "source_path_id": str(revision["source_path_id"]),
+                "operation": str(revision["operation"]),
+                "content_fingerprint": str(revision["content_fingerprint"]),
+                "created_at": str(revision["created_at"]),
+            },
+            "lineage": lineage,
+            "tracks": tracks,
+            "adjacent_transitions": adjacent,
+            "m3u8_verification": verification,
+            "personal_dj_model_training_authorized": False,
+            "production_activation_authorized": False,
+        }
+        return document, verification
+
+    def _lineage(self, revision: dict[str, object]) -> list[dict[str, object]]:
+        current = revision
+        reversed_lineage: list[dict[str, object]] = []
+        seen: set[str] = set()
+        for _ in range(100):
+            revision_id = str(current["revision_id"])
+            if revision_id in seen:
+                raise DesktopPlaylistEvidenceExportError(
+                    "playlist_evidence_revision_invalid",
+                    "The playlist revision lineage contains a cycle.",
+                )
+            seen.add(revision_id)
+            reversed_lineage.append(
+                {
+                    "revision_id": revision_id,
+                    "parent_revision_id": current["parent_revision_id"],
+                    "revision_index": int(current["revision_index"]),
+                    "operation": str(current["operation"]),
+                    "content_fingerprint": str(current["content_fingerprint"]),
+                }
+            )
+            parent_id = current["parent_revision_id"]
+            if parent_id is None:
+                break
+            parent = self.revisions.get_revision(str(parent_id))
+            if parent is None or parent["playlist_id"] != revision["playlist_id"]:
+                raise DesktopPlaylistEvidenceExportError(
+                    "playlist_evidence_revision_invalid",
+                    "The playlist revision lineage is incomplete.",
+                )
+            current = parent
+        else:
+            raise DesktopPlaylistEvidenceExportError(
+                "playlist_evidence_revision_invalid",
+                "The playlist revision lineage exceeds the bounded history limit.",
+            )
+        lineage = list(reversed(reversed_lineage))
+        for index, entry in enumerate(lineage):
+            if entry["revision_index"] != index:
+                raise DesktopPlaylistEvidenceExportError(
+                    "playlist_evidence_revision_invalid",
+                    "The playlist revision lineage order is invalid.",
+                )
+        return lineage
+
+    def _revision(self, revision_id: str) -> dict[str, object]:
+        token = self._token(revision_id)
+        revision = self.revisions.get_revision(token)
+        if revision is None:
+            raise DesktopPlaylistEvidenceExportError(
+                "playlist_evidence_revision_not_found",
+                "The requested immutable playlist revision was not found.",
+            )
+        if revision.get("personal_dj_model_training_authorized") is not False:
+            raise DesktopPlaylistEvidenceExportError(
+                "playlist_evidence_revision_invalid",
+                "The revision training boundary is invalid.",
+            )
+        if revision.get("production_activation_authorized") is not False:
+            raise DesktopPlaylistEvidenceExportError(
+                "playlist_evidence_revision_invalid",
+                "The revision activation boundary is invalid.",
+            )
+        return revision
+
+    @staticmethod
+    def _items(revision: dict[str, object]) -> tuple[dict[str, object], ...]:
+        raw = revision.get("items")
+        if not isinstance(raw, (tuple, list)) or not 3 <= len(raw) <= 8:
+            raise DesktopPlaylistEvidenceExportError(
+                "playlist_evidence_revision_invalid",
+                "The revision sequence is invalid.",
+            )
+        result: list[dict[str, object]] = []
+        for index, item in enumerate(raw):
+            if not isinstance(item, dict) or set(item) != {
+                "order_index",
+                "track_id",
+                "display_name",
+                "locked",
+            }:
+                raise DesktopPlaylistEvidenceExportError(
+                    "playlist_evidence_revision_invalid",
+                    "The revision sequence is invalid.",
+                )
+            if item["order_index"] != index:
+                raise DesktopPlaylistEvidenceExportError(
+                    "playlist_evidence_revision_invalid",
+                    "The revision order is invalid.",
+                )
+            result.append(item)
+        return tuple(result)
+
+    @staticmethod
+    def _token(value: str) -> str:
+        if not isinstance(value, str) or not value or value.strip() != value or len(value) > 256:
+            raise DesktopPlaylistEvidenceExportError(
+                "invalid_playlist_evidence_export_request",
+                "The evidence export revision identity is invalid.",
+            )
+        if "/" in value or "\\" in value or any(ch.isspace() or ord(ch) < 32 for ch in value):
+            raise DesktopPlaylistEvidenceExportError(
+                "invalid_playlist_evidence_export_request",
+                "The evidence export revision identity is invalid.",
+            )
+        return value
+
+    @staticmethod
+    def _suggested_filename(revision_id: str) -> str:
+        safe = "".join(ch for ch in revision_id if ch.isascii() and (ch.isalnum() or ch in "_-"))
+        if not safe:
+            safe = "playlist-revision"
+        return f"APPLAYLIST_{safe[:96]}_evidence.json"
+
+
+__all__ = [
+    "DesktopPlaylistEvidenceExportError",
+    "DesktopPlaylistEvidenceExportTransport",
+]

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -20,6 +20,8 @@ fn main() {
             "playlist_editor_history",
             "playlist_export_preview",
             "playlist_export_m3u8",
+            "playlist_evidence_preview",
+            "playlist_evidence_export_json",
         ]),
     ))
     .expect("failed to configure APPLAYLIST desktop host build");

--- a/src-tauri/capabilities/main-playlist-evidence-export.json
+++ b/src-tauri/capabilities/main-playlist-evidence-export.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "main-playlist-evidence-export",
+  "description": "Allow the local main window to preview and explicitly export governed JSON evidence for one immutable playlist revision.",
+  "local": true,
+  "windows": [
+    "main"
+  ],
+  "platforms": [
+    "macOS"
+  ],
+  "permissions": [
+    "allow-playlist-evidence-preview",
+    "allow-playlist-evidence-export-json"
+  ]
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod analysis_job;
 mod import_job;
 mod library_capability;
 mod playlist_editor;
+mod playlist_evidence_export;
 mod playlist_export;
 mod set_proposal;
 mod sidecar_bridge;
@@ -12,6 +13,7 @@ use analysis_job::AnalysisJobRegistry;
 use import_job::ImportJobRegistry;
 use library_capability::LibraryCapabilityRegistry;
 use playlist_editor::PlaylistEditorBridge;
+use playlist_evidence_export::PlaylistEvidenceExportBridge;
 use playlist_export::PlaylistExportBridge;
 use set_proposal::SetProposalBridge;
 use sidecar_bridge::SidecarBridge;
@@ -28,6 +30,7 @@ pub fn run() {
         .manage(SetProposalBridge::from_environment())
         .manage(PlaylistEditorBridge::from_environment())
         .manage(PlaylistExportBridge::from_environment())
+        .manage(PlaylistEvidenceExportBridge::from_environment())
         .invoke_handler(tauri::generate_handler![
             library_capability::library_choose_root,
             import_job::library_import_start,
@@ -47,7 +50,9 @@ pub fn run() {
             playlist_editor::playlist_editor_replace,
             playlist_editor::playlist_editor_history,
             playlist_export::playlist_export_preview,
-            playlist_export::playlist_export_m3u8
+            playlist_export::playlist_export_m3u8,
+            playlist_evidence_export::playlist_evidence_preview,
+            playlist_evidence_export::playlist_evidence_export_json
         ])
         .run(tauri::generate_context!())
         .expect("error while running APPLAYLIST desktop host");

--- a/src-tauri/src/playlist_evidence_export.rs
+++ b/src-tauri/src/playlist_evidence_export.rs
@@ -88,7 +88,12 @@ impl PlaylistEvidenceExportBridge {
         if status != 200 {
             let code = serde_json::from_slice::<Value>(&bytes)
                 .ok()
-                .and_then(|value| value.get("error").and_then(Value::as_str).map(str::to_owned));
+                .and_then(|value| {
+                    value
+                        .get("error")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned)
+                });
             return Err(EvidenceExportError::rejected(code.as_deref()));
         }
         Ok(bytes)
@@ -284,7 +289,10 @@ impl Session {
             "nonce": nonce
         }))
         .map_err(|_| EvidenceExportError::startup_failed())?;
-        let mut stdin = child.stdin.take().ok_or_else(EvidenceExportError::startup_failed)?;
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(EvidenceExportError::startup_failed)?;
         stdin
             .write_all(&envelope)
             .and_then(|_| stdin.write_all(b"\n"))
@@ -451,8 +459,8 @@ fn request_json(
         .windows(4)
         .position(|window| window == b"\r\n\r\n")
         .ok_or_else(EvidenceExportError::request_failed)?;
-    let headers =
-        std::str::from_utf8(&response[..boundary]).map_err(|_| EvidenceExportError::request_failed())?;
+    let headers = std::str::from_utf8(&response[..boundary])
+        .map_err(|_| EvidenceExportError::request_failed())?;
     let mut lines = headers.split("\r\n");
     let mut parts = lines
         .next()
@@ -558,9 +566,14 @@ fn validate_document(value: &Value, material: &PlaylistEvidenceMaterial) -> bool
         ],
     ) || root.get("schema").and_then(Value::as_str)
         != Some("applaylist-playlist-revision-evidence-r1")
-        || root.get("personal_dj_model_training_authorized").and_then(Value::as_bool)
+        || root
+            .get("personal_dj_model_training_authorized")
+            .and_then(Value::as_bool)
             != Some(false)
-        || root.get("production_activation_authorized").and_then(Value::as_bool) != Some(false)
+        || root
+            .get("production_activation_authorized")
+            .and_then(Value::as_bool)
+            != Some(false)
     {
         return false;
     }
@@ -580,8 +593,10 @@ fn validate_document(value: &Value, material: &PlaylistEvidenceMaterial) -> bool
             "content_fingerprint",
             "created_at",
         ],
-    ) || revision.get("revision_id").and_then(Value::as_str) != Some(material.revision_id.as_str())
-        || revision.get("playlist_id").and_then(Value::as_str) != Some(material.playlist_id.as_str())
+    ) || revision.get("revision_id").and_then(Value::as_str)
+        != Some(material.revision_id.as_str())
+        || revision.get("playlist_id").and_then(Value::as_str)
+            != Some(material.playlist_id.as_str())
         || revision.get("revision_index").and_then(Value::as_u64)
             != Some(material.revision_index as u64)
     {
@@ -604,7 +619,13 @@ fn validate_document(value: &Value, material: &PlaylistEvidenceMaterial) -> bool
     };
     if !exact_keys(
         verification,
-        &["path_valid", "format", "track_count", "content_sha256", "byte_count"],
+        &[
+            "path_valid",
+            "format",
+            "track_count",
+            "content_sha256",
+            "byte_count",
+        ],
     ) || verification.get("path_valid").and_then(Value::as_bool) != Some(true)
         || verification.get("format").and_then(Value::as_str) != Some("m3u8")
         || verification.get("track_count").and_then(Value::as_u64)
@@ -620,8 +641,10 @@ fn validate_document(value: &Value, material: &PlaylistEvidenceMaterial) -> bool
 fn contains_forbidden_path_key(value: &Value) -> bool {
     match value {
         Value::Object(map) => map.iter().any(|(key, child)| {
-            matches!(key.as_str(), "path" | "file_path" | "source_path" | "output_path")
-                || contains_forbidden_path_key(child)
+            matches!(
+                key.as_str(),
+                "path" | "file_path" | "source_path" | "output_path"
+            ) || contains_forbidden_path_key(child)
         }),
         Value::Array(items) => items.iter().any(contains_forbidden_path_key),
         _ => false,
@@ -647,8 +670,8 @@ fn validate_material(value: &PlaylistEvidenceMaterial) -> Result<(), EvidenceExp
     {
         return Err(EvidenceExportError::invalid_response());
     }
-    let document: Value =
-        serde_json::from_str(&value.content_utf8).map_err(|_| EvidenceExportError::invalid_response())?;
+    let document: Value = serde_json::from_str(&value.content_utf8)
+        .map_err(|_| EvidenceExportError::invalid_response())?;
     if !validate_document(&document, value) {
         return Err(EvidenceExportError::invalid_response());
     }
@@ -664,7 +687,9 @@ fn normalize_target(mut target: PathBuf) -> Result<PathBuf, EvidenceExportError>
         Some(value) if value.eq_ignore_ascii_case("json") => {}
         Some(_) => return Err(EvidenceExportError::invalid_target()),
     }
-    let parent = target.parent().ok_or_else(EvidenceExportError::invalid_target)?;
+    let parent = target
+        .parent()
+        .ok_or_else(EvidenceExportError::invalid_target)?;
     if !parent.is_dir()
         || target
             .file_name()
@@ -680,7 +705,9 @@ fn normalize_target(mut target: PathBuf) -> Result<PathBuf, EvidenceExportError>
 }
 
 fn write_atomic(target: &Path, content: &[u8]) -> Result<(), EvidenceExportError> {
-    let parent = target.parent().ok_or_else(EvidenceExportError::invalid_target)?;
+    let parent = target
+        .parent()
+        .ok_or_else(EvidenceExportError::invalid_target)?;
     let temporary = parent.join(format!(
         ".applaylist-evidence-export-{}.tmp",
         Uuid::new_v4().simple()
@@ -733,13 +760,7 @@ pub async fn playlist_evidence_preview(
     bridge: State<'_, PlaylistEvidenceExportBridge>,
     app: AppHandle,
 ) -> Result<PlaylistEvidencePreview, DesktopHostError> {
-    let bytes = request_bytes(
-        bridge,
-        &app,
-        "/v1/playlist/evidence/preview",
-        revision_id,
-    )
-    .await?;
+    let bytes = request_bytes(bridge, &app, "/v1/playlist/evidence/preview", revision_id).await?;
     let preview: PlaylistEvidencePreview =
         serde_json::from_slice(&bytes).map_err(|_| EvidenceExportError::invalid_response())?;
     validate_preview(&preview).map_err(DesktopHostError::from)?;
@@ -752,13 +773,7 @@ pub async fn playlist_evidence_export_json(
     bridge: State<'_, PlaylistEvidenceExportBridge>,
     app: AppHandle,
 ) -> Result<Option<PlaylistEvidenceExportReceipt>, DesktopHostError> {
-    let bytes = request_bytes(
-        bridge,
-        &app,
-        "/v1/playlist/evidence/material",
-        revision_id,
-    )
-    .await?;
+    let bytes = request_bytes(bridge, &app, "/v1/playlist/evidence/material", revision_id).await?;
     let material: PlaylistEvidenceMaterial =
         serde_json::from_slice(&bytes).map_err(|_| EvidenceExportError::invalid_response())?;
     validate_material(&material).map_err(DesktopHostError::from)?;
@@ -852,7 +867,9 @@ mod tests {
         fs::create_dir_all(&root).expect("create target root");
         let without_extension = normalize_target(root.join("evidence")).expect("normalize target");
         assert_eq!(
-            without_extension.extension().and_then(|value| value.to_str()),
+            without_extension
+                .extension()
+                .and_then(|value| value.to_str()),
             Some("json")
         );
         assert!(normalize_target(root.join("evidence.txt")).is_err());

--- a/src-tauri/src/playlist_evidence_export.rs
+++ b/src-tauri/src/playlist_evidence_export.rs
@@ -447,8 +447,7 @@ fn request_json(
         .and_then(|_| stream.flush())
         .map_err(|_| EvidenceExportError::request_failed())?;
     let mut response = Vec::new();
-    stream
-        .by_ref()
+    std::io::Read::by_ref(&mut stream)
         .take(MAX_HTTP_RESPONSE_BYTES + 1)
         .read_to_end(&mut response)
         .map_err(|_| EvidenceExportError::request_failed())?;

--- a/src-tauri/src/playlist_evidence_export.rs
+++ b/src-tauri/src/playlist_evidence_export.rs
@@ -1,0 +1,863 @@
+use std::{
+    env,
+    fs::{self, OpenOptions},
+    io::{Read, Write},
+    net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream},
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    sync::mpsc,
+    thread,
+    time::{Duration, Instant},
+};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+use tauri::{AppHandle, Manager, State};
+use tauri_plugin_dialog::DialogExt;
+use uuid::Uuid;
+
+use crate::library_capability::DesktopHostError;
+
+const SIDECAR_EXECUTABLE_ENV: &str = "APPLAYLIST_DESKTOP_SIDECAR_EXECUTABLE";
+const BUNDLED_SIDECAR_RESOURCE: &str = "applaylist-sidecar/applaylist-sidecar";
+const PROTOCOL_VERSION: &str = "applaylist-sidecar-v1";
+const SECRET_HEADER: &str = "X-APPLAYLIST-Sidecar-Secret";
+const NONCE_HEADER: &str = "X-APPLAYLIST-Readiness-Nonce";
+const READY_TIMEOUT: Duration = Duration::from_secs(5);
+const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_READY_BYTES: usize = 8_192;
+const MAX_HTTP_RESPONSE_BYTES: u64 = 2 * 1024 * 1024;
+const MAX_JSON_BYTES: usize = 256 * 1024;
+const MAX_TOKEN: usize = 256;
+
+#[derive(Debug, Clone)]
+pub struct PlaylistEvidenceExportBridge {
+    executable: Option<PathBuf>,
+}
+
+impl PlaylistEvidenceExportBridge {
+    pub fn from_environment() -> Self {
+        Self {
+            executable: if cfg!(debug_assertions) {
+                env::var_os(SIDECAR_EXECUTABLE_ENV).map(PathBuf::from)
+            } else {
+                None
+            },
+        }
+    }
+
+    fn executable(&self, resource_dir: Option<&Path>) -> Result<PathBuf, EvidenceExportError> {
+        if let Some(path) = self.executable.as_ref() {
+            let canonical = path
+                .canonicalize()
+                .map_err(|_| EvidenceExportError::unavailable())?;
+            return canonical
+                .is_file()
+                .then_some(canonical)
+                .ok_or_else(EvidenceExportError::unavailable);
+        }
+        let root = resource_dir.ok_or_else(EvidenceExportError::not_configured)?;
+        let root = root
+            .canonicalize()
+            .map_err(|_| EvidenceExportError::unavailable())?;
+        let binary = root
+            .join(BUNDLED_SIDECAR_RESOURCE)
+            .canonicalize()
+            .map_err(|_| EvidenceExportError::unavailable())?;
+        if !binary.starts_with(&root) || !binary.is_file() {
+            return Err(EvidenceExportError::unavailable());
+        }
+        Ok(binary)
+    }
+
+    fn request(
+        &self,
+        path: &str,
+        revision_id: &str,
+        resource_dir: Option<&Path>,
+    ) -> Result<Vec<u8>, EvidenceExportError> {
+        let executable = self.executable(resource_dir)?;
+        let mut session = Session::connect(&executable)?;
+        let body = serde_json::to_vec(&json!({"revision_id": revision_id}))
+            .map_err(|_| EvidenceExportError::request_failed())?;
+        let response = session.post(path, &body);
+        session.shutdown();
+        let (status, bytes) = response?;
+        if status != 200 {
+            let code = serde_json::from_slice::<Value>(&bytes)
+                .ok()
+                .and_then(|value| value.get("error").and_then(Value::as_str).map(str::to_owned));
+            return Err(EvidenceExportError::rejected(code.as_deref()));
+        }
+        Ok(bytes)
+    }
+}
+
+impl Default for PlaylistEvidenceExportBridge {
+    fn default() -> Self {
+        Self::from_environment()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct EvidenceExportError {
+    code: &'static str,
+    message: &'static str,
+}
+
+impl EvidenceExportError {
+    const fn new(code: &'static str, message: &'static str) -> Self {
+        Self { code, message }
+    }
+    const fn not_configured() -> Self {
+        Self::new(
+            "desktop_playlist_evidence_sidecar_not_configured",
+            "The playlist evidence export service is not configured.",
+        )
+    }
+    const fn unavailable() -> Self {
+        Self::new(
+            "desktop_playlist_evidence_sidecar_unavailable",
+            "The playlist evidence export service is unavailable.",
+        )
+    }
+    const fn startup_failed() -> Self {
+        Self::new(
+            "desktop_playlist_evidence_sidecar_startup_failed",
+            "The playlist evidence export service could not start.",
+        )
+    }
+    const fn readiness_failed() -> Self {
+        Self::new(
+            "desktop_playlist_evidence_sidecar_readiness_failed",
+            "The playlist evidence export service did not become ready.",
+        )
+    }
+    const fn request_failed() -> Self {
+        Self::new(
+            "desktop_playlist_evidence_request_failed",
+            "The playlist evidence export request failed.",
+        )
+    }
+    const fn invalid_request() -> Self {
+        Self::new(
+            "invalid_playlist_evidence_export_request",
+            "The playlist evidence export request is invalid.",
+        )
+    }
+    const fn invalid_response() -> Self {
+        Self::new(
+            "desktop_playlist_evidence_response_invalid",
+            "The playlist evidence export response is invalid.",
+        )
+    }
+    const fn invalid_target() -> Self {
+        Self::new(
+            "playlist_evidence_export_target_invalid",
+            "The selected evidence export target is invalid.",
+        )
+    }
+    const fn target_exists() -> Self {
+        Self::new(
+            "playlist_evidence_export_target_exists",
+            "The selected evidence export target already exists; choose a new file name.",
+        )
+    }
+    const fn write_failed() -> Self {
+        Self::new(
+            "playlist_evidence_export_write_failed",
+            "The playlist evidence JSON file could not be written.",
+        )
+    }
+    fn rejected(code: Option<&str>) -> Self {
+        match code {
+            Some("playlist_evidence_revision_not_found") => Self::new(
+                "playlist_evidence_revision_not_found",
+                "The selected playlist revision was not found.",
+            ),
+            Some("playlist_export_track_missing") => Self::new(
+                "playlist_export_track_missing",
+                "A revision track is missing from the local track registry.",
+            ),
+            Some("playlist_export_track_unavailable") => Self::new(
+                "playlist_export_track_unavailable",
+                "A revision track file is unavailable.",
+            ),
+            Some("playlist_export_track_path_invalid") => Self::new(
+                "playlist_export_track_path_invalid",
+                "A revision track path is invalid.",
+            ),
+            Some("playlist_evidence_export_too_large") => Self::new(
+                "playlist_evidence_export_too_large",
+                "The JSON evidence export exceeds the bounded size limit.",
+            ),
+            Some("invalid_playlist_evidence_export_request") => Self::invalid_request(),
+            _ => Self::new(
+                "desktop_playlist_evidence_rejected",
+                "The playlist evidence export request was rejected.",
+            ),
+        }
+    }
+}
+
+impl From<EvidenceExportError> for DesktopHostError {
+    fn from(value: EvidenceExportError) -> Self {
+        DesktopHostError::new(value.code, value.message)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlaylistEvidencePreview {
+    schema: String,
+    revision_id: String,
+    playlist_id: String,
+    revision_index: usize,
+    format: String,
+    suggested_filename: String,
+    track_count: usize,
+    analysis_evidence_count: usize,
+    transition_pair_count: usize,
+    transition_evidence_pair_count: usize,
+    m3u8_path_valid: bool,
+    m3u8_content_sha256: String,
+    personal_dj_model_training_authorized: bool,
+    production_activation_authorized: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PlaylistEvidenceMaterial {
+    schema: String,
+    revision_id: String,
+    playlist_id: String,
+    revision_index: usize,
+    format: String,
+    suggested_filename: String,
+    track_count: usize,
+    m3u8_path_valid: bool,
+    m3u8_content_sha256: String,
+    content_utf8: String,
+    content_sha256: String,
+    byte_count: usize,
+    personal_dj_model_training_authorized: bool,
+    production_activation_authorized: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct PlaylistEvidenceExportReceipt {
+    revision_id: String,
+    format: String,
+    filename: String,
+    track_count: usize,
+    content_sha256: String,
+    bytes_written: usize,
+    m3u8_path_valid: bool,
+    m3u8_content_sha256: String,
+    personal_dj_model_training_authorized: bool,
+    production_activation_authorized: bool,
+}
+
+struct Session {
+    child: Child,
+    port: u16,
+    secret: String,
+    nonce: String,
+}
+
+impl Session {
+    fn connect(executable: &Path) -> Result<Self, EvidenceExportError> {
+        let secret = random_token();
+        let nonce = random_token();
+        let mut child = Command::new(executable)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|_| EvidenceExportError::startup_failed())?;
+        let envelope = serde_json::to_vec(&json!({
+            "protocol": PROTOCOL_VERSION,
+            "secret": secret,
+            "nonce": nonce
+        }))
+        .map_err(|_| EvidenceExportError::startup_failed())?;
+        let mut stdin = child.stdin.take().ok_or_else(EvidenceExportError::startup_failed)?;
+        stdin
+            .write_all(&envelope)
+            .and_then(|_| stdin.write_all(b"\n"))
+            .and_then(|_| stdin.flush())
+            .map_err(|_| EvidenceExportError::startup_failed())?;
+        drop(stdin);
+        let line = read_ready(&mut child)?;
+        let ready: Value =
+            serde_json::from_slice(&line).map_err(|_| EvidenceExportError::readiness_failed())?;
+        let port = validate_ready(&ready, &nonce)?;
+        let (status, health) = request_json(port, "GET", "/v1/health", &secret, &nonce, None)?;
+        if status != 200 {
+            return Err(EvidenceExportError::readiness_failed());
+        }
+        let health: Value =
+            serde_json::from_slice(&health).map_err(|_| EvidenceExportError::readiness_failed())?;
+        let nonce_hash = sha256_hex(nonce.as_bytes());
+        if health.get("status").and_then(Value::as_str) != Some("ready")
+            || health.get("protocol").and_then(Value::as_str) != Some(PROTOCOL_VERSION)
+            || health.get("nonce_sha256").and_then(Value::as_str) != Some(nonce_hash.as_str())
+        {
+            return Err(EvidenceExportError::readiness_failed());
+        }
+        Ok(Self {
+            child,
+            port,
+            secret,
+            nonce,
+        })
+    }
+
+    fn post(&mut self, path: &str, body: &[u8]) -> Result<(u16, Vec<u8>), EvidenceExportError> {
+        request_json(
+            self.port,
+            "POST",
+            path,
+            &self.secret,
+            &self.nonce,
+            Some(body),
+        )
+    }
+
+    fn shutdown(&mut self) {
+        let _ = request_json(
+            self.port,
+            "POST",
+            "/v1/shutdown",
+            &self.secret,
+            &self.nonce,
+            Some(&[]),
+        );
+        let deadline = Instant::now() + SHUTDOWN_TIMEOUT;
+        while Instant::now() < deadline {
+            match self.child.try_wait() {
+                Ok(Some(_)) => return,
+                Ok(None) => thread::sleep(Duration::from_millis(25)),
+                Err(_) => break,
+            }
+        }
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        if matches!(self.child.try_wait(), Ok(None)) {
+            let _ = self.child.kill();
+        }
+        let _ = self.child.wait();
+    }
+}
+
+fn read_ready(child: &mut Child) -> Result<Vec<u8>, EvidenceExportError> {
+    let mut stdout = child
+        .stdout
+        .take()
+        .ok_or_else(EvidenceExportError::readiness_failed)?;
+    let (sender, receiver) = mpsc::sync_channel(1);
+    thread::spawn(move || {
+        let mut line = Vec::new();
+        let result = (|| -> std::io::Result<Vec<u8>> {
+            for _ in 0..=MAX_READY_BYTES {
+                let mut byte = [0_u8; 1];
+                if stdout.read(&mut byte)? == 0 {
+                    break;
+                }
+                if byte[0] == b'\n' {
+                    return Ok(line);
+                }
+                line.push(byte[0]);
+            }
+            Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "invalid readiness line",
+            ))
+        })();
+        let _ = sender.send(result);
+    });
+    receiver
+        .recv_timeout(READY_TIMEOUT)
+        .map_err(|_| EvidenceExportError::readiness_failed())?
+        .map_err(|_| EvidenceExportError::readiness_failed())
+}
+
+fn validate_ready(value: &Value, nonce: &str) -> Result<u16, EvidenceExportError> {
+    let nonce_hash = sha256_hex(nonce.as_bytes());
+    if value.get("event").and_then(Value::as_str) != Some("ready")
+        || value.get("protocol").and_then(Value::as_str) != Some(PROTOCOL_VERSION)
+        || value.get("host").and_then(Value::as_str) != Some("127.0.0.1")
+        || value.get("nonce_sha256").and_then(Value::as_str) != Some(nonce_hash.as_str())
+        || value.get("process_id").and_then(Value::as_u64).unwrap_or(0) == 0
+    {
+        return Err(EvidenceExportError::readiness_failed());
+    }
+    value
+        .get("port")
+        .and_then(Value::as_u64)
+        .filter(|port| (1..=u16::MAX as u64).contains(port))
+        .map(|port| port as u16)
+        .ok_or_else(EvidenceExportError::readiness_failed)
+}
+
+fn request_json(
+    port: u16,
+    method: &str,
+    path: &str,
+    secret: &str,
+    nonce: &str,
+    body: Option<&[u8]>,
+) -> Result<(u16, Vec<u8>), EvidenceExportError> {
+    let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+    let mut stream = TcpStream::connect_timeout(&address, HTTP_TIMEOUT)
+        .map_err(|_| EvidenceExportError::request_failed())?;
+    stream
+        .set_read_timeout(Some(HTTP_TIMEOUT))
+        .map_err(|_| EvidenceExportError::request_failed())?;
+    stream
+        .set_write_timeout(Some(HTTP_TIMEOUT))
+        .map_err(|_| EvidenceExportError::request_failed())?;
+    let payload = body.unwrap_or(&[]);
+    let content_type = if body.is_some() {
+        "Content-Type: application/json\r\n"
+    } else {
+        ""
+    };
+    let request = format!(
+        "{method} {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\n{SECRET_HEADER}: {secret}\r\n{NONCE_HEADER}: {nonce}\r\n{content_type}Content-Length: {}\r\n\r\n",
+        payload.len()
+    );
+    stream
+        .write_all(request.as_bytes())
+        .and_then(|_| stream.write_all(payload))
+        .and_then(|_| stream.flush())
+        .map_err(|_| EvidenceExportError::request_failed())?;
+    let mut response = Vec::new();
+    stream
+        .by_ref()
+        .take(MAX_HTTP_RESPONSE_BYTES + 1)
+        .read_to_end(&mut response)
+        .map_err(|_| EvidenceExportError::request_failed())?;
+    if response.len() as u64 > MAX_HTTP_RESPONSE_BYTES {
+        return Err(EvidenceExportError::request_failed());
+    }
+    let boundary = response
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .ok_or_else(EvidenceExportError::request_failed)?;
+    let headers =
+        std::str::from_utf8(&response[..boundary]).map_err(|_| EvidenceExportError::request_failed())?;
+    let mut lines = headers.split("\r\n");
+    let mut parts = lines
+        .next()
+        .ok_or_else(EvidenceExportError::request_failed)?
+        .split_whitespace();
+    if parts.next() != Some("HTTP/1.1") {
+        return Err(EvidenceExportError::request_failed());
+    }
+    let status = parts
+        .next()
+        .and_then(|value| value.parse::<u16>().ok())
+        .ok_or_else(EvidenceExportError::request_failed)?;
+    let mut length = None;
+    for line in lines {
+        let Some((name, value)) = line.split_once(':') else {
+            return Err(EvidenceExportError::request_failed());
+        };
+        if name.eq_ignore_ascii_case("Content-Length") {
+            length = value.trim().parse::<usize>().ok();
+        }
+    }
+    let body = &response[boundary + 4..];
+    if length != Some(body.len()) {
+        return Err(EvidenceExportError::request_failed());
+    }
+    Ok((status, body.to_vec()))
+}
+
+fn random_token() -> String {
+    format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple())
+}
+
+fn sha256_hex(value: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(value))
+}
+
+fn token(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_TOKEN
+        && value.trim() == value
+        && !value.contains('/')
+        && !value.contains('\\')
+        && !value.chars().any(char::is_whitespace)
+        && !value.chars().any(char::is_control)
+}
+
+fn digest(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn safe_filename(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 128
+        && value.ends_with(".json")
+        && value.trim() == value
+        && !value.contains('/')
+        && !value.contains('\\')
+        && !value.chars().any(char::is_control)
+}
+
+fn validate_preview(value: &PlaylistEvidencePreview) -> Result<(), EvidenceExportError> {
+    if value.schema != "applaylist-desktop-playlist-evidence-preview-r1"
+        || !token(&value.revision_id)
+        || !token(&value.playlist_id)
+        || value.format != "json"
+        || !safe_filename(&value.suggested_filename)
+        || !(3..=8).contains(&value.track_count)
+        || value.analysis_evidence_count > value.track_count
+        || value.transition_pair_count != value.track_count - 1
+        || value.transition_evidence_pair_count > value.transition_pair_count
+        || !value.m3u8_path_valid
+        || !digest(&value.m3u8_content_sha256)
+        || value.personal_dj_model_training_authorized
+        || value.production_activation_authorized
+    {
+        return Err(EvidenceExportError::invalid_response());
+    }
+    Ok(())
+}
+
+fn exact_keys(map: &Map<String, Value>, expected: &[&str]) -> bool {
+    map.len() == expected.len() && expected.iter().all(|key| map.contains_key(*key))
+}
+
+fn validate_document(value: &Value, material: &PlaylistEvidenceMaterial) -> bool {
+    let Some(root) = value.as_object() else {
+        return false;
+    };
+    if !exact_keys(
+        root,
+        &[
+            "schema",
+            "revision",
+            "lineage",
+            "tracks",
+            "adjacent_transitions",
+            "m3u8_verification",
+            "personal_dj_model_training_authorized",
+            "production_activation_authorized",
+        ],
+    ) || root.get("schema").and_then(Value::as_str)
+        != Some("applaylist-playlist-revision-evidence-r1")
+        || root.get("personal_dj_model_training_authorized").and_then(Value::as_bool)
+            != Some(false)
+        || root.get("production_activation_authorized").and_then(Value::as_bool) != Some(false)
+    {
+        return false;
+    }
+    let Some(revision) = root.get("revision").and_then(Value::as_object) else {
+        return false;
+    };
+    if !exact_keys(
+        revision,
+        &[
+            "revision_id",
+            "playlist_id",
+            "parent_revision_id",
+            "revision_index",
+            "source_proposal_id",
+            "source_path_id",
+            "operation",
+            "content_fingerprint",
+            "created_at",
+        ],
+    ) || revision.get("revision_id").and_then(Value::as_str) != Some(material.revision_id.as_str())
+        || revision.get("playlist_id").and_then(Value::as_str) != Some(material.playlist_id.as_str())
+        || revision.get("revision_index").and_then(Value::as_u64)
+            != Some(material.revision_index as u64)
+    {
+        return false;
+    }
+    let Some(tracks) = root.get("tracks").and_then(Value::as_array) else {
+        return false;
+    };
+    if tracks.len() != material.track_count || !(3..=8).contains(&tracks.len()) {
+        return false;
+    }
+    let Some(transitions) = root.get("adjacent_transitions").and_then(Value::as_array) else {
+        return false;
+    };
+    if transitions.len() != tracks.len() - 1 {
+        return false;
+    }
+    let Some(verification) = root.get("m3u8_verification").and_then(Value::as_object) else {
+        return false;
+    };
+    if !exact_keys(
+        verification,
+        &["path_valid", "format", "track_count", "content_sha256", "byte_count"],
+    ) || verification.get("path_valid").and_then(Value::as_bool) != Some(true)
+        || verification.get("format").and_then(Value::as_str) != Some("m3u8")
+        || verification.get("track_count").and_then(Value::as_u64)
+            != Some(material.track_count as u64)
+        || verification.get("content_sha256").and_then(Value::as_str)
+            != Some(material.m3u8_content_sha256.as_str())
+    {
+        return false;
+    }
+    !contains_forbidden_path_key(value)
+}
+
+fn contains_forbidden_path_key(value: &Value) -> bool {
+    match value {
+        Value::Object(map) => map.iter().any(|(key, child)| {
+            matches!(key.as_str(), "path" | "file_path" | "source_path" | "output_path")
+                || contains_forbidden_path_key(child)
+        }),
+        Value::Array(items) => items.iter().any(contains_forbidden_path_key),
+        _ => false,
+    }
+}
+
+fn validate_material(value: &PlaylistEvidenceMaterial) -> Result<(), EvidenceExportError> {
+    if value.schema != "applaylist-desktop-playlist-evidence-material-r1"
+        || !token(&value.revision_id)
+        || !token(&value.playlist_id)
+        || value.format != "json"
+        || !safe_filename(&value.suggested_filename)
+        || !(3..=8).contains(&value.track_count)
+        || !value.m3u8_path_valid
+        || !digest(&value.m3u8_content_sha256)
+        || value.byte_count == 0
+        || value.byte_count > MAX_JSON_BYTES
+        || value.content_utf8.len() != value.byte_count
+        || !digest(&value.content_sha256)
+        || sha256_hex(value.content_utf8.as_bytes()) != value.content_sha256
+        || value.personal_dj_model_training_authorized
+        || value.production_activation_authorized
+    {
+        return Err(EvidenceExportError::invalid_response());
+    }
+    let document: Value =
+        serde_json::from_str(&value.content_utf8).map_err(|_| EvidenceExportError::invalid_response())?;
+    if !validate_document(&document, value) {
+        return Err(EvidenceExportError::invalid_response());
+    }
+    Ok(())
+}
+
+fn normalize_target(mut target: PathBuf) -> Result<PathBuf, EvidenceExportError> {
+    let extension = target.extension().and_then(|value| value.to_str());
+    match extension {
+        None => {
+            target.set_extension("json");
+        }
+        Some(value) if value.eq_ignore_ascii_case("json") => {}
+        Some(_) => return Err(EvidenceExportError::invalid_target()),
+    }
+    let parent = target.parent().ok_or_else(EvidenceExportError::invalid_target)?;
+    if !parent.is_dir()
+        || target
+            .file_name()
+            .and_then(|value| value.to_str())
+            .is_none()
+    {
+        return Err(EvidenceExportError::invalid_target());
+    }
+    if target.exists() {
+        return Err(EvidenceExportError::target_exists());
+    }
+    Ok(target)
+}
+
+fn write_atomic(target: &Path, content: &[u8]) -> Result<(), EvidenceExportError> {
+    let parent = target.parent().ok_or_else(EvidenceExportError::invalid_target)?;
+    let temporary = parent.join(format!(
+        ".applaylist-evidence-export-{}.tmp",
+        Uuid::new_v4().simple()
+    ));
+    let result = (|| -> std::io::Result<()> {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)?;
+        file.write_all(content)?;
+        file.sync_all()?;
+        drop(file);
+        fs::rename(&temporary, target)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+        return Err(EvidenceExportError::write_failed());
+    }
+    Ok(())
+}
+
+async fn request_bytes(
+    bridge: State<'_, PlaylistEvidenceExportBridge>,
+    app: &AppHandle,
+    path: &'static str,
+    revision_id: String,
+) -> Result<Vec<u8>, DesktopHostError> {
+    if !token(&revision_id) {
+        return Err(EvidenceExportError::invalid_request().into());
+    }
+    let resource_dir = app.path().resource_dir().ok();
+    let bridge = bridge.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        bridge.request(path, &revision_id, resource_dir.as_deref())
+    })
+    .await
+    .map_err(|_| {
+        DesktopHostError::new(
+            "desktop_playlist_evidence_task_failed",
+            "The playlist evidence export task failed.",
+        )
+    })?
+    .map_err(DesktopHostError::from)
+}
+
+#[tauri::command]
+pub async fn playlist_evidence_preview(
+    revision_id: String,
+    bridge: State<'_, PlaylistEvidenceExportBridge>,
+    app: AppHandle,
+) -> Result<PlaylistEvidencePreview, DesktopHostError> {
+    let bytes = request_bytes(
+        bridge,
+        &app,
+        "/v1/playlist/evidence/preview",
+        revision_id,
+    )
+    .await?;
+    let preview: PlaylistEvidencePreview =
+        serde_json::from_slice(&bytes).map_err(|_| EvidenceExportError::invalid_response())?;
+    validate_preview(&preview).map_err(DesktopHostError::from)?;
+    Ok(preview)
+}
+
+#[tauri::command]
+pub async fn playlist_evidence_export_json(
+    revision_id: String,
+    bridge: State<'_, PlaylistEvidenceExportBridge>,
+    app: AppHandle,
+) -> Result<Option<PlaylistEvidenceExportReceipt>, DesktopHostError> {
+    let bytes = request_bytes(
+        bridge,
+        &app,
+        "/v1/playlist/evidence/material",
+        revision_id,
+    )
+    .await?;
+    let material: PlaylistEvidenceMaterial =
+        serde_json::from_slice(&bytes).map_err(|_| EvidenceExportError::invalid_response())?;
+    validate_material(&material).map_err(DesktopHostError::from)?;
+
+    let Some(selected) = app
+        .dialog()
+        .file()
+        .set_file_name(&material.suggested_filename)
+        .add_filter("APPLAYLIST JSON evidence", &["json"])
+        .blocking_save_file()
+    else {
+        return Ok(None);
+    };
+    let selected_path = selected
+        .into_path()
+        .map_err(|_| DesktopHostError::from(EvidenceExportError::invalid_target()))?;
+    let target = normalize_target(selected_path).map_err(DesktopHostError::from)?;
+    write_atomic(&target, material.content_utf8.as_bytes()).map_err(DesktopHostError::from)?;
+    let filename = target
+        .file_name()
+        .and_then(|value| value.to_str())
+        .filter(|value| safe_filename(value))
+        .ok_or_else(|| DesktopHostError::from(EvidenceExportError::invalid_target()))?
+        .to_owned();
+
+    Ok(Some(PlaylistEvidenceExportReceipt {
+        revision_id: material.revision_id,
+        format: material.format,
+        filename,
+        track_count: material.track_count,
+        content_sha256: material.content_sha256,
+        bytes_written: material.byte_count,
+        m3u8_path_valid: material.m3u8_path_valid,
+        m3u8_content_sha256: material.m3u8_content_sha256,
+        personal_dj_model_training_authorized: false,
+        production_activation_authorized: false,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn evidence_preview_rejects_authority_escalation() {
+        let valid = serde_json::from_value::<PlaylistEvidencePreview>(json!({
+            "schema":"applaylist-desktop-playlist-evidence-preview-r1",
+            "revision_id":"prv_abc",
+            "playlist_id":"plr_abc",
+            "revision_index":2,
+            "format":"json",
+            "suggested_filename":"APPLAYLIST_prv_abc_evidence.json",
+            "track_count":3,
+            "analysis_evidence_count":2,
+            "transition_pair_count":2,
+            "transition_evidence_pair_count":1,
+            "m3u8_path_valid":true,
+            "m3u8_content_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "personal_dj_model_training_authorized":false,
+            "production_activation_authorized":false
+        }))
+        .expect("valid preview");
+        assert!(validate_preview(&valid).is_ok());
+
+        let escalated = serde_json::from_value::<PlaylistEvidencePreview>(json!({
+            "schema":"applaylist-desktop-playlist-evidence-preview-r1",
+            "revision_id":"prv_abc",
+            "playlist_id":"plr_abc",
+            "revision_index":2,
+            "format":"json",
+            "suggested_filename":"APPLAYLIST_prv_abc_evidence.json",
+            "track_count":3,
+            "analysis_evidence_count":2,
+            "transition_pair_count":2,
+            "transition_evidence_pair_count":1,
+            "m3u8_path_valid":true,
+            "m3u8_content_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "personal_dj_model_training_authorized":true,
+            "production_activation_authorized":false
+        }))
+        .expect("shape valid");
+        assert!(validate_preview(&escalated).is_err());
+    }
+
+    #[test]
+    fn target_normalization_enforces_json_and_non_overwrite() {
+        let root = std::env::temp_dir().join(format!(
+            "applaylist-evidence-export-target-{}",
+            Uuid::new_v4().simple()
+        ));
+        fs::create_dir_all(&root).expect("create target root");
+        let without_extension = normalize_target(root.join("evidence")).expect("normalize target");
+        assert_eq!(
+            without_extension.extension().and_then(|value| value.to_str()),
+            Some("json")
+        );
+        assert!(normalize_target(root.join("evidence.txt")).is_err());
+        fs::write(root.join("exists.json"), b"existing").expect("write existing");
+        assert!(normalize_target(root.join("exists.json")).is_err());
+        let _ = fs::remove_dir_all(root);
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,8 @@
         "main-library-root",
         "main-set-proposal",
         "main-playlist-editor",
-        "main-playlist-export"
+        "main-playlist-export",
+        "main-playlist-evidence-export"
       ]
     },
     "withGlobalTauri": true

--- a/tests/test_desktop_playlist_evidence_export.py
+++ b/tests/test_desktop_playlist_evidence_export.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from data.connection import get_sqlite_connection
+from data.repositories.analysis_evidence_repository import AnalysisEvidenceRepository
+from data.repositories.music_intelligence_repository import MusicIntelligenceRepository
+from data.repositories.playlist_revision_repository import PlaylistRevisionRepository
+from services.desktop.playlist_evidence_export_transport import (
+    DesktopPlaylistEvidenceExportError,
+    DesktopPlaylistEvidenceExportTransport,
+)
+from tests.test_desktop_playlist_export_transport import _seed_export_revision
+from tests.test_desktop_readiness_sidecar import _finish, _request
+from tests.test_desktop_set_proposal_transport import (
+    _configure_database,
+    _start_extended_sidecar,
+)
+
+
+def _seed_analysis_and_transition(revision: dict[str, object]) -> None:
+    analysis = AnalysisEvidenceRepository()
+    items = revision["items"]
+    assert isinstance(items, tuple)
+    first_evidence_id = None
+    for index, item in enumerate(items):
+        track_id = str(item["track_id"])
+        evidence = analysis.append_evidence(
+            track_id=track_id,
+            provider="fixture-provider",
+            analysis_version="fixture-v1",
+            provider_version="1.0",
+            algorithm_version="algo-1",
+            bpm=128.0 + index,
+            bpm_confidence=0.9,
+            key_tonic="C",
+            key_scale="minor",
+            camelot="5A",
+            key_confidence=0.8,
+            energy=0.5 + index * 0.1,
+            duration_seconds=300.0 + index,
+            warnings=("fixture_warning",),
+        )
+        if index == 0:
+            first_evidence_id = evidence.evidence_id
+            analysis.append_correction(
+                track_id=track_id,
+                base_evidence_id=evidence.evidence_id,
+                values={"bpm": 129.0},
+                reason="fixture correction",
+            )
+    assert first_evidence_id is not None
+
+    source = str(items[0]["track_id"])
+    target = str(items[1]["track_id"])
+    MusicIntelligenceRepository().ensure_schema()
+    payload = json.dumps(
+        {"fixture": "bundle59", "source": source, "target": target},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    with get_sqlite_connection() as conn:
+        conn.execute(
+            '''
+            INSERT INTO transition_assessment_snapshots (
+                snapshot_id, transition_id, source_track_id, source_segment_id,
+                target_track_id, target_segment_id, assessment_version, policy_version,
+                context_id, context_version, payload_json, payload_sha256
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ''',
+            (
+                "tas_fixture_bundle59",
+                "tr_fixture_bundle59",
+                source,
+                f"seg:{source}",
+                target,
+                f"seg:{target}",
+                "transition-assessment-r1",
+                "transition-policy-r1",
+                "ctx_fixture",
+                "ctx-v1",
+                payload,
+                digest,
+            ),
+        )
+        conn.commit()
+
+
+def test_json_evidence_material_is_deterministic_path_safe_and_revision_immutable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_database(monkeypatch, tmp_path)
+    revision, paths = _seed_export_revision(tmp_path)
+    _seed_analysis_and_transition(revision)
+    transport = DesktopPlaylistEvidenceExportTransport()
+    ledger = PlaylistRevisionRepository()
+    before = ledger.count_revisions(str(revision["playlist_id"]))
+
+    preview = transport.preview(revision_id=str(revision["revision_id"]))
+    first = transport.material(revision_id=str(revision["revision_id"]))
+    second = transport.material(revision_id=str(revision["revision_id"]))
+
+    assert first == second
+    assert preview["schema"] == "applaylist-desktop-playlist-evidence-preview-r1"
+    assert preview["m3u8_path_valid"] is True
+    assert preview["track_count"] == 3
+    assert preview["analysis_evidence_count"] == 3
+    assert preview["transition_pair_count"] == 2
+    assert preview["transition_evidence_pair_count"] == 1
+    assert preview["personal_dj_model_training_authorized"] is False
+    assert preview["production_activation_authorized"] is False
+
+    content = str(first["content_utf8"])
+    assert first["byte_count"] == len(content.encode("utf-8"))
+    assert first["content_sha256"] == hashlib.sha256(content.encode("utf-8")).hexdigest()
+    document = json.loads(content)
+    assert document["schema"] == "applaylist-playlist-revision-evidence-r1"
+    assert document["revision"]["revision_id"] == revision["revision_id"]
+    assert document["lineage"][-1]["revision_id"] == revision["revision_id"]
+    assert document["tracks"][0]["analysis"]["status"] == "present"
+    assert document["tracks"][0]["analysis"]["active_correction"]["payload"] == {"bpm": 129.0}
+    assert document["adjacent_transitions"][0]["status"] == "present"
+    assert document["adjacent_transitions"][0]["snapshots"][0]["snapshot_id"] == "tas_fixture_bundle59"
+    assert document["adjacent_transitions"][1]["status"] == "missing"
+    assert document["m3u8_verification"]["path_valid"] is True
+    assert document["m3u8_verification"]["content_sha256"] == first["m3u8_content_sha256"]
+    assert document["personal_dj_model_training_authorized"] is False
+    assert document["production_activation_authorized"] is False
+
+    for path in paths:
+        assert str(path) not in content
+    assert "content_utf8" not in document
+    assert ledger.count_revisions(str(revision["playlist_id"])) == before
+
+
+def test_json_evidence_export_fails_closed_when_m3u8_path_verification_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_database(monkeypatch, tmp_path)
+    revision, paths = _seed_export_revision(tmp_path)
+    paths[1].unlink()
+
+    with pytest.raises(DesktopPlaylistEvidenceExportError) as exc_info:
+        DesktopPlaylistEvidenceExportTransport().material(
+            revision_id=str(revision["revision_id"])
+        )
+    assert exc_info.value.code == "playlist_export_track_unavailable"
+
+
+def test_json_evidence_export_keeps_missing_analysis_and_transition_explicit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_database(monkeypatch, tmp_path)
+    revision, _ = _seed_export_revision(tmp_path)
+    material = DesktopPlaylistEvidenceExportTransport().material(
+        revision_id=str(revision["revision_id"])
+    )
+    document = json.loads(str(material["content_utf8"]))
+    assert [item["analysis"]["status"] for item in document["tracks"]] == [
+        "missing",
+        "missing",
+        "missing",
+    ]
+    assert [item["status"] for item in document["adjacent_transitions"]] == [
+        "missing",
+        "missing",
+    ]
+
+
+def test_authenticated_json_evidence_routes_are_strict_and_path_safe(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    database = _configure_database(monkeypatch, tmp_path)
+    revision, paths = _seed_export_revision(tmp_path)
+    _seed_analysis_and_transition(revision)
+    process, ready = _start_extended_sidecar(database)
+    body = json.dumps({"revision_id": revision["revision_id"]}).encode("utf-8")
+    try:
+        status, payload = _request(
+            ready,
+            method="POST",
+            path="/v1/playlist/evidence/preview",
+            secret="X" * 48,
+            body=body,
+        )
+        assert status == 401
+        assert payload == {"error": "unauthorized"}
+
+        status, payload = _request(
+            ready,
+            method="POST",
+            path="/v1/playlist/evidence/preview",
+            body=json.dumps(
+                {"revision_id": revision["revision_id"], "path": "/must/not/pass"}
+            ).encode("utf-8"),
+        )
+        assert status == 400
+        assert payload == {"error": "invalid_playlist_evidence_export_request"}
+
+        status, preview = _request(
+            ready,
+            method="POST",
+            path="/v1/playlist/evidence/preview",
+            body=body,
+        )
+        assert status == 200
+        encoded_preview = json.dumps(preview, sort_keys=True)
+        for path in paths:
+            assert str(path) not in encoded_preview
+        assert preview["m3u8_path_valid"] is True
+
+        status, material = _request(
+            ready,
+            method="POST",
+            path="/v1/playlist/evidence/material",
+            body=body,
+        )
+        assert status == 200
+        assert material["schema"] == "applaylist-desktop-playlist-evidence-material-r1"
+        document = json.loads(material["content_utf8"])
+        for path in paths:
+            assert str(path) not in material["content_utf8"]
+        assert document["revision"]["revision_id"] == revision["revision_id"]
+        assert document["m3u8_verification"]["path_valid"] is True
+
+        status, shutdown = _request(ready, method="POST", path="/v1/shutdown")
+        assert status == 202
+        assert shutdown == {"status": "shutting_down"}
+        _finish(process)
+    finally:
+        if process.poll() is None:
+            process.kill()
+            _finish(process)

--- a/tests/test_desktop_playlist_evidence_renderer.py
+++ b/tests/test_desktop_playlist_evidence_renderer.py
@@ -53,8 +53,9 @@ def test_playlist_evidence_renderer_is_external_strict_and_path_safe() -> None:
         "X-APPLAYLIST-Readiness-Nonce",
         "127.0.0.1",
         "content_utf8",
-        "source_path",
-        "output_path",
+        '"path"',
+        '"file_path"',
+        '"output_path"',
     ):
         assert forbidden not in js
 
@@ -72,7 +73,7 @@ def test_playlist_evidence_tauri_surface_is_separate_and_narrow() -> None:
         assert f"allow-{command.replace('_', '-')}" in capability["permissions"]
 
     assert ".manage(PlaylistEvidenceExportBridge::from_environment())" in lib_rs
-    assert '"main-playlist-evidence-export"' in conf["app"]["security"]["capabilities"]
+    assert "main-playlist-evidence-export" in conf["app"]["security"]["capabilities"]
     assert "#[serde(deny_unknown_fields)]" in rust
     assert '"/v1/playlist/evidence/preview"' in rust
     assert '"/v1/playlist/evidence/material"' in rust

--- a/tests/test_desktop_playlist_evidence_renderer.py
+++ b/tests/test_desktop_playlist_evidence_renderer.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HTML = ROOT / "desktop" / "host-proof" / "index.html"
+JS = ROOT / "desktop" / "host-proof" / "playlist-evidence-export.js"
+BUILD_RS = ROOT / "src-tauri" / "build.rs"
+LIB_RS = ROOT / "src-tauri" / "src" / "lib.rs"
+RUST = ROOT / "src-tauri" / "src" / "playlist_evidence_export.rs"
+CAPABILITY = ROOT / "src-tauri" / "capabilities" / "main-playlist-evidence-export.json"
+TAURI_CONF = ROOT / "src-tauri" / "tauri.conf.json"
+
+
+def test_playlist_evidence_renderer_is_external_strict_and_path_safe() -> None:
+    html = HTML.read_text(encoding="utf-8")
+    js = JS.read_text(encoding="utf-8")
+
+    assert '<script src="./playlist-evidence-export.js" defer></script>' in html
+    for required in (
+        'id="playlist-evidence-export"',
+        'id="playlist-evidence-revision"',
+        'id="playlist-evidence-preview"',
+        'id="playlist-evidence-write"',
+        'id="playlist-evidence-preview-result"',
+        'id="playlist-evidence-receipt"',
+    ):
+        assert required in html
+
+    assert 'originalInvoke("playlist_evidence_preview", {' in js
+    assert 'originalInvoke("playlist_evidence_export_json", {' in js
+    assert "applaylist-desktop-playlist-evidence-preview-r1" in js
+    assert "m3u8_path_valid === true" in js
+    assert "validDigest" in js
+    assert "exactKeys" in js
+    assert "document.createElement" in js
+    assert ".textContent" in js
+    assert ".innerHTML" not in js
+    assert "insertAdjacentHTML" not in js
+
+    for forbidden in (
+        "fetch(",
+        "XMLHttpRequest",
+        "WebSocket",
+        "__TAURI__.fs",
+        "__TAURI__.shell",
+        "__TAURI__.http",
+        "plugin:fs",
+        "plugin:shell",
+        "/v1/playlist/evidence/",
+        "X-APPLAYLIST-Sidecar-Secret",
+        "X-APPLAYLIST-Readiness-Nonce",
+        "127.0.0.1",
+        "content_utf8",
+        "source_path",
+        "output_path",
+    ):
+        assert forbidden not in js
+
+
+def test_playlist_evidence_tauri_surface_is_separate_and_narrow() -> None:
+    build_rs = BUILD_RS.read_text(encoding="utf-8")
+    lib_rs = LIB_RS.read_text(encoding="utf-8")
+    rust = RUST.read_text(encoding="utf-8")
+    capability = json.loads(CAPABILITY.read_text(encoding="utf-8"))
+    conf = json.loads(TAURI_CONF.read_text(encoding="utf-8"))
+
+    for command in ("playlist_evidence_preview", "playlist_evidence_export_json"):
+        assert f'"{command}"' in build_rs
+        assert f"playlist_evidence_export::{command}" in lib_rs
+        assert f"allow-{command.replace('_', '-')}" in capability["permissions"]
+
+    assert ".manage(PlaylistEvidenceExportBridge::from_environment())" in lib_rs
+    assert '"main-playlist-evidence-export"' in conf["app"]["security"]["capabilities"]
+    assert "#[serde(deny_unknown_fields)]" in rust
+    assert '"/v1/playlist/evidence/preview"' in rust
+    assert '"/v1/playlist/evidence/material"' in rust
+    assert "blocking_save_file" in rust
+    assert "contains_forbidden_path_key" in rust
+    assert 'add_filter("APPLAYLIST JSON evidence", &["json"])' in rust
+    assert "personal_dj_model_training_authorized" in rust
+    assert "production_activation_authorized" in rust

--- a/tests/test_desktop_set_proposal_renderer.py
+++ b/tests/test_desktop_set_proposal_renderer.py
@@ -87,6 +87,7 @@ def test_set_proposal_tauri_surface_is_separate_and_narrow() -> None:
         "main-set-proposal",
         "main-playlist-editor",
         "main-playlist-export",
+        "main-playlist-evidence-export",
     }
 
     assert "#[serde(deny_unknown_fields)]" in rust


### PR DESCRIPTION
Closes #137 when merged.

## Summary

Adds deterministic JSON evidence export for one explicitly selected immutable `PlaylistRevision`, paired with Bundle 58 M3U8 path-validity verification.

The JSON companion records immutable revision lineage, ordered track evidence, active corrections, persisted adjacent TransitionAssessment metadata when available, and an M3U8 verification digest — without exposing filesystem paths.

## Exact identity

- base branch: `feature/bundle-0-bootstrap`
- exact base SHA: `35be83c47d2d367a60f6ac7140f0f9cd1b5fb52a`
- head branch: `feature/bundle-59-json-evidence-export-r1`
- exact head SHA: `155acfa7f6327b3ceebe8e9e731d7a327a5fb4e3`
- compare: 18 commits ahead / 0 behind / 15 changed files
- merge base equals exact canonical base `35be83c47d2d367a60f6ac7140f0f9cd1b5fb52a`

## Product flow

```text
immutable PlaylistRevision
  -> exact lineage
  -> persisted AnalysisEvidence + active correction
  -> persisted adjacent TransitionAssessment metadata or explicit missing
  -> Bundle 58 M3U8 path verification
  -> deterministic canonical JSON
  -> authenticated private material
  -> trusted Rust validation
  -> native save dialog
  -> atomic local .json write
  -> renderer-safe receipt
```

## Authority / privacy boundary

- `PlaylistRevisionRepository` remains sole playlist revision authority
- Bundle 58 `DesktopPlaylistExportTransport.material()` remains path-validity authority
- `AnalysisEvidenceRepository` is read only
- `TransitionEvidenceIndex` is read-only metadata over canonical persisted TransitionAssessment snapshots and re-verifies stored payload SHA-256
- no transition assessment is synthesized when missing
- JSON document contains no source filesystem paths, output paths, sidecar secrets, raw M3U8 material or raw exceptions
- private JSON material is consumed only by trusted Rust host
- renderer has no fs/shell/http authority
- exact revision ID is always explicit; no implicit current-head substitution

## Determinism / path verification

- UTF-8 canonical JSON with sorted keys, compact separators and final newline
- 256 KiB material bound
- deterministic SHA-256 + byte count for identical persisted state
- M3U8 path verification reuses Bundle 58, so every revision track must resolve to an existing canonical local TrackRecord file
- no audio bytes are read or hashed

## Native write semantics

- explicit native Save dialog
- cancel => no write
- `.json` enforced
- existing target rejected instead of silent overwrite
- bounded temp file + sync + rename
- sanitized receipt returns basename only plus revision ID, JSON SHA-256, byte count, M3U8 path-valid flag and M3U8 SHA-256

## Verification

Exact-head verification for `155acfa7f6327b3ceebe8e9e731d7a327a5fb4e3`:

- PR Guard #278: SUCCESS
- CI #764: SUCCESS
- Python 3.11: compile PASS, critical lint PASS, `410 passed, 6 warnings in 46.03s`
- Python 3.11 evidence artifact ID `9350230782`, SHA-256 `278aa4c38fe7537a42596a4a0479f1fdab44a98bf2086479f4d98c91d0bb73da`
- Python 3.12: compile PASS, critical lint PASS, `410 passed, 5 warnings in 46.22s`
- Python 3.12 evidence artifact ID `9350230355`, SHA-256 `dae9d73ba0c545bb56a291d27ab9cd0ed956d5fb834b143950f31eed88cc2fd0`
- Desktop Rust #96: SUCCESS — rustfmt, compile-only bundled resource fixture, Cargo check and Cargo test all PASS
- Desktop Sidecar Proof #61: SUCCESS — Ubuntu and macOS sidecar unit/process tests, target-native build, packaged smoke, manifest verification and proof upload all PASS
- Linux packaged proof artifact ID `9350237977`, SHA-256 `31515628e33d984ce41aa38ab159c1e57ebcdc9e8723952ce3bd168a03d94e6e`
- macOS packaged proof artifact ID `9350283859`, SHA-256 `1a0094cbd77afa3a6602ebc5eb849308768b75f9bef81e9a8670c04458b46b54`
- unresolved review threads: `0`
- submitted reviews: `0`
- GitHub compare: 18 commits ahead / 0 behind; merge base is exact canonical base

First-pass diagnostics were repaired forward-only without force push or history rewrite:

- initial head `5f62f615475ca4e8fa6c57361259c1c895a58603`: two erroneous renderer contract assertions plus mechanical rustfmt failure
- intermediate head `ce119355d3b544a298ba8b457bd89fe9d6b9f4b8`: Python CI passed, then pinned Rust 1.88 exposed one `TcpStream::by_ref()` ambiguity
- current head `155acfa7f6327b3ceebe8e9e731d7a327a5fb4e3`: disambiguated with `std::io::Read::by_ref(&mut stream)`; all exact-head gates pass

## Bundle Context

Bundle 58 is canonical at `35be83c47d2d367a60f6ac7140f0f9cd1b5fb52a` and provides explicit immutable-revision M3U8 export. Bundle 59 adds the machine-readable evidence companion and path-valid export proof required by the R4 interoperability release roadmap.

## Non-scope

- vendor DB/XML mutation
- selected-transition editor UI
- regeneration around locks
- audio copy/transcode/read/hash
- MIR/provider execution
- optimizer rerun
- Personal DJ Model training
- production activation
- cloud upload/sync
- release/deploy/signing/notarization

`MERGE_AUTHORIZATION=NO`
`RELEASE_AUTHORIZATION=NO`
`DEPLOY_AUTHORIZATION=NO`