### PR TITLE
Bundle 61: selected transition inspection R1

### DIFF
--- a/desktop/host-proof/index.html
+++ b/desktop/host-proof/index.html
@@ -11,6 +11,7 @@
   <script src="./playlist-export.js" defer></script>
   <script src="./playlist-evidence-export.js" defer></script>
   <script src="./playlist-vendor-interop.js" defer></script>
+  <script src="./transition-inspector.js" defer></script>
   <script src="./playlist-editor.js" defer></script>
   <script src="./set-proposal.js" defer></script>
 </head>
@@ -163,6 +164,20 @@
       <div id="playlist-editor-source"></div>
       <div id="playlist-editor-current"></div>
       <div id="playlist-editor-history"></div>
+    </section>
+
+    <section id="transition-inspector" aria-labelledby="transition-inspector-heading">
+      <h2 id="transition-inspector-heading">Selected Transition Inspector</h2>
+      <p>Inspect only already-persisted TransitionAssessment evidence for one adjacent pair in one exact immutable revision. Inspection never recomputes a transition or mutates the playlist.</p>
+      <div class="actions">
+        <label for="transition-inspector-revision">Revision</label>
+        <select id="transition-inspector-revision" disabled></select>
+        <label for="transition-inspector-pair">Adjacent transition</label>
+        <select id="transition-inspector-pair" disabled></select>
+        <button id="transition-inspector-load" type="button" disabled>Inspect persisted transition</button>
+      </div>
+      <p id="transition-inspector-status" class="status">Accept a Set Proposal revision to enable transition inspection.</p>
+      <div id="transition-inspector-result"></div>
     </section>
 
     <section id="playlist-export" aria-labelledby="playlist-export-heading">

--- a/desktop/host-proof/transition-inspector.js
+++ b/desktop/host-proof/transition-inspector.js
@@ -1,0 +1,408 @@
+(() => {
+  "use strict";
+
+  const tauriCore = window.__TAURI__?.core;
+  const originalInvoke = tauriCore?.invoke;
+  const section = document.getElementById("transition-inspector");
+  const status = document.getElementById("transition-inspector-status");
+  const revisionSelect = document.getElementById("transition-inspector-revision");
+  const pairSelect = document.getElementById("transition-inspector-pair");
+  const inspectButton = document.getElementById("transition-inspector-load");
+  const resultNode = document.getElementById("transition-inspector-result");
+
+  if (
+    !section ||
+    !status ||
+    !revisionSelect ||
+    !pairSelect ||
+    !inspectButton ||
+    !resultNode ||
+    typeof originalInvoke !== "function"
+  ) {
+    return;
+  }
+
+  const TOKEN = /^[A-Za-z0-9][A-Za-z0-9_.:+-]{0,255}$/;
+  const OPERATIONS = new Set(["accept", "reorder", "lock", "replace"]);
+  let trustedHistory = null;
+  let busy = false;
+
+  function exactKeys(value, keys) {
+    if (value === null || typeof value !== "object" || Array.isArray(value)) {
+      return false;
+    }
+    const actual = Object.keys(value).sort();
+    const expected = [...keys].sort();
+    return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+  }
+
+  function validToken(value) {
+    return typeof value === "string" && TOKEN.test(value) && !value.includes("/") && !value.includes("\\");
+  }
+
+  function pathShaped(value) {
+    return value.startsWith("/") || value.startsWith("\\\\") || /^[A-Za-z]:[\\/]/.test(value);
+  }
+
+  function validDisplayName(value) {
+    return (
+      typeof value === "string" &&
+      value.length > 0 &&
+      value.length <= 512 &&
+      value.trim() === value &&
+      !/[\u0000-\u001f\u007f]/.test(value) &&
+      !pathShaped(value)
+    );
+  }
+
+  function validRevision(value) {
+    if (
+      !exactKeys(value, [
+        "schema",
+        "playlist_id",
+        "revision_id",
+        "parent_revision_id",
+        "revision_index",
+        "source_proposal_id",
+        "source_path_id",
+        "operation",
+        "content_fingerprint",
+        "created_at",
+        "sequence",
+        "personal_dj_model_training_authorized",
+        "production_activation_authorized",
+      ]) ||
+      value.schema !== "applaylist-desktop-playlist-revision-r1" ||
+      !validToken(value.playlist_id) ||
+      !validToken(value.revision_id) ||
+      !(value.parent_revision_id === null || validToken(value.parent_revision_id)) ||
+      !Number.isInteger(value.revision_index) ||
+      value.revision_index < 0 ||
+      !validToken(value.source_proposal_id) ||
+      !validToken(value.source_path_id) ||
+      !OPERATIONS.has(value.operation) ||
+      !/^[0-9a-f]{64}$/.test(value.content_fingerprint) ||
+      !Array.isArray(value.sequence) ||
+      value.sequence.length < 3 ||
+      value.sequence.length > 8 ||
+      value.personal_dj_model_training_authorized !== false ||
+      value.production_activation_authorized !== false
+    ) {
+      return false;
+    }
+    const ids = new Set();
+    return value.sequence.every((item, index) => {
+      if (
+        !exactKeys(item, ["order_index", "track_id", "display_name", "locked"]) ||
+        item.order_index !== index ||
+        !validToken(item.track_id) ||
+        !validDisplayName(item.display_name) ||
+        typeof item.locked !== "boolean" ||
+        ids.has(item.track_id)
+      ) {
+        return false;
+      }
+      ids.add(item.track_id);
+      return true;
+    });
+  }
+
+  function validHistory(value) {
+    return (
+      exactKeys(value, [
+        "schema",
+        "playlist_id",
+        "current_revision_id",
+        "revisions",
+        "history_truncated",
+        "personal_dj_model_training_authorized",
+        "production_activation_authorized",
+      ]) &&
+      value.schema === "applaylist-desktop-playlist-history-r1" &&
+      validToken(value.playlist_id) &&
+      validToken(value.current_revision_id) &&
+      Array.isArray(value.revisions) &&
+      value.revisions.length >= 1 &&
+      value.revisions.length <= 100 &&
+      value.revisions.every(validRevision) &&
+      value.revisions[value.revisions.length - 1].revision_id === value.current_revision_id &&
+      typeof value.history_truncated === "boolean" &&
+      value.personal_dj_model_training_authorized === false &&
+      value.production_activation_authorized === false
+    );
+  }
+
+  function validSnapshot(value) {
+    return (
+      exactKeys(value, [
+        "snapshot_id",
+        "transition_id",
+        "source_segment_id",
+        "target_segment_id",
+        "assessment_version",
+        "policy_version",
+        "context_id",
+        "context_version",
+        "payload_sha256",
+        "created_at",
+      ]) &&
+      validToken(value.snapshot_id) &&
+      validToken(value.transition_id) &&
+      validToken(value.source_segment_id) &&
+      validToken(value.target_segment_id) &&
+      validToken(value.assessment_version) &&
+      validToken(value.policy_version) &&
+      validToken(value.context_id) &&
+      validToken(value.context_version) &&
+      /^[0-9a-f]{64}$/.test(value.payload_sha256) &&
+      typeof value.created_at === "string" &&
+      value.created_at.length > 0 &&
+      value.created_at.length <= 64
+    );
+  }
+
+  function safeObject(value, depth = 0) {
+    if (depth > 8) return false;
+    if (value === null || typeof value === "boolean" || typeof value === "number") return true;
+    if (typeof value === "string") {
+      return value.length <= 1024 && !pathShaped(value) && !/[\u0000-\u001f\u007f]/.test(value);
+    }
+    if (Array.isArray(value)) {
+      return value.length <= 128 && value.every((item) => safeObject(item, depth + 1));
+    }
+    if (typeof value !== "object") return false;
+    return Object.entries(value).every(([key, item]) => {
+      if (["payload_json", "content_utf8", "source_path", "target_path", "filesystem_path"].includes(key)) {
+        return false;
+      }
+      return safeObject(item, depth + 1);
+    });
+  }
+
+  function validInspection(value, revisionId, pairIndex) {
+    if (
+      !exactKeys(value, [
+        "schema",
+        "revision_id",
+        "playlist_id",
+        "revision_index",
+        "pair_index",
+        "source",
+        "target",
+        "available_snapshots",
+        "personal_dj_model_training_authorized",
+        "production_activation_authorized",
+        "transition_recomputation_authorized",
+        "playlist_mutation_authorized",
+        "state",
+        "selected_snapshot_id",
+        "assessment",
+      ]) ||
+      value.schema !== "applaylist-desktop-transition-inspection-r1" ||
+      value.revision_id !== revisionId ||
+      !validToken(value.playlist_id) ||
+      value.pair_index !== pairIndex ||
+      !Number.isInteger(value.revision_index) ||
+      value.revision_index < 0 ||
+      !exactKeys(value.source, ["order_index", "track_id", "display_name", "locked"]) ||
+      !exactKeys(value.target, ["order_index", "track_id", "display_name", "locked"]) ||
+      value.source.order_index !== pairIndex ||
+      value.target.order_index !== pairIndex + 1 ||
+      !validToken(value.source.track_id) ||
+      !validToken(value.target.track_id) ||
+      !validDisplayName(value.source.display_name) ||
+      !validDisplayName(value.target.display_name) ||
+      typeof value.source.locked !== "boolean" ||
+      typeof value.target.locked !== "boolean" ||
+      !Array.isArray(value.available_snapshots) ||
+      value.available_snapshots.length > 16 ||
+      !value.available_snapshots.every(validSnapshot) ||
+      value.personal_dj_model_training_authorized !== false ||
+      value.production_activation_authorized !== false ||
+      value.transition_recomputation_authorized !== false ||
+      value.playlist_mutation_authorized !== false
+    ) {
+      return false;
+    }
+    if (value.state === "missing") {
+      return value.available_snapshots.length === 0 && value.selected_snapshot_id === null && value.assessment === null;
+    }
+    return (
+      value.state === "present" &&
+      value.available_snapshots.length > 0 &&
+      validToken(value.selected_snapshot_id) &&
+      value.available_snapshots[0].snapshot_id === value.selected_snapshot_id &&
+      value.assessment !== null &&
+      typeof value.assessment === "object" &&
+      !Array.isArray(value.assessment) &&
+      safeObject(value.assessment)
+    );
+  }
+
+  function selectedRevision() {
+    if (!trustedHistory) return null;
+    return trustedHistory.revisions.find((revision) => revision.revision_id === revisionSelect.value) || null;
+  }
+
+  function setStatus(message) {
+    status.textContent = message;
+  }
+
+  function populatePairs() {
+    pairSelect.replaceChildren();
+    resultNode.replaceChildren();
+    const revision = selectedRevision();
+    if (!revision) {
+      pairSelect.disabled = true;
+      inspectButton.disabled = true;
+      return;
+    }
+    for (let index = 0; index < revision.sequence.length - 1; index += 1) {
+      const source = revision.sequence[index];
+      const target = revision.sequence[index + 1];
+      const option = document.createElement("option");
+      option.value = String(index);
+      option.textContent = `${index + 1}. ${source.display_name} → ${target.display_name}`;
+      pairSelect.appendChild(option);
+    }
+    pairSelect.disabled = false;
+    inspectButton.disabled = false;
+    setStatus("Choose one adjacent transition from the immutable revision.");
+  }
+
+  function setHistory(history) {
+    trustedHistory = history;
+    revisionSelect.replaceChildren();
+    for (const revision of history.revisions) {
+      const option = document.createElement("option");
+      option.value = revision.revision_id;
+      option.textContent = `#${revision.revision_index} ${revision.operation} · ${revision.revision_id}`;
+      option.selected = revision.revision_id === history.current_revision_id;
+      revisionSelect.appendChild(option);
+    }
+    revisionSelect.disabled = false;
+    populatePairs();
+  }
+
+  async function observedInvoke(command, args) {
+    const result = await originalInvoke(command, args);
+    if (command === "playlist_editor_history" && validHistory(result)) {
+      setHistory(result);
+    }
+    return result;
+  }
+
+  try {
+    tauriCore.invoke = observedInvoke;
+  } catch (_error) {
+    setStatus("Transition inspection history capture is unavailable in this desktop host.");
+    return;
+  }
+  if (tauriCore.invoke !== observedInvoke) {
+    setStatus("Transition inspection history capture is unavailable in this desktop host.");
+    return;
+  }
+
+  revisionSelect.addEventListener("change", populatePairs);
+  pairSelect.addEventListener("change", () => {
+    resultNode.replaceChildren();
+    setStatus("Inspect the selected persisted transition evidence.");
+  });
+
+  inspectButton.addEventListener("click", async () => {
+    if (busy) return;
+    const revision = selectedRevision();
+    const pairIndex = Number.parseInt(pairSelect.value, 10);
+    if (!revision || !Number.isInteger(pairIndex) || pairIndex < 0 || pairIndex >= revision.sequence.length - 1) {
+      return;
+    }
+    busy = true;
+    inspectButton.disabled = true;
+    resultNode.replaceChildren();
+    setStatus("Loading persisted TransitionAssessment evidence…");
+    try {
+      const inspection = await originalInvoke("playlist_transition_inspect", {
+        revisionId: revision.revision_id,
+        pairIndex,
+      });
+      if (!validInspection(inspection, revision.revision_id, pairIndex)) {
+        throw new Error("Invalid transition inspection response.");
+      }
+      renderInspection(inspection);
+      setStatus(
+        inspection.state === "present"
+          ? "Persisted transition evidence loaded. No recomputation was performed."
+          : "No persisted TransitionAssessment exists for this adjacent pair.",
+      );
+    } catch (_error) {
+      resultNode.replaceChildren();
+      setStatus("Transition inspection was rejected safely.");
+    } finally {
+      busy = false;
+      inspectButton.disabled = false;
+    }
+  });
+
+  function addMetric(list, label, value) {
+    const term = document.createElement("dt");
+    term.textContent = label;
+    const description = document.createElement("dd");
+    description.textContent = value === null || value === undefined ? "—" : String(value);
+    list.append(term, description);
+  }
+
+  function renderInspection(inspection) {
+    resultNode.replaceChildren();
+    const heading = document.createElement("h3");
+    heading.textContent = `${inspection.source.display_name} → ${inspection.target.display_name}`;
+    resultNode.appendChild(heading);
+
+    if (inspection.state === "missing") {
+      const empty = document.createElement("p");
+      empty.className = "empty-state";
+      empty.textContent = "No persisted TransitionAssessment snapshot is available for this pair.";
+      resultNode.appendChild(empty);
+      return;
+    }
+
+    const assessment = inspection.assessment;
+    const summary = document.createElement("dl");
+    summary.className = "summary-grid";
+    addMetric(summary, "Snapshot", inspection.selected_snapshot_id);
+    addMetric(summary, "Transition", assessment.transition_id);
+    addMetric(summary, "Context", `${assessment.contextual_projection.context_id} · ${assessment.contextual_projection.context_version}`);
+    addMetric(summary, "Context score", assessment.contextual_projection.score);
+    addMetric(summary, "Preferred strategy", assessment.preferred_strategy || "none");
+    addMetric(summary, "Tempo fit", assessment.compatibility.tempo_fit);
+    addMetric(summary, "Phrase fit", assessment.compatibility.phrase_fit);
+    addMetric(summary, "Harmonic fit", assessment.compatibility.harmonic_fit);
+    addMetric(summary, "Risk uncertainty", assessment.risk.uncertainty);
+    addMetric(summary, "Energy direction", assessment.energy_effect.direction);
+    addMetric(summary, "Overall confidence", assessment.confidence.score);
+    resultNode.appendChild(summary);
+
+    const strategiesHeading = document.createElement("h4");
+    strategiesHeading.textContent = "Candidate strategies";
+    const strategies = document.createElement("ol");
+    for (const item of assessment.candidate_strategies) {
+      const row = document.createElement("li");
+      row.textContent = `${item.strategy} · suitability ${item.suitability}`;
+      strategies.appendChild(row);
+    }
+    resultNode.append(strategiesHeading, strategies);
+
+    const evidenceHeading = document.createElement("h4");
+    evidenceHeading.textContent = "Evidence references";
+    const evidence = document.createElement("ul");
+    for (const ref of assessment.evidence_refs) {
+      const row = document.createElement("li");
+      row.textContent = ref;
+      evidence.appendChild(row);
+    }
+    resultNode.append(evidenceHeading, evidence);
+  }
+
+  revisionSelect.disabled = true;
+  pairSelect.disabled = true;
+  inspectButton.disabled = true;
+})();

--- a/docs/bundles/BUNDLE_61_SELECTED_TRANSITION_INSPECTION_R1.md
+++ b/docs/bundles/BUNDLE_61_SELECTED_TRANSITION_INSPECTION_R1.md
@@ -1,0 +1,123 @@
+# Bundle 61 — Selected Transition Inspection R1
+
+## Canonical dependency
+
+- base branch: `feature/bundle-0-bootstrap`
+- exact base SHA: `72fd76f033d484a8fa093a6ba38f58b26c6ac782`
+- issue: #141
+
+## Purpose
+
+Complete the R4 `selected transition inspection` capability without introducing transition recomputation, editor mutation, optimizer execution, filesystem authority or Personal DJ Model training.
+
+## Authority chain
+
+```text
+explicit immutable PlaylistRevision
+  -> pair_index
+  -> source/target derived from immutable revision order
+  -> TransitionEvidenceIndex
+  -> integrity-verified persisted TransitionAssessment snapshot
+  -> renderer-safe inspection DTO
+```
+
+The renderer never supplies source or target track IDs. It supplies only the exact immutable `revision_id` plus the adjacent `pair_index`. Pair identity is derived on the authenticated sidecar from the canonical revision ledger.
+
+## Persisted evidence only
+
+Bundle 61 never calls an MIR provider and never constructs a new TransitionAssessment. `TransitionEvidenceIndex` finds existing snapshots for the derived source/target pair. `MusicIntelligenceRepository.get_transition_snapshot()` verifies the stored payload digest before decoding the immutable assessment.
+
+When no persisted snapshot exists, the response is explicit:
+
+```text
+state = missing
+selected_snapshot_id = null
+assessment = null
+```
+
+No fallback recomputation occurs.
+
+When multiple context-bound snapshots exist, the existing index ordering is authoritative: `created_at DESC, snapshot_id DESC`. The first snapshot is selected deterministically while metadata for all bounded available snapshots remains visible.
+
+## Renderer-safe projection
+
+The inspection DTO may expose:
+
+- exact revision and pair identity;
+- safe track labels and lock flags;
+- snapshot/context/version/digest metadata;
+- compatibility vector;
+- risk vector;
+- cost vector;
+- energy effect;
+- candidate and preferred strategies;
+- usable transition window;
+- contextual projection;
+- confidence;
+- explanations and warnings;
+- opaque evidence references.
+
+It does not expose raw `payload_json`, filesystem paths, audio bytes, sidecar credentials, provider execution handles or write authority.
+
+## Desktop boundary
+
+- authenticated sidecar route: `/v1/playlist/transition/inspect`
+- strict request keys: `revision_id`, `pair_index`
+- dedicated Tauri command: `playlist_transition_inspect`
+- dedicated capability: `main-transition-inspector`
+- no native save dialog
+- no filesystem write
+- renderer CSP remains `connect-src 'none'`
+
+## Immutable/non-authorized effects
+
+The response hard-codes:
+
+```text
+personal_dj_model_training_authorized = false
+production_activation_authorized = false
+transition_recomputation_authorized = false
+playlist_mutation_authorized = false
+```
+
+## Acceptance gates
+
+- exact revision identity required;
+- pair index must identify an adjacent edge;
+- renderer cannot choose arbitrary source/target IDs;
+- missing evidence stays explicit;
+- stored evidence integrity is verified;
+- full assessment projection is bounded and path-safe;
+- inspection does not append playlist revisions;
+- strict authenticated route tests;
+- renderer authority tests;
+- Desktop Rust rustfmt/check/test;
+- Python 3.11/3.12 full CI;
+- packaged sidecar proof on Ubuntu and macOS;
+- PR Guard;
+- zero unresolved review threads.
+
+## Non-scope
+
+- regeneration around locks;
+- transition recomputation;
+- changing preferred strategy;
+- persisting human review decisions;
+- audio read/hash;
+- MIR/provider execution;
+- optimizer rerun;
+- playlist revision mutation;
+- vendor export mutation;
+- Personal DJ Model training;
+- production activation;
+- release/deploy/signing/notarization.
+
+## Next dependency
+
+Bundle 62 may implement the remaining R4 capability: bounded regeneration around explicit locks, while preserving immutable revision history and keeping the DJ in control.
+
+`MERGE_AUTHORIZATION=NO`
+
+`RELEASE_AUTHORIZATION=NO`
+
+`DEPLOY_AUTHORIZATION=NO`

--- a/scripts/applaylist_sidecar_entry.py
+++ b/scripts/applaylist_sidecar_entry.py
@@ -8,6 +8,7 @@ from services.desktop.playlist_vendor_interop_sidecar import (
 )
 from services.desktop.set_proposal_sidecar import install_set_proposal_sidecar
 from services.desktop.sidecar import main
+from services.desktop.transition_inspector_sidecar import install_transition_inspector_sidecar
 
 
 install_set_proposal_sidecar()
@@ -15,6 +16,7 @@ install_playlist_editor_sidecar()
 install_playlist_export_sidecar()
 install_playlist_evidence_export_sidecar()
 install_playlist_vendor_interop_sidecar()
+install_transition_inspector_sidecar()
 
 
 if __name__ == "__main__":

--- a/services/desktop/transition_inspector_sidecar.py
+++ b/services/desktop/transition_inspector_sidecar.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import services.desktop.sidecar as sidecar
+from services.desktop.transition_inspector_transport import (
+    DesktopTransitionInspectorError,
+    DesktopTransitionInspectorTransport,
+)
+
+MAX_TRANSITION_INSPECTION_REQUEST_BYTES = 8 * 1024
+_INSTALLED = False
+_PATH = "/v1/playlist/transition/inspect"
+_CONFLICT_CODES = {
+    "transition_inspection_revision_not_found",
+    "transition_inspection_snapshot_missing",
+    "transition_inspection_identity_mismatch",
+}
+
+
+def install_transition_inspector_sidecar() -> None:
+    global _INSTALLED
+    if _INSTALLED:
+        return
+
+    original_handler = sidecar._SidecarRequestHandler
+    original_server = sidecar._SidecarHTTPServer
+
+    class TransitionInspectorRequestHandler(original_handler):
+        def do_POST(self) -> None:  # noqa: N802
+            if self.path != _PATH:
+                super().do_POST()
+                return
+            if not self._authorized():
+                self._write_json(HTTPStatus.UNAUTHORIZED, {"error": "unauthorized"})
+                return
+            payload = self._read_json_payload(MAX_TRANSITION_INSPECTION_REQUEST_BYTES)
+            if payload is None or set(payload) != {"revision_id", "pair_index"}:
+                self._write_json(
+                    HTTPStatus.BAD_REQUEST,
+                    {"error": "invalid_transition_inspection_request"},
+                )
+                return
+            try:
+                result = self.sidecar_server.transition_inspector.inspect(
+                    revision_id=payload["revision_id"],
+                    pair_index=payload["pair_index"],
+                )
+            except DesktopTransitionInspectorError as exc:
+                status = HTTPStatus.CONFLICT if exc.code in _CONFLICT_CODES else HTTPStatus.BAD_REQUEST
+                self._write_json(status, {"error": exc.code})
+                return
+            except Exception:
+                self._write_json(
+                    HTTPStatus.INTERNAL_SERVER_ERROR,
+                    {"error": "transition_inspection_operation_failed"},
+                )
+                return
+            self._write_json(HTTPStatus.OK, result)
+
+    sidecar._SidecarRequestHandler = TransitionInspectorRequestHandler
+
+    class TransitionInspectorHTTPServer(original_server):
+        def __init__(self, startup: sidecar.SidecarStartup) -> None:
+            super().__init__(startup)
+            self.transition_inspector = DesktopTransitionInspectorTransport()
+
+    sidecar._SidecarHTTPServer = TransitionInspectorHTTPServer
+    _INSTALLED = True
+
+
+__all__ = ["MAX_TRANSITION_INSPECTION_REQUEST_BYTES", "install_transition_inspector_sidecar"]

--- a/services/desktop/transition_inspector_transport.py
+++ b/services/desktop/transition_inspector_transport.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any
+
+from core.intelligence.music_dna import Confidence
+from core.intelligence.transition_contract import TransitionAssessment
+from data.repositories.music_intelligence_repository import MusicIntelligenceRepository
+from data.repositories.playlist_revision_repository import (
+    PlaylistRevisionRepository,
+    PlaylistRevisionRepositoryError,
+)
+from data.repositories.transition_evidence_index import TransitionEvidenceIndex
+
+
+class DesktopTransitionInspectorError(ValueError):
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+class DesktopTransitionInspectorTransport:
+    """Read-only inspection of persisted TransitionAssessment evidence for one revision edge."""
+
+    def __init__(
+        self,
+        *,
+        revisions: PlaylistRevisionRepository | None = None,
+        intelligence: MusicIntelligenceRepository | None = None,
+        evidence_index: TransitionEvidenceIndex | None = None,
+    ) -> None:
+        self.revisions = revisions or PlaylistRevisionRepository()
+        self.intelligence = intelligence or MusicIntelligenceRepository()
+        self.evidence_index = evidence_index or TransitionEvidenceIndex(repository=self.intelligence)
+
+    def inspect(self, *, revision_id: str, pair_index: int) -> dict[str, object]:
+        revision = self._revision(revision_id)
+        sequence = tuple(revision["items"])
+        if not isinstance(pair_index, int) or isinstance(pair_index, bool) or not 0 <= pair_index < len(sequence) - 1:
+            raise DesktopTransitionInspectorError(
+                "invalid_transition_inspection_request",
+                "pair_index must identify an adjacent pair in the selected revision.",
+            )
+        source = sequence[pair_index]
+        target = sequence[pair_index + 1]
+        source_track_id = self._token(str(source["track_id"]))
+        target_track_id = self._token(str(target["track_id"]))
+        snapshots = self.evidence_index.list_pair_snapshots(
+            source_track_id=source_track_id,
+            target_track_id=target_track_id,
+        )
+        metadata = tuple(self._snapshot_metadata(item) for item in snapshots)
+        base: dict[str, object] = {
+            "schema": "applaylist-desktop-transition-inspection-r1",
+            "revision_id": str(revision["revision_id"]),
+            "playlist_id": str(revision["playlist_id"]),
+            "revision_index": int(revision["revision_index"]),
+            "pair_index": pair_index,
+            "source": self._revision_item(source),
+            "target": self._revision_item(target),
+            "available_snapshots": metadata,
+            "personal_dj_model_training_authorized": False,
+            "production_activation_authorized": False,
+            "transition_recomputation_authorized": False,
+            "playlist_mutation_authorized": False,
+        }
+        if not snapshots:
+            return {
+                **base,
+                "state": "missing",
+                "selected_snapshot_id": None,
+                "assessment": None,
+            }
+
+        selected = snapshots[0]
+        snapshot_id = self._token(str(selected["snapshot_id"]))
+        assessment = self.intelligence.get_transition_snapshot(snapshot_id)
+        if assessment is None:
+            raise DesktopTransitionInspectorError(
+                "transition_inspection_snapshot_missing",
+                "The selected persisted transition snapshot is unavailable.",
+            )
+        self._verify_pair(assessment, source_track_id, target_track_id)
+        return {
+            **base,
+            "state": "present",
+            "selected_snapshot_id": snapshot_id,
+            "assessment": self._assessment(assessment),
+        }
+
+    def _revision(self, revision_id: str) -> dict[str, object]:
+        try:
+            revision = self.revisions.get_revision(revision_id)
+        except PlaylistRevisionRepositoryError as exc:
+            raise DesktopTransitionInspectorError(
+                "invalid_transition_inspection_request",
+                "The selected revision identity is invalid.",
+            ) from exc
+        if revision is None:
+            raise DesktopTransitionInspectorError(
+                "transition_inspection_revision_not_found",
+                "The selected playlist revision was not found.",
+            )
+        items = revision.get("items")
+        if not isinstance(items, tuple) or not 3 <= len(items) <= 8:
+            raise DesktopTransitionInspectorError(
+                "transition_inspection_revision_invalid",
+                "The selected playlist revision is invalid.",
+            )
+        return revision
+
+    @classmethod
+    def _revision_item(cls, item: object) -> dict[str, object]:
+        if not isinstance(item, dict):
+            raise DesktopTransitionInspectorError(
+                "transition_inspection_revision_invalid",
+                "The selected playlist revision is invalid.",
+            )
+        return {
+            "order_index": int(item["order_index"]),
+            "track_id": cls._token(str(item["track_id"])),
+            "display_name": cls._label(str(item["display_name"])),
+            "locked": bool(item["locked"]),
+        }
+
+    @classmethod
+    def _snapshot_metadata(cls, value: dict[str, object]) -> dict[str, object]:
+        return {
+            "snapshot_id": cls._token(str(value["snapshot_id"])),
+            "transition_id": cls._token(str(value["transition_id"])),
+            "source_segment_id": cls._token(str(value["source_segment_id"])),
+            "target_segment_id": cls._token(str(value["target_segment_id"])),
+            "assessment_version": cls._token(str(value["assessment_version"])),
+            "policy_version": cls._token(str(value["policy_version"])),
+            "context_id": cls._token(str(value["context_id"])),
+            "context_version": cls._token(str(value["context_version"])),
+            "payload_sha256": cls._digest(str(value["payload_sha256"])),
+            "created_at": cls._text(str(value["created_at"]), limit=64),
+        }
+
+    @classmethod
+    def _assessment(cls, value: TransitionAssessment) -> dict[str, object]:
+        identity = value.identity
+        projection = value.contextual_projection
+        return {
+            "transition_id": cls._token(identity.transition_id),
+            "source_segment_id": cls._token(identity.source_segment_id),
+            "target_segment_id": cls._token(identity.target_segment_id),
+            "assessment_version": cls._token(identity.assessment_version),
+            "policy_version": cls._token(identity.policy_version),
+            "music_dna_revision_refs": [cls._token(item) for item in identity.music_dna_revision_refs],
+            "created_at": cls._text(identity.created_at, limit=64),
+            "compatibility": cls._json_safe(asdict(value.compatibility_vector)),
+            "risk": cls._json_safe(asdict(value.risk_vector)),
+            "cost": cls._json_safe(asdict(value.cost_vector)),
+            "energy_effect": {
+                "source_energy_state": value.energy_effect.source_energy_state,
+                "target_energy_state": value.energy_effect.target_energy_state,
+                "delta": value.energy_effect.delta,
+                "local_curve_alignment": value.energy_effect.local_curve_alignment,
+                "direction": value.energy_effect.direction.value,
+                "confidence": cls._confidence(value.energy_effect.confidence),
+            },
+            "candidate_strategies": [
+                {
+                    "strategy": item.strategy.value,
+                    "suitability": item.suitability,
+                    "required_capabilities": [cls._token(capability) for capability in item.required_capabilities],
+                    "explanation_codes": [cls._token(code) for code in item.explanation_codes],
+                }
+                for item in value.candidate_strategies
+            ],
+            "preferred_strategy": value.preferred_strategy.value if value.preferred_strategy else None,
+            "usable_window": {
+                "source_start_seconds": value.usable_window.source_start_seconds,
+                "source_end_seconds": value.usable_window.source_end_seconds,
+                "target_start_seconds": value.usable_window.target_start_seconds,
+                "target_end_seconds": value.usable_window.target_end_seconds,
+                "source_bar_count": value.usable_window.source_bar_count,
+                "target_bar_count": value.usable_window.target_bar_count,
+                "confidence": cls._confidence(value.usable_window.confidence),
+            },
+            "contextual_projection": {
+                "context_id": cls._token(projection.context_id),
+                "context_version": cls._token(projection.context_version),
+                "score": projection.score,
+                "blocked_reasons": [cls._token(item) for item in projection.blocked_reasons],
+                "rank_features": [cls._token(item) for item in projection.rank_features],
+                "confidence": cls._confidence(projection.confidence),
+                "explanation_codes": [cls._token(item) for item in projection.explanation_codes],
+            },
+            "confidence": cls._confidence(value.confidence),
+            "explanations": [
+                {
+                    "code": cls._token(item.code),
+                    "severity": cls._token(item.severity),
+                    "dimension": cls._token(item.dimension),
+                    "evidence_refs": [cls._token(ref) for ref in item.evidence_refs],
+                    "confidence": cls._confidence(item.confidence),
+                }
+                for item in value.explanations
+            ],
+            "evidence_refs": [cls._token(item) for item in value.evidence_refs],
+            "warnings": [cls._text(item, limit=512) for item in value.warnings],
+        }
+
+    @staticmethod
+    def _confidence(value: Confidence) -> dict[str, object]:
+        return {
+            "score": value.score,
+            "calibration_state": value.calibration_state.value,
+            "evidence_count": value.evidence_count,
+            "disagreement": value.disagreement,
+        }
+
+    @staticmethod
+    def _json_safe(value: dict[str, Any]) -> dict[str, object]:
+        return {str(key): item for key, item in value.items()}
+
+    @staticmethod
+    def _verify_pair(assessment: TransitionAssessment, source_track_id: str, target_track_id: str) -> None:
+        if (
+            assessment.identity.source_track_id != source_track_id
+            or assessment.identity.target_track_id != target_track_id
+        ):
+            raise DesktopTransitionInspectorError(
+                "transition_inspection_identity_mismatch",
+                "Persisted transition evidence does not match the selected revision pair.",
+            )
+
+    @staticmethod
+    def _token(value: str) -> str:
+        if not isinstance(value, str) or not value or value.strip() != value or len(value) > 256:
+            raise DesktopTransitionInspectorError("transition_inspection_projection_invalid", "Unsafe identity token.")
+        if "/" in value or "\\" in value or any(ch.isspace() or ord(ch) < 32 for ch in value):
+            raise DesktopTransitionInspectorError("transition_inspection_projection_invalid", "Unsafe identity token.")
+        return value
+
+    @staticmethod
+    def _label(value: str) -> str:
+        if not isinstance(value, str) or not value or value.strip() != value or len(value) > 512:
+            raise DesktopTransitionInspectorError("transition_inspection_projection_invalid", "Unsafe display label.")
+        if value.startswith(("/", "\\\\")) or any(ord(ch) < 32 or ord(ch) == 127 for ch in value):
+            raise DesktopTransitionInspectorError("transition_inspection_projection_invalid", "Unsafe display label.")
+        if len(value) >= 3 and value[0].isalpha() and value[1:3] in {":\\", ":/"}:
+            raise DesktopTransitionInspectorError("transition_inspection_projection_invalid", "Unsafe display label.")
+        return value
+
+    @staticmethod
+    def _text(value: str, *, limit: int) -> str:
+        if not isinstance(value, str) or len(value) > limit or any(ord(ch) < 32 and ch not in "\t" for ch in value):
+            raise DesktopTransitionInspectorError("transition_inspection_projection_invalid", "Unsafe text value.")
+        return value
+
+    @staticmethod
+    def _digest(value: str) -> str:
+        if len(value) != 64 or any(ch not in "0123456789abcdef" for ch in value):
+            raise DesktopTransitionInspectorError("transition_inspection_projection_invalid", "Invalid evidence digest.")
+        return value
+
+
+__all__ = ["DesktopTransitionInspectorError", "DesktopTransitionInspectorTransport"]

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -24,6 +24,7 @@ fn main() {
             "playlist_evidence_export_json",
             "playlist_vendor_interop_preview",
             "playlist_vendor_interop_export_rekordbox",
+            "playlist_transition_inspect",
         ]),
     ))
     .expect("failed to configure APPLAYLIST desktop host build");

--- a/src-tauri/capabilities/main-transition-inspector.json
+++ b/src-tauri/capabilities/main-transition-inspector.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "main-transition-inspector",
+  "description": "Read-only selected transition inspection for the main desktop window.",
+  "windows": ["main"],
+  "platforms": ["macOS"],
+  "permissions": [
+    "core:default",
+    "allow-playlist-transition-inspect"
+  ]
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod playlist_export;
 mod playlist_vendor_interop;
 mod set_proposal;
 mod sidecar_bridge;
+mod transition_inspector;
 
 use analysis_bridge::AnalysisSidecarBridge;
 use analysis_job::AnalysisJobRegistry;
@@ -19,6 +20,7 @@ use playlist_export::PlaylistExportBridge;
 use playlist_vendor_interop::PlaylistVendorInteropBridge;
 use set_proposal::SetProposalBridge;
 use sidecar_bridge::SidecarBridge;
+use transition_inspector::TransitionInspectorBridge;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -34,6 +36,7 @@ pub fn run() {
         .manage(PlaylistExportBridge::from_environment())
         .manage(PlaylistEvidenceExportBridge::from_environment())
         .manage(PlaylistVendorInteropBridge::from_environment())
+        .manage(TransitionInspectorBridge::from_environment())
         .invoke_handler(tauri::generate_handler![
             library_capability::library_choose_root,
             import_job::library_import_start,
@@ -57,7 +60,8 @@ pub fn run() {
             playlist_evidence_export::playlist_evidence_preview,
             playlist_evidence_export::playlist_evidence_export_json,
             playlist_vendor_interop::playlist_vendor_interop_preview,
-            playlist_vendor_interop::playlist_vendor_interop_export_rekordbox
+            playlist_vendor_interop::playlist_vendor_interop_export_rekordbox,
+            transition_inspector::playlist_transition_inspect
         ])
         .run(tauri::generate_context!())
         .expect("error while running APPLAYLIST desktop host");

--- a/src-tauri/src/transition_inspector.rs
+++ b/src-tauri/src/transition_inspector.rs
@@ -380,8 +380,8 @@ fn request_json(
         .windows(4)
         .position(|window| window == b"\r\n\r\n")
         .ok_or_else(InspectorError::request_failed)?;
-    let headers = std::str::from_utf8(&response[..boundary])
-        .map_err(|_| InspectorError::request_failed())?;
+    let headers =
+        std::str::from_utf8(&response[..boundary]).map_err(|_| InspectorError::request_failed())?;
     let mut lines = headers.split("\r\n");
     let mut parts = lines
         .next()
@@ -460,9 +460,14 @@ fn valid_item(value: &Value, expected_index: usize) -> bool {
     let Some(object) = value.as_object() else {
         return false;
     };
-    exact_keys(object, &["order_index", "track_id", "display_name", "locked"])
-        && object.get("order_index").and_then(Value::as_u64) == Some(expected_index as u64)
-        && object.get("track_id").and_then(Value::as_str).is_some_and(token)
+    exact_keys(
+        object,
+        &["order_index", "track_id", "display_name", "locked"],
+    ) && object.get("order_index").and_then(Value::as_u64) == Some(expected_index as u64)
+        && object
+            .get("track_id")
+            .and_then(Value::as_str)
+            .is_some_and(token)
         && object
             .get("display_name")
             .and_then(Value::as_str)
@@ -512,7 +517,9 @@ fn valid_snapshot(value: &Value) -> bool {
         && object
             .get("created_at")
             .and_then(Value::as_str)
-            .is_some_and(|value| !value.is_empty() && value.len() <= 64 && !value.chars().any(char::is_control))
+            .is_some_and(|value| {
+                !value.is_empty() && value.len() <= 64 && !value.chars().any(char::is_control)
+            })
 }
 
 fn valid_confidence(value: &Value) -> bool {
@@ -521,20 +528,26 @@ fn valid_confidence(value: &Value) -> bool {
     };
     exact_keys(
         object,
-        &["score", "calibration_state", "evidence_count", "disagreement"],
+        &[
+            "score",
+            "calibration_state",
+            "evidence_count",
+            "disagreement",
+        ],
     ) && object
         .get("calibration_state")
         .and_then(Value::as_str)
         .is_some_and(|value| matches!(value, "unknown" | "uncalibrated" | "calibrated"))
-        && object.get("evidence_count").and_then(Value::as_u64).unwrap_or(0) >= 1
+        && object
+            .get("evidence_count")
+            .and_then(Value::as_u64)
+            .unwrap_or(0)
+            >= 1
 }
 
 fn valid_token_array(value: &Value, max: usize) -> bool {
     value.as_array().is_some_and(|items| {
-        items.len() <= max
-            && items
-                .iter()
-                .all(|item| item.as_str().is_some_and(token))
+        items.len() <= max && items.iter().all(|item| item.as_str().is_some_and(token))
     })
 }
 
@@ -582,21 +595,28 @@ fn valid_assessment(value: &Value) -> bool {
     if !object
         .get("music_dna_revision_refs")
         .and_then(Value::as_array)
-        .is_some_and(|items| items.len() == 2 && items.iter().all(|item| item.as_str().is_some_and(token)))
+        .is_some_and(|items| {
+            items.len() == 2 && items.iter().all(|item| item.as_str().is_some_and(token))
+        })
         || !object
             .get("created_at")
             .and_then(Value::as_str)
             .is_some_and(|value| !value.is_empty() && value.len() <= 64)
         || !valid_confidence(&object["confidence"])
         || !valid_token_array(&object["evidence_refs"], 64)
-        || !object.get("warnings").and_then(Value::as_array).is_some_and(|items| {
-            items.len() <= 64
-                && items.iter().all(|item| {
-                    item.as_str().is_some_and(|value| {
-                        value.len() <= 512 && !value.starts_with('/') && !value.chars().any(char::is_control)
+        || !object
+            .get("warnings")
+            .and_then(Value::as_array)
+            .is_some_and(|items| {
+                items.len() <= 64
+                    && items.iter().all(|item| {
+                        item.as_str().is_some_and(|value| {
+                            value.len() <= 512
+                                && !value.starts_with('/')
+                                && !value.chars().any(char::is_control)
+                        })
                     })
-                })
-        })
+            })
     {
         return false;
     }
@@ -619,7 +639,10 @@ fn valid_assessment(value: &Value) -> bool {
                 "required_capabilities",
                 "explanation_codes",
             ],
-        ) || !item.get("strategy").and_then(Value::as_str).is_some_and(token)
+        ) || !item
+            .get("strategy")
+            .and_then(Value::as_str)
+            .is_some_and(token)
             || !valid_token_array(&item["required_capabilities"], 32)
             || !valid_token_array(&item["explanation_codes"], 32)
         {
@@ -679,20 +702,37 @@ fn valid_assessment(value: &Value) -> bool {
         return false;
     }
 
-    object.get("explanations").and_then(Value::as_array).is_some_and(|items| {
-        items.len() <= 64
-            && items.iter().all(|value| {
-                let Some(item) = value.as_object() else {
-                    return false;
-                };
-                exact_keys(item, &["code", "severity", "dimension", "evidence_refs", "confidence"])
-                    && item.get("code").and_then(Value::as_str).is_some_and(token)
-                    && item.get("severity").and_then(Value::as_str).is_some_and(token)
-                    && item.get("dimension").and_then(Value::as_str).is_some_and(token)
-                    && valid_token_array(&item["evidence_refs"], 64)
-                    && valid_confidence(&item["confidence"])
-            })
-    })
+    object
+        .get("explanations")
+        .and_then(Value::as_array)
+        .is_some_and(|items| {
+            items.len() <= 64
+                && items.iter().all(|value| {
+                    let Some(item) = value.as_object() else {
+                        return false;
+                    };
+                    exact_keys(
+                        item,
+                        &[
+                            "code",
+                            "severity",
+                            "dimension",
+                            "evidence_refs",
+                            "confidence",
+                        ],
+                    ) && item.get("code").and_then(Value::as_str).is_some_and(token)
+                        && item
+                            .get("severity")
+                            .and_then(Value::as_str)
+                            .is_some_and(token)
+                        && item
+                            .get("dimension")
+                            .and_then(Value::as_str)
+                            .is_some_and(token)
+                        && valid_token_array(&item["evidence_refs"], 64)
+                        && valid_confidence(&item["confidence"])
+                })
+        })
 }
 
 fn validate_response(value: &Value, revision_id: &str, pair_index: usize) -> bool {
@@ -721,7 +761,10 @@ fn validate_response(value: &Value, revision_id: &str, pair_index: usize) -> boo
     ) || object.get("schema").and_then(Value::as_str)
         != Some("applaylist-desktop-transition-inspection-r1")
         || object.get("revision_id").and_then(Value::as_str) != Some(revision_id)
-        || !object.get("playlist_id").and_then(Value::as_str).is_some_and(token)
+        || !object
+            .get("playlist_id")
+            .and_then(Value::as_str)
+            .is_some_and(token)
         || object.get("pair_index").and_then(Value::as_u64) != Some(pair_index as u64)
         || !valid_item(&object["source"], pair_index)
         || !valid_item(&object["target"], pair_index + 1)

--- a/src-tauri/src/transition_inspector.rs
+++ b/src-tauri/src/transition_inspector.rs
@@ -1,0 +1,831 @@
+use std::{
+    collections::HashSet,
+    env,
+    io::{Read, Write},
+    net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream},
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    sync::mpsc,
+    thread,
+    time::{Duration, Instant},
+};
+
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+use tauri::{AppHandle, Manager, State};
+use uuid::Uuid;
+
+use crate::library_capability::DesktopHostError;
+
+const SIDECAR_EXECUTABLE_ENV: &str = "APPLAYLIST_DESKTOP_SIDECAR_EXECUTABLE";
+const BUNDLED_SIDECAR_RESOURCE: &str = "applaylist-sidecar/applaylist-sidecar";
+const PROTOCOL_VERSION: &str = "applaylist-sidecar-v1";
+const SECRET_HEADER: &str = "X-APPLAYLIST-Sidecar-Secret";
+const NONCE_HEADER: &str = "X-APPLAYLIST-Readiness-Nonce";
+const READY_TIMEOUT: Duration = Duration::from_secs(5);
+const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_READY_BYTES: usize = 8_192;
+const MAX_HTTP_RESPONSE_BYTES: u64 = 4 * 1024 * 1024;
+const MAX_TOKEN: usize = 256;
+
+#[derive(Debug, Clone)]
+pub struct TransitionInspectorBridge {
+    executable: Option<PathBuf>,
+}
+
+impl TransitionInspectorBridge {
+    pub fn from_environment() -> Self {
+        Self {
+            executable: if cfg!(debug_assertions) {
+                env::var_os(SIDECAR_EXECUTABLE_ENV).map(PathBuf::from)
+            } else {
+                None
+            },
+        }
+    }
+
+    fn executable(&self, resource_dir: Option<&Path>) -> Result<PathBuf, InspectorError> {
+        if let Some(path) = self.executable.as_ref() {
+            let canonical = path
+                .canonicalize()
+                .map_err(|_| InspectorError::unavailable())?;
+            return canonical
+                .is_file()
+                .then_some(canonical)
+                .ok_or_else(InspectorError::unavailable);
+        }
+        let root = resource_dir.ok_or_else(InspectorError::not_configured)?;
+        let root = root
+            .canonicalize()
+            .map_err(|_| InspectorError::unavailable())?;
+        let binary = root
+            .join(BUNDLED_SIDECAR_RESOURCE)
+            .canonicalize()
+            .map_err(|_| InspectorError::unavailable())?;
+        if !binary.starts_with(&root) || !binary.is_file() {
+            return Err(InspectorError::unavailable());
+        }
+        Ok(binary)
+    }
+
+    fn request(
+        &self,
+        revision_id: &str,
+        pair_index: usize,
+        resource_dir: Option<&Path>,
+    ) -> Result<Value, InspectorError> {
+        let executable = self.executable(resource_dir)?;
+        let mut session = Session::connect(&executable)?;
+        let payload = serde_json::to_vec(&json!({
+            "revision_id": revision_id,
+            "pair_index": pair_index,
+        }))
+        .map_err(|_| InspectorError::request_failed())?;
+        let response = session.post("/v1/playlist/transition/inspect", &payload);
+        session.shutdown();
+        let (status, bytes) = response?;
+        if status != 200 {
+            let code = serde_json::from_slice::<Value>(&bytes)
+                .ok()
+                .and_then(|value| {
+                    value
+                        .get("error")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned)
+                });
+            return Err(InspectorError::rejected(code.as_deref()));
+        }
+        serde_json::from_slice(&bytes).map_err(|_| InspectorError::invalid_response())
+    }
+}
+
+impl Default for TransitionInspectorBridge {
+    fn default() -> Self {
+        Self::from_environment()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct InspectorError {
+    code: &'static str,
+    message: &'static str,
+}
+
+impl InspectorError {
+    const fn new(code: &'static str, message: &'static str) -> Self {
+        Self { code, message }
+    }
+    const fn not_configured() -> Self {
+        Self::new(
+            "desktop_transition_inspector_sidecar_not_configured",
+            "The transition inspector service is not configured.",
+        )
+    }
+    const fn unavailable() -> Self {
+        Self::new(
+            "desktop_transition_inspector_sidecar_unavailable",
+            "The transition inspector service is unavailable.",
+        )
+    }
+    const fn startup_failed() -> Self {
+        Self::new(
+            "desktop_transition_inspector_sidecar_startup_failed",
+            "The transition inspector service could not start.",
+        )
+    }
+    const fn readiness_failed() -> Self {
+        Self::new(
+            "desktop_transition_inspector_sidecar_readiness_failed",
+            "The transition inspector service did not become ready.",
+        )
+    }
+    const fn request_failed() -> Self {
+        Self::new(
+            "desktop_transition_inspector_request_failed",
+            "The transition inspection request failed.",
+        )
+    }
+    const fn invalid_request() -> Self {
+        Self::new(
+            "invalid_transition_inspection_request",
+            "The transition inspection request is invalid.",
+        )
+    }
+    const fn invalid_response() -> Self {
+        Self::new(
+            "desktop_transition_inspector_response_invalid",
+            "The transition inspection response is invalid.",
+        )
+    }
+    fn rejected(code: Option<&str>) -> Self {
+        match code {
+            Some("transition_inspection_revision_not_found") => Self::new(
+                "transition_inspection_revision_not_found",
+                "The selected playlist revision was not found.",
+            ),
+            Some("transition_inspection_snapshot_missing") => Self::new(
+                "transition_inspection_snapshot_missing",
+                "The selected transition snapshot is unavailable.",
+            ),
+            Some("transition_inspection_identity_mismatch") => Self::new(
+                "transition_inspection_identity_mismatch",
+                "Persisted transition evidence does not match the selected revision pair.",
+            ),
+            Some("invalid_transition_inspection_request") => Self::invalid_request(),
+            _ => Self::new(
+                "desktop_transition_inspector_rejected",
+                "The transition inspection request was rejected.",
+            ),
+        }
+    }
+}
+
+impl From<InspectorError> for DesktopHostError {
+    fn from(value: InspectorError) -> Self {
+        DesktopHostError::new(value.code, value.message)
+    }
+}
+
+struct Session {
+    child: Child,
+    port: u16,
+    secret: String,
+    nonce: String,
+}
+
+impl Session {
+    fn connect(executable: &Path) -> Result<Self, InspectorError> {
+        let secret = random_token();
+        let nonce = random_token();
+        let mut child = Command::new(executable)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|_| InspectorError::startup_failed())?;
+        let envelope = serde_json::to_vec(&json!({
+            "protocol": PROTOCOL_VERSION,
+            "secret": secret,
+            "nonce": nonce,
+        }))
+        .map_err(|_| InspectorError::startup_failed())?;
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(InspectorError::startup_failed)?;
+        stdin
+            .write_all(&envelope)
+            .and_then(|_| stdin.write_all(b"\n"))
+            .and_then(|_| stdin.flush())
+            .map_err(|_| InspectorError::startup_failed())?;
+        drop(stdin);
+
+        let line = read_ready(&mut child)?;
+        let ready: Value =
+            serde_json::from_slice(&line).map_err(|_| InspectorError::readiness_failed())?;
+        let port = validate_ready(&ready, &nonce)?;
+        let (status, health) = request_json(port, "GET", "/v1/health", &secret, &nonce, None)?;
+        if status != 200 {
+            return Err(InspectorError::readiness_failed());
+        }
+        let health: Value =
+            serde_json::from_slice(&health).map_err(|_| InspectorError::readiness_failed())?;
+        let nonce_hash = sha256_hex(nonce.as_bytes());
+        if health.get("status").and_then(Value::as_str) != Some("ready")
+            || health.get("protocol").and_then(Value::as_str) != Some(PROTOCOL_VERSION)
+            || health.get("nonce_sha256").and_then(Value::as_str) != Some(nonce_hash.as_str())
+        {
+            return Err(InspectorError::readiness_failed());
+        }
+        Ok(Self {
+            child,
+            port,
+            secret,
+            nonce,
+        })
+    }
+
+    fn post(&mut self, path: &str, body: &[u8]) -> Result<(u16, Vec<u8>), InspectorError> {
+        request_json(
+            self.port,
+            "POST",
+            path,
+            &self.secret,
+            &self.nonce,
+            Some(body),
+        )
+    }
+
+    fn shutdown(&mut self) {
+        let _ = request_json(
+            self.port,
+            "POST",
+            "/v1/shutdown",
+            &self.secret,
+            &self.nonce,
+            Some(&[]),
+        );
+        let deadline = Instant::now() + SHUTDOWN_TIMEOUT;
+        while Instant::now() < deadline {
+            match self.child.try_wait() {
+                Ok(Some(_)) => return,
+                Ok(None) => thread::sleep(Duration::from_millis(25)),
+                Err(_) => break,
+            }
+        }
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        if matches!(self.child.try_wait(), Ok(None)) {
+            let _ = self.child.kill();
+        }
+        let _ = self.child.wait();
+    }
+}
+
+fn read_ready(child: &mut Child) -> Result<Vec<u8>, InspectorError> {
+    let mut stdout = child
+        .stdout
+        .take()
+        .ok_or_else(InspectorError::readiness_failed)?;
+    let (sender, receiver) = mpsc::sync_channel(1);
+    thread::spawn(move || {
+        let mut line = Vec::new();
+        let result = (|| -> std::io::Result<Vec<u8>> {
+            for _ in 0..=MAX_READY_BYTES {
+                let mut byte = [0_u8; 1];
+                if stdout.read(&mut byte)? == 0 {
+                    break;
+                }
+                if byte[0] == b'\n' {
+                    return Ok(line);
+                }
+                line.push(byte[0]);
+            }
+            Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "invalid readiness line",
+            ))
+        })();
+        let _ = sender.send(result);
+    });
+    receiver
+        .recv_timeout(READY_TIMEOUT)
+        .map_err(|_| InspectorError::readiness_failed())?
+        .map_err(|_| InspectorError::readiness_failed())
+}
+
+fn validate_ready(value: &Value, nonce: &str) -> Result<u16, InspectorError> {
+    let nonce_hash = sha256_hex(nonce.as_bytes());
+    if value.get("event").and_then(Value::as_str) != Some("ready")
+        || value.get("protocol").and_then(Value::as_str) != Some(PROTOCOL_VERSION)
+        || value.get("host").and_then(Value::as_str) != Some("127.0.0.1")
+        || value.get("nonce_sha256").and_then(Value::as_str) != Some(nonce_hash.as_str())
+        || value.get("process_id").and_then(Value::as_u64).unwrap_or(0) == 0
+    {
+        return Err(InspectorError::readiness_failed());
+    }
+    value
+        .get("port")
+        .and_then(Value::as_u64)
+        .filter(|port| (1..=u16::MAX as u64).contains(port))
+        .map(|port| port as u16)
+        .ok_or_else(InspectorError::readiness_failed)
+}
+
+fn request_json(
+    port: u16,
+    method: &str,
+    path: &str,
+    secret: &str,
+    nonce: &str,
+    body: Option<&[u8]>,
+) -> Result<(u16, Vec<u8>), InspectorError> {
+    let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+    let mut stream = TcpStream::connect_timeout(&address, HTTP_TIMEOUT)
+        .map_err(|_| InspectorError::request_failed())?;
+    stream
+        .set_read_timeout(Some(HTTP_TIMEOUT))
+        .map_err(|_| InspectorError::request_failed())?;
+    stream
+        .set_write_timeout(Some(HTTP_TIMEOUT))
+        .map_err(|_| InspectorError::request_failed())?;
+    let payload = body.unwrap_or(&[]);
+    let content_type = if body.is_some() {
+        "Content-Type: application/json\r\n"
+    } else {
+        ""
+    };
+    let request = format!(
+        "{method} {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\n{SECRET_HEADER}: {secret}\r\n{NONCE_HEADER}: {nonce}\r\n{content_type}Content-Length: {}\r\n\r\n",
+        payload.len()
+    );
+    stream
+        .write_all(request.as_bytes())
+        .and_then(|_| stream.write_all(payload))
+        .and_then(|_| stream.flush())
+        .map_err(|_| InspectorError::request_failed())?;
+    let mut response = Vec::new();
+    std::io::Read::by_ref(&mut stream)
+        .take(MAX_HTTP_RESPONSE_BYTES + 1)
+        .read_to_end(&mut response)
+        .map_err(|_| InspectorError::request_failed())?;
+    if response.len() as u64 > MAX_HTTP_RESPONSE_BYTES {
+        return Err(InspectorError::request_failed());
+    }
+    let boundary = response
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .ok_or_else(InspectorError::request_failed)?;
+    let headers = std::str::from_utf8(&response[..boundary])
+        .map_err(|_| InspectorError::request_failed())?;
+    let mut lines = headers.split("\r\n");
+    let mut parts = lines
+        .next()
+        .ok_or_else(InspectorError::request_failed)?
+        .split_whitespace();
+    if parts.next() != Some("HTTP/1.1") {
+        return Err(InspectorError::request_failed());
+    }
+    let status = parts
+        .next()
+        .and_then(|value| value.parse::<u16>().ok())
+        .ok_or_else(InspectorError::request_failed)?;
+    let mut length = None;
+    for line in lines {
+        let Some((name, value)) = line.split_once(':') else {
+            return Err(InspectorError::request_failed());
+        };
+        if name.eq_ignore_ascii_case("Content-Length") {
+            length = value.trim().parse::<usize>().ok();
+        }
+    }
+    let body = &response[boundary + 4..];
+    if length != Some(body.len()) {
+        return Err(InspectorError::request_failed());
+    }
+    Ok((status, body.to_vec()))
+}
+
+fn random_token() -> String {
+    format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple())
+}
+
+fn sha256_hex(value: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(value))
+}
+
+fn token(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_TOKEN
+        && value.trim() == value
+        && !value.contains('/')
+        && !value.contains('\\')
+        && !value.chars().any(char::is_whitespace)
+        && !value.chars().any(char::is_control)
+}
+
+fn safe_label(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 512
+        && value.trim() == value
+        && !value.starts_with('/')
+        && !value.starts_with("\\\\")
+        && !(value.len() >= 3
+            && value.as_bytes()[0].is_ascii_alphabetic()
+            && value.as_bytes()[1] == b':'
+            && matches!(value.as_bytes()[2], b'/' | b'\\'))
+        && !value.chars().any(char::is_control)
+}
+
+fn digest(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn exact_keys(object: &Map<String, Value>, expected: &[&str]) -> bool {
+    if object.len() != expected.len() {
+        return false;
+    }
+    let expected: HashSet<&str> = expected.iter().copied().collect();
+    object.keys().all(|key| expected.contains(key.as_str()))
+}
+
+fn valid_item(value: &Value, expected_index: usize) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    exact_keys(object, &["order_index", "track_id", "display_name", "locked"])
+        && object.get("order_index").and_then(Value::as_u64) == Some(expected_index as u64)
+        && object.get("track_id").and_then(Value::as_str).is_some_and(token)
+        && object
+            .get("display_name")
+            .and_then(Value::as_str)
+            .is_some_and(safe_label)
+        && object.get("locked").and_then(Value::as_bool).is_some()
+}
+
+fn valid_snapshot(value: &Value) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    if !exact_keys(
+        object,
+        &[
+            "snapshot_id",
+            "transition_id",
+            "source_segment_id",
+            "target_segment_id",
+            "assessment_version",
+            "policy_version",
+            "context_id",
+            "context_version",
+            "payload_sha256",
+            "created_at",
+        ],
+    ) {
+        return false;
+    }
+    for key in [
+        "snapshot_id",
+        "transition_id",
+        "source_segment_id",
+        "target_segment_id",
+        "assessment_version",
+        "policy_version",
+        "context_id",
+        "context_version",
+    ] {
+        if !object.get(key).and_then(Value::as_str).is_some_and(token) {
+            return false;
+        }
+    }
+    object
+        .get("payload_sha256")
+        .and_then(Value::as_str)
+        .is_some_and(digest)
+        && object
+            .get("created_at")
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.is_empty() && value.len() <= 64 && !value.chars().any(char::is_control))
+}
+
+fn valid_confidence(value: &Value) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    exact_keys(
+        object,
+        &["score", "calibration_state", "evidence_count", "disagreement"],
+    ) && object
+        .get("calibration_state")
+        .and_then(Value::as_str)
+        .is_some_and(|value| matches!(value, "unknown" | "uncalibrated" | "calibrated"))
+        && object.get("evidence_count").and_then(Value::as_u64).unwrap_or(0) >= 1
+}
+
+fn valid_token_array(value: &Value, max: usize) -> bool {
+    value.as_array().is_some_and(|items| {
+        items.len() <= max
+            && items
+                .iter()
+                .all(|item| item.as_str().is_some_and(token))
+    })
+}
+
+fn valid_assessment(value: &Value) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    if !exact_keys(
+        object,
+        &[
+            "transition_id",
+            "source_segment_id",
+            "target_segment_id",
+            "assessment_version",
+            "policy_version",
+            "music_dna_revision_refs",
+            "created_at",
+            "compatibility",
+            "risk",
+            "cost",
+            "energy_effect",
+            "candidate_strategies",
+            "preferred_strategy",
+            "usable_window",
+            "contextual_projection",
+            "confidence",
+            "explanations",
+            "evidence_refs",
+            "warnings",
+        ],
+    ) {
+        return false;
+    }
+    for key in [
+        "transition_id",
+        "source_segment_id",
+        "target_segment_id",
+        "assessment_version",
+        "policy_version",
+    ] {
+        if !object.get(key).and_then(Value::as_str).is_some_and(token) {
+            return false;
+        }
+    }
+    if !object
+        .get("music_dna_revision_refs")
+        .and_then(Value::as_array)
+        .is_some_and(|items| items.len() == 2 && items.iter().all(|item| item.as_str().is_some_and(token)))
+        || !object
+            .get("created_at")
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.is_empty() && value.len() <= 64)
+        || !valid_confidence(&object["confidence"])
+        || !valid_token_array(&object["evidence_refs"], 64)
+        || !object.get("warnings").and_then(Value::as_array).is_some_and(|items| {
+            items.len() <= 64
+                && items.iter().all(|item| {
+                    item.as_str().is_some_and(|value| {
+                        value.len() <= 512 && !value.starts_with('/') && !value.chars().any(char::is_control)
+                    })
+                })
+        })
+    {
+        return false;
+    }
+
+    let Some(strategies) = object.get("candidate_strategies").and_then(Value::as_array) else {
+        return false;
+    };
+    if strategies.is_empty() || strategies.len() > 16 {
+        return false;
+    }
+    for strategy in strategies {
+        let Some(item) = strategy.as_object() else {
+            return false;
+        };
+        if !exact_keys(
+            item,
+            &[
+                "strategy",
+                "suitability",
+                "required_capabilities",
+                "explanation_codes",
+            ],
+        ) || !item.get("strategy").and_then(Value::as_str).is_some_and(token)
+            || !valid_token_array(&item["required_capabilities"], 32)
+            || !valid_token_array(&item["explanation_codes"], 32)
+        {
+            return false;
+        }
+    }
+
+    let Some(window) = object.get("usable_window").and_then(Value::as_object) else {
+        return false;
+    };
+    if !exact_keys(
+        window,
+        &[
+            "source_start_seconds",
+            "source_end_seconds",
+            "target_start_seconds",
+            "target_end_seconds",
+            "source_bar_count",
+            "target_bar_count",
+            "confidence",
+        ],
+    ) || !valid_confidence(&window["confidence"])
+    {
+        return false;
+    }
+
+    let Some(projection) = object
+        .get("contextual_projection")
+        .and_then(Value::as_object)
+    else {
+        return false;
+    };
+    if !exact_keys(
+        projection,
+        &[
+            "context_id",
+            "context_version",
+            "score",
+            "blocked_reasons",
+            "rank_features",
+            "confidence",
+            "explanation_codes",
+        ],
+    ) || !projection
+        .get("context_id")
+        .and_then(Value::as_str)
+        .is_some_and(token)
+        || !projection
+            .get("context_version")
+            .and_then(Value::as_str)
+            .is_some_and(token)
+        || !valid_token_array(&projection["blocked_reasons"], 32)
+        || !valid_token_array(&projection["rank_features"], 32)
+        || !valid_token_array(&projection["explanation_codes"], 32)
+        || !valid_confidence(&projection["confidence"])
+    {
+        return false;
+    }
+
+    object.get("explanations").and_then(Value::as_array).is_some_and(|items| {
+        items.len() <= 64
+            && items.iter().all(|value| {
+                let Some(item) = value.as_object() else {
+                    return false;
+                };
+                exact_keys(item, &["code", "severity", "dimension", "evidence_refs", "confidence"])
+                    && item.get("code").and_then(Value::as_str).is_some_and(token)
+                    && item.get("severity").and_then(Value::as_str).is_some_and(token)
+                    && item.get("dimension").and_then(Value::as_str).is_some_and(token)
+                    && valid_token_array(&item["evidence_refs"], 64)
+                    && valid_confidence(&item["confidence"])
+            })
+    })
+}
+
+fn validate_response(value: &Value, revision_id: &str, pair_index: usize) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    if !exact_keys(
+        object,
+        &[
+            "schema",
+            "revision_id",
+            "playlist_id",
+            "revision_index",
+            "pair_index",
+            "source",
+            "target",
+            "available_snapshots",
+            "personal_dj_model_training_authorized",
+            "production_activation_authorized",
+            "transition_recomputation_authorized",
+            "playlist_mutation_authorized",
+            "state",
+            "selected_snapshot_id",
+            "assessment",
+        ],
+    ) || object.get("schema").and_then(Value::as_str)
+        != Some("applaylist-desktop-transition-inspection-r1")
+        || object.get("revision_id").and_then(Value::as_str) != Some(revision_id)
+        || !object.get("playlist_id").and_then(Value::as_str).is_some_and(token)
+        || object.get("pair_index").and_then(Value::as_u64) != Some(pair_index as u64)
+        || !valid_item(&object["source"], pair_index)
+        || !valid_item(&object["target"], pair_index + 1)
+        || object
+            .get("personal_dj_model_training_authorized")
+            .and_then(Value::as_bool)
+            != Some(false)
+        || object
+            .get("production_activation_authorized")
+            .and_then(Value::as_bool)
+            != Some(false)
+        || object
+            .get("transition_recomputation_authorized")
+            .and_then(Value::as_bool)
+            != Some(false)
+        || object
+            .get("playlist_mutation_authorized")
+            .and_then(Value::as_bool)
+            != Some(false)
+    {
+        return false;
+    }
+
+    let Some(snapshots) = object.get("available_snapshots").and_then(Value::as_array) else {
+        return false;
+    };
+    if snapshots.len() > 16 || !snapshots.iter().all(valid_snapshot) {
+        return false;
+    }
+    match object.get("state").and_then(Value::as_str) {
+        Some("missing") => {
+            snapshots.is_empty()
+                && object.get("selected_snapshot_id") == Some(&Value::Null)
+                && object.get("assessment") == Some(&Value::Null)
+        }
+        Some("present") => {
+            let selected = object.get("selected_snapshot_id").and_then(Value::as_str);
+            !snapshots.is_empty()
+                && selected.is_some_and(token)
+                && snapshots[0].get("snapshot_id").and_then(Value::as_str) == selected
+                && object.get("assessment").is_some_and(valid_assessment)
+        }
+        _ => false,
+    }
+}
+
+#[tauri::command]
+pub async fn playlist_transition_inspect(
+    revision_id: String,
+    pair_index: usize,
+    bridge: State<'_, TransitionInspectorBridge>,
+    app: AppHandle,
+) -> Result<Value, DesktopHostError> {
+    if !token(&revision_id) || pair_index > 6 {
+        return Err(InspectorError::invalid_request().into());
+    }
+    let resource_dir = app.path().resource_dir().ok();
+    let bridge = bridge.inner().clone();
+    let expected_revision = revision_id.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        bridge.request(&revision_id, pair_index, resource_dir.as_deref())
+    })
+    .await
+    .map_err(|_| {
+        DesktopHostError::new(
+            "desktop_transition_inspector_task_failed",
+            "The transition inspection task failed.",
+        )
+    })?
+    .map_err(DesktopHostError::from)?;
+    if !validate_response(&result, &expected_revision, pair_index) {
+        return Err(InspectorError::invalid_response().into());
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validation_rejects_authority_escalation_and_unknown_fields() {
+        let mut value = json!({
+            "schema":"applaylist-desktop-transition-inspection-r1",
+            "revision_id":"prv_abc",
+            "playlist_id":"plr_abc",
+            "revision_index":1,
+            "pair_index":0,
+            "source":{"order_index":0,"track_id":"trk_a","display_name":"A","locked":false},
+            "target":{"order_index":1,"track_id":"trk_b","display_name":"B","locked":true},
+            "available_snapshots":[],
+            "personal_dj_model_training_authorized":false,
+            "production_activation_authorized":false,
+            "transition_recomputation_authorized":false,
+            "playlist_mutation_authorized":false,
+            "state":"missing",
+            "selected_snapshot_id":null,
+            "assessment":null
+        });
+        assert!(validate_response(&value, "prv_abc", 0));
+        value["transition_recomputation_authorized"] = Value::Bool(true);
+        assert!(!validate_response(&value, "prv_abc", 0));
+        value["transition_recomputation_authorized"] = Value::Bool(false);
+        value["source_path"] = Value::String("/tmp/audio.wav".into());
+        assert!(!validate_response(&value, "prv_abc", 0));
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,8 @@
         "main-playlist-editor",
         "main-playlist-export",
         "main-playlist-evidence-export",
-        "main-playlist-vendor-interop"
+        "main-playlist-vendor-interop",
+        "main-transition-inspector"
       ]
     },
     "withGlobalTauri": true

--- a/tests/test_desktop_set_proposal_renderer.py
+++ b/tests/test_desktop_set_proposal_renderer.py
@@ -89,6 +89,7 @@ def test_set_proposal_tauri_surface_is_separate_and_narrow() -> None:
         "main-playlist-export",
         "main-playlist-evidence-export",
         "main-playlist-vendor-interop",
+        "main-transition-inspector",
     }
 
     assert "#[serde(deny_unknown_fields)]" in rust

--- a/tests/test_desktop_transition_inspector.py
+++ b/tests/test_desktop_transition_inspector.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.intelligence.music_dna import CalibrationState, Confidence
+from core.intelligence.transition_contract import (
+    ContextualTransitionProjection,
+    EnergyDirection,
+    TransitionAssessment,
+    TransitionCompatibility,
+    TransitionCost,
+    TransitionEnergyEffect,
+    TransitionExplanation,
+    TransitionIdentity,
+    TransitionRisk,
+    TransitionStrategy,
+    TransitionStrategyCandidate,
+    TransitionWindow,
+)
+from data.connection import get_sqlite_connection
+from data.repositories.music_intelligence_repository import MusicIntelligenceRepository
+from data.repositories.playlist_revision_repository import PlaylistRevisionRepository
+from services.desktop.transition_inspector_transport import (
+    DesktopTransitionInspectorError,
+    DesktopTransitionInspectorTransport,
+)
+from tests.test_desktop_readiness_sidecar import _finish, _request
+from tests.test_desktop_set_proposal_transport import _configure_database, _start_extended_sidecar
+
+
+def _revision() -> dict[str, object]:
+    return PlaylistRevisionRepository().append_root(
+        source_proposal_id="spr_transition_inspector",
+        source_path_id="spp_transition_inspector",
+        items=[("trk_a", "A"), ("trk_b", "B"), ("trk_c", "C")],
+        operation_metadata={"fixture": "bundle61"},
+    )
+
+
+def _confidence(score: float = 0.8) -> Confidence:
+    return Confidence(
+        score=score,
+        calibration_state=CalibrationState.UNCALIBRATED,
+        evidence_count=2,
+        disagreement=0.1,
+    )
+
+
+def _assessment(*, context_id: str = "ctx_fixture", context_version: str = "1") -> TransitionAssessment:
+    confidence = _confidence()
+    return TransitionAssessment(
+        identity=TransitionIdentity(
+            transition_id="trn_a_b",
+            source_track_id="trk_a",
+            source_segment_id="seg_a_out",
+            target_track_id="trk_b",
+            target_segment_id="seg_b_in",
+            assessment_version="transition-assessment-v1",
+            policy_version="transition-policy-v1",
+            music_dna_revision_refs=("mdr_a", "mdr_b"),
+            created_at="2026-08-19T06:55:00Z",
+        ),
+        compatibility_vector=TransitionCompatibility(
+            tempo_fit=0.9,
+            beat_grid_fit=0.8,
+            phrase_fit=0.7,
+            harmonic_fit=0.75,
+            groove_continuity=0.85,
+            structural_fit=0.8,
+            timbral_fit=0.65,
+            melodic_fit=0.6,
+            semantic_fit=0.7,
+        ),
+        risk_vector=TransitionRisk(
+            bass_collision=0.15,
+            vocal_collision=0.1,
+            spectral_masking=0.2,
+            loudness_discontinuity=0.1,
+            harmonic_clash=0.2,
+            phrase_mismatch=0.15,
+            tempo_instability=0.05,
+            transient_overload=0.1,
+            uncertainty=0.2,
+        ),
+        cost_vector=TransitionCost(
+            tempo_change_percent=1.5,
+            time_stretch_cost=0.1,
+            pitch_shift_semitones=0.0,
+            key_shift_cost=0.0,
+            loop_dependency=False,
+            stem_dependency=False,
+            effect_dependency=False,
+            preparation_complexity=0.2,
+        ),
+        energy_effect=TransitionEnergyEffect(
+            source_energy_state=0.55,
+            target_energy_state=0.65,
+            delta=0.1,
+            local_curve_alignment=0.9,
+            direction=EnergyDirection.RISE,
+            confidence=confidence,
+        ),
+        candidate_strategies=(
+            TransitionStrategyCandidate(
+                strategy=TransitionStrategy.EQ_BLEND,
+                suitability=0.88,
+                required_capabilities=("eq",),
+                explanation_codes=("tempo_fit", "phrase_fit"),
+            ),
+            TransitionStrategyCandidate(
+                strategy=TransitionStrategy.SHORT_BLEND,
+                suitability=0.72,
+                required_capabilities=("channel_faders",),
+                explanation_codes=("low_risk",),
+            ),
+        ),
+        preferred_strategy=TransitionStrategy.EQ_BLEND,
+        usable_window=TransitionWindow(
+            source_start_seconds=120.0,
+            source_end_seconds=136.0,
+            target_start_seconds=0.0,
+            target_end_seconds=16.0,
+            source_bar_count=8,
+            target_bar_count=8,
+            confidence=confidence,
+        ),
+        contextual_projection=ContextualTransitionProjection(
+            context_id=context_id,
+            context_version=context_version,
+            score=0.86,
+            blocked_reasons=(),
+            rank_features=("tempo_fit", "energy_rise"),
+            confidence=confidence,
+            explanation_codes=("good_fit",),
+        ),
+        confidence=confidence,
+        explanations=(
+            TransitionExplanation(
+                code="good_fit",
+                severity="info",
+                dimension="overall",
+                evidence_refs=("ev_a", "ev_b"),
+                confidence=confidence,
+            ),
+        ),
+        evidence_refs=("ev_a", "ev_b"),
+        warnings=("review_phrase_boundary",),
+    )
+
+
+def test_inspector_returns_explicit_missing_without_recompute(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_database(monkeypatch, tmp_path)
+    revision = _revision()
+    ledger = PlaylistRevisionRepository()
+    before = ledger.count_revisions(str(revision["playlist_id"]))
+
+    result = DesktopTransitionInspectorTransport().inspect(
+        revision_id=str(revision["revision_id"]),
+        pair_index=0,
+    )
+
+    assert result["schema"] == "applaylist-desktop-transition-inspection-r1"
+    assert result["state"] == "missing"
+    assert result["selected_snapshot_id"] is None
+    assert result["assessment"] is None
+    assert result["source"]["track_id"] == "trk_a"
+    assert result["target"]["track_id"] == "trk_b"
+    assert result["available_snapshots"] == ()
+    assert result["transition_recomputation_authorized"] is False
+    assert result["playlist_mutation_authorized"] is False
+    assert ledger.count_revisions(str(revision["playlist_id"])) == before
+
+
+def test_inspector_projects_persisted_assessment_for_revision_adjacent_pair(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_database(monkeypatch, tmp_path)
+    revision = _revision()
+    repository = MusicIntelligenceRepository()
+    snapshot_id = repository.append_transition_assessment(_assessment())
+
+    result = DesktopTransitionInspectorTransport().inspect(
+        revision_id=str(revision["revision_id"]),
+        pair_index=0,
+    )
+
+    assert result["state"] == "present"
+    assert result["selected_snapshot_id"] == snapshot_id
+    assert len(result["available_snapshots"]) == 1
+    assessment = result["assessment"]
+    assert assessment["transition_id"] == "trn_a_b"
+    assert assessment["preferred_strategy"] == "eq_blend"
+    assert assessment["compatibility"]["tempo_fit"] == 0.9
+    assert assessment["risk"]["uncertainty"] == 0.2
+    assert assessment["energy_effect"]["direction"] == "rise"
+    assert assessment["contextual_projection"]["score"] == 0.86
+    assert assessment["evidence_refs"] == ["ev_a", "ev_b"]
+    encoded = json.dumps(result, sort_keys=True)
+    assert "payload_json" not in encoded
+    assert "content_utf8" not in encoded
+    assert "/Users/" not in encoded
+
+
+def test_inspector_rejects_nonexistent_pair_index_and_never_accepts_renderer_track_ids(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_database(monkeypatch, tmp_path)
+    revision = _revision()
+
+    with pytest.raises(DesktopTransitionInspectorError) as exc_info:
+        DesktopTransitionInspectorTransport().inspect(
+            revision_id=str(revision["revision_id"]),
+            pair_index=2,
+        )
+    assert exc_info.value.code == "invalid_transition_inspection_request"
+
+
+def test_inspector_detects_persisted_snapshot_integrity_tamper(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_database(monkeypatch, tmp_path)
+    revision = _revision()
+    repository = MusicIntelligenceRepository()
+    snapshot_id = repository.append_transition_assessment(_assessment())
+    with get_sqlite_connection() as conn:
+        conn.execute(
+            "UPDATE transition_assessment_snapshots SET payload_json=? WHERE snapshot_id=?",
+            ('{"tampered":true}', snapshot_id),
+        )
+        conn.commit()
+
+    with pytest.raises(RuntimeError, match="integrity"):
+        DesktopTransitionInspectorTransport().inspect(
+            revision_id=str(revision["revision_id"]),
+            pair_index=0,
+        )
+
+
+def test_authenticated_transition_inspector_route_is_strict(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    database = _configure_database(monkeypatch, tmp_path)
+    revision = _revision()
+    MusicIntelligenceRepository().append_transition_assessment(_assessment())
+    process, ready = _start_extended_sidecar(database)
+    body = json.dumps({"revision_id": revision["revision_id"], "pair_index": 0}).encode()
+    try:
+        status, payload = _request(
+            ready,
+            method="POST",
+            path="/v1/playlist/transition/inspect",
+            secret="X" * 48,
+            body=body,
+        )
+        assert status == 401
+        assert payload == {"error": "unauthorized"}
+
+        status, payload = _request(
+            ready,
+            method="POST",
+            path="/v1/playlist/transition/inspect",
+            body=json.dumps(
+                {"revision_id": revision["revision_id"], "pair_index": 0, "source_track_id": "trk_a"}
+            ).encode(),
+        )
+        assert status == 400
+        assert payload == {"error": "invalid_transition_inspection_request"}
+
+        status, payload = _request(
+            ready,
+            method="POST",
+            path="/v1/playlist/transition/inspect",
+            body=body,
+        )
+        assert status == 200
+        assert payload["state"] == "present"
+        assert payload["source"]["track_id"] == "trk_a"
+        assert payload["target"]["track_id"] == "trk_b"
+        assert payload["transition_recomputation_authorized"] is False
+
+        status, shutdown = _request(ready, method="POST", path="/v1/shutdown")
+        assert status == 202
+        assert shutdown == {"status": "shutting_down"}
+        _finish(process)
+    finally:
+        if process.poll() is None:
+            process.kill()
+            _finish(process)

--- a/tests/test_desktop_transition_inspector_renderer.py
+++ b/tests/test_desktop_transition_inspector_renderer.py
@@ -37,6 +37,7 @@ def test_transition_inspector_renderer_is_external_dom_safe_and_read_only() -> N
     assert ".textContent" in js
     assert ".innerHTML" not in js
     assert "insertAdjacentHTML" not in js
+    assert '["payload_json", "content_utf8", "source_path", "target_path", "filesystem_path"].includes(key)' in js
 
     for forbidden in (
         "fetch(",
@@ -51,10 +52,6 @@ def test_transition_inspector_renderer_is_external_dom_safe_and_read_only() -> N
         "X-APPLAYLIST-Sidecar-Secret",
         "X-APPLAYLIST-Readiness-Nonce",
         "127.0.0.1",
-        "payload_json",
-        "content_utf8",
-        "source_path",
-        "target_path",
     ):
         assert forbidden not in js
 

--- a/tests/test_desktop_transition_inspector_renderer.py
+++ b/tests/test_desktop_transition_inspector_renderer.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HTML = ROOT / "desktop" / "host-proof" / "index.html"
+JS = ROOT / "desktop" / "host-proof" / "transition-inspector.js"
+BUILD_RS = ROOT / "src-tauri" / "build.rs"
+LIB_RS = ROOT / "src-tauri" / "src" / "lib.rs"
+RUST = ROOT / "src-tauri" / "src" / "transition_inspector.rs"
+CAPABILITY = ROOT / "src-tauri" / "capabilities" / "main-transition-inspector.json"
+TAURI_CONF = ROOT / "src-tauri" / "tauri.conf.json"
+
+
+def test_transition_inspector_renderer_is_external_dom_safe_and_read_only() -> None:
+    html = HTML.read_text(encoding="utf-8")
+    js = JS.read_text(encoding="utf-8")
+
+    assert '<script src="./transition-inspector.js" defer></script>' in html
+    assert html.index('src="./transition-inspector.js"') < html.index('src="./playlist-editor.js"')
+    for required in (
+        'id="transition-inspector"',
+        'id="transition-inspector-revision"',
+        'id="transition-inspector-pair"',
+        'id="transition-inspector-load"',
+        'id="transition-inspector-result"',
+    ):
+        assert required in html
+
+    assert 'originalInvoke("playlist_transition_inspect", {' in js
+    assert "playlist_editor_history" in js
+    assert "pairIndex" in js
+    assert "transition_recomputation_authorized !== false" in js
+    assert "playlist_mutation_authorized !== false" in js
+    assert "document.createElement" in js
+    assert ".textContent" in js
+    assert ".innerHTML" not in js
+    assert "insertAdjacentHTML" not in js
+
+    for forbidden in (
+        "fetch(",
+        "XMLHttpRequest",
+        "WebSocket",
+        "__TAURI__.fs",
+        "__TAURI__.shell",
+        "__TAURI__.http",
+        "plugin:fs",
+        "plugin:shell",
+        "/v1/playlist/transition/",
+        "X-APPLAYLIST-Sidecar-Secret",
+        "X-APPLAYLIST-Readiness-Nonce",
+        "127.0.0.1",
+        "payload_json",
+        "content_utf8",
+        "source_path",
+        "target_path",
+    ):
+        assert forbidden not in js
+
+
+def test_transition_inspector_tauri_surface_is_separate_and_narrow() -> None:
+    build_rs = BUILD_RS.read_text(encoding="utf-8")
+    lib_rs = LIB_RS.read_text(encoding="utf-8")
+    rust = RUST.read_text(encoding="utf-8")
+    capability = json.loads(CAPABILITY.read_text(encoding="utf-8"))
+    conf = json.loads(TAURI_CONF.read_text(encoding="utf-8"))
+
+    assert '"playlist_transition_inspect"' in build_rs
+    assert "transition_inspector::playlist_transition_inspect" in lib_rs
+    assert ".manage(TransitionInspectorBridge::from_environment())" in lib_rs
+    assert capability["permissions"] == [
+        "core:default",
+        "allow-playlist-transition-inspect",
+    ]
+    assert "main-transition-inspector" in conf["app"]["security"]["capabilities"]
+    assert "connect-src 'none'" in conf["app"]["security"]["csp"]
+
+    assert '"/v1/playlist/transition/inspect"' in rust
+    assert 'BUNDLED_SIDECAR_RESOURCE: &str = "applaylist-sidecar/applaylist-sidecar"' in rust
+    assert "stderr(Stdio::null())" in rust
+    assert "validate_response" in rust
+    assert "transition_recomputation_authorized" in rust
+    assert "playlist_mutation_authorized" in rust
+    assert "blocking_save_file" not in rust
+    assert "write_atomic" not in rust


### PR DESCRIPTION
## Summary

Adds the remaining read-only R4 `selected transition inspection` capability over one exact immutable `PlaylistRevision`.

- explicit revision + adjacent `pair_index`
- source/target identity derived from immutable revision order
- persisted TransitionAssessment lookup only
- stored payload integrity verification before projection
- explicit `missing` state when evidence does not exist
- renderer-safe assessment projection
- no transition recomputation, optimizer rerun, playlist mutation, PDM training, production activation, release or deploy

Closes #141

## Bundle Context

Bundle 57 established immutable PlaylistRevision history. Bundles 58–60 added export/evidence/vendor interoperability. The canonical R4 roadmap still requires `selected transition inspection` and `regeneration around locks`; Bundle 61 implements only the read-only inspection slice.

Canonical base SHA: `72fd76f033d484a8fa093a6ba38f58b26c6ac782`
Initial implementation head SHA: `a48275d831575fdcea1723f3c44a0c5e95a1506b`
Initial compare: `14 commits ahead / 0 behind / 14 files`; merge-base is exactly the canonical base SHA.

## Authority boundaries

- renderer supplies only `revision_id` + adjacent `pair_index`
- authenticated sidecar derives track pair from immutable revision order
- only persisted TransitionAssessment snapshots are inspectable
- no raw payload JSON, filesystem path, audio, provider handle, or write authority reaches renderer
- dedicated Tauri command/capability; CSP remains `connect-src 'none'`
- response hard-codes training/production/recompute/mutation authority to false

## Verification

Fresh exact-head CI evidence will be recorded after PR workflows complete.

`MERGE_AUTHORIZATION=NO`
`RELEASE_AUTHORIZATION=NO`
`DEPLOY_AUTHORIZATION=NO`
`PRODUCTION_EFFECTS=NO`