### PR TITLE
Bundle 62: regeneration around locks R1

### DIFF
--- a/data/repositories/playlist_revision_repository.py
+++ b/data/repositories/playlist_revision_repository.py
@@ -8,7 +8,7 @@ from data.connection import get_sqlite_connection
 
 _MAX_ITEMS = 8
 _MAX_HISTORY = 100
-_OPERATIONS = {"accept", "reorder", "lock", "replace"}
+_OPERATIONS = {"accept", "reorder", "lock", "replace", "regenerate"}
 
 
 class PlaylistRevisionRepositoryError(ValueError):
@@ -24,42 +24,118 @@ class PlaylistRevisionRepository:
     def ensure_schema(self) -> None:
         with get_sqlite_connection() as conn:
             conn.execute("PRAGMA foreign_keys = ON")
-            conn.executescript(
+            self._create_schema(conn)
+            row = conn.execute(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name='playlist_revisions'"
+            ).fetchone()
+            table_sql = "" if row is None else str(row["sql"] or "")
+            if "regenerate" not in table_sql:
+                conn.commit()
+                self._migrate_revision_operations(conn)
+            conn.commit()
+
+    @staticmethod
+    def _create_schema(conn: object) -> None:
+        conn.executescript(  # type: ignore[attr-defined]
+            """
+            CREATE TABLE IF NOT EXISTS playlist_revisions (
+                revision_id TEXT PRIMARY KEY,
+                playlist_id TEXT NOT NULL,
+                parent_revision_id TEXT,
+                revision_index INTEGER NOT NULL CHECK (revision_index >= 0),
+                source_proposal_id TEXT NOT NULL,
+                source_path_id TEXT NOT NULL,
+                operation TEXT NOT NULL CHECK (operation IN ('accept','reorder','lock','replace','regenerate')),
+                operation_json TEXT NOT NULL,
+                content_fingerprint TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                personal_dj_model_training_authorized INTEGER NOT NULL DEFAULT 0 CHECK (personal_dj_model_training_authorized = 0),
+                production_activation_authorized INTEGER NOT NULL DEFAULT 0 CHECK (production_activation_authorized = 0),
+                UNIQUE (playlist_id, revision_index),
+                FOREIGN KEY(parent_revision_id) REFERENCES playlist_revisions(revision_id)
+            );
+            CREATE TABLE IF NOT EXISTS playlist_revision_items (
+                revision_id TEXT NOT NULL,
+                order_index INTEGER NOT NULL CHECK (order_index >= 0),
+                track_id TEXT NOT NULL,
+                display_name TEXT NOT NULL,
+                locked INTEGER NOT NULL DEFAULT 0 CHECK (locked IN (0,1)),
+                PRIMARY KEY (revision_id, order_index),
+                UNIQUE (revision_id, track_id),
+                FOREIGN KEY(revision_id) REFERENCES playlist_revisions(revision_id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_playlist_revision_head ON playlist_revisions(playlist_id, revision_index);
+            CREATE TRIGGER IF NOT EXISTS playlist_revisions_no_update BEFORE UPDATE ON playlist_revisions BEGIN SELECT RAISE(ABORT, 'playlist revisions are immutable'); END;
+            CREATE TRIGGER IF NOT EXISTS playlist_revisions_no_delete BEFORE DELETE ON playlist_revisions BEGIN SELECT RAISE(ABORT, 'playlist revisions are immutable'); END;
+            CREATE TRIGGER IF NOT EXISTS playlist_revision_items_no_update BEFORE UPDATE ON playlist_revision_items BEGIN SELECT RAISE(ABORT, 'playlist revision items are immutable'); END;
+            CREATE TRIGGER IF NOT EXISTS playlist_revision_items_no_delete BEFORE DELETE ON playlist_revision_items BEGIN SELECT RAISE(ABORT, 'playlist revision items are immutable'); END;
+            """
+        )
+
+    @staticmethod
+    def _migrate_revision_operations(conn: object) -> None:
+        conn.execute("PRAGMA foreign_keys = OFF")  # type: ignore[attr-defined]
+        try:
+            conn.execute("BEGIN IMMEDIATE")  # type: ignore[attr-defined]
+            conn.execute("DROP TRIGGER IF EXISTS playlist_revisions_no_update")  # type: ignore[attr-defined]
+            conn.execute("DROP TRIGGER IF EXISTS playlist_revisions_no_delete")  # type: ignore[attr-defined]
+            conn.execute("DROP TABLE IF EXISTS playlist_revisions_next")  # type: ignore[attr-defined]
+            conn.execute(  # type: ignore[attr-defined]
                 """
-                CREATE TABLE IF NOT EXISTS playlist_revisions (
+                CREATE TABLE playlist_revisions_next (
                     revision_id TEXT PRIMARY KEY,
                     playlist_id TEXT NOT NULL,
                     parent_revision_id TEXT,
                     revision_index INTEGER NOT NULL CHECK (revision_index >= 0),
                     source_proposal_id TEXT NOT NULL,
                     source_path_id TEXT NOT NULL,
-                    operation TEXT NOT NULL CHECK (operation IN ('accept','reorder','lock','replace')),
+                    operation TEXT NOT NULL CHECK (operation IN ('accept','reorder','lock','replace','regenerate')),
                     operation_json TEXT NOT NULL,
                     content_fingerprint TEXT NOT NULL,
                     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
                     personal_dj_model_training_authorized INTEGER NOT NULL DEFAULT 0 CHECK (personal_dj_model_training_authorized = 0),
                     production_activation_authorized INTEGER NOT NULL DEFAULT 0 CHECK (production_activation_authorized = 0),
                     UNIQUE (playlist_id, revision_index),
-                    FOREIGN KEY(parent_revision_id) REFERENCES playlist_revisions(revision_id)
-                );
-                CREATE TABLE IF NOT EXISTS playlist_revision_items (
-                    revision_id TEXT NOT NULL,
-                    order_index INTEGER NOT NULL CHECK (order_index >= 0),
-                    track_id TEXT NOT NULL,
-                    display_name TEXT NOT NULL,
-                    locked INTEGER NOT NULL DEFAULT 0 CHECK (locked IN (0,1)),
-                    PRIMARY KEY (revision_id, order_index),
-                    UNIQUE (revision_id, track_id),
-                    FOREIGN KEY(revision_id) REFERENCES playlist_revisions(revision_id)
-                );
-                CREATE INDEX IF NOT EXISTS idx_playlist_revision_head ON playlist_revisions(playlist_id, revision_index);
-                CREATE TRIGGER IF NOT EXISTS playlist_revisions_no_update BEFORE UPDATE ON playlist_revisions BEGIN SELECT RAISE(ABORT, 'playlist revisions are immutable'); END;
-                CREATE TRIGGER IF NOT EXISTS playlist_revisions_no_delete BEFORE DELETE ON playlist_revisions BEGIN SELECT RAISE(ABORT, 'playlist revisions are immutable'); END;
-                CREATE TRIGGER IF NOT EXISTS playlist_revision_items_no_update BEFORE UPDATE ON playlist_revision_items BEGIN SELECT RAISE(ABORT, 'playlist revision items are immutable'); END;
-                CREATE TRIGGER IF NOT EXISTS playlist_revision_items_no_delete BEFORE DELETE ON playlist_revision_items BEGIN SELECT RAISE(ABORT, 'playlist revision items are immutable'); END;
+                    FOREIGN KEY(parent_revision_id) REFERENCES playlist_revisions_next(revision_id)
+                )
                 """
             )
-            conn.commit()
+            conn.execute(  # type: ignore[attr-defined]
+                """
+                INSERT INTO playlist_revisions_next (
+                    revision_id, playlist_id, parent_revision_id, revision_index,
+                    source_proposal_id, source_path_id, operation, operation_json,
+                    content_fingerprint, created_at,
+                    personal_dj_model_training_authorized, production_activation_authorized
+                )
+                SELECT
+                    revision_id, playlist_id, parent_revision_id, revision_index,
+                    source_proposal_id, source_path_id, operation, operation_json,
+                    content_fingerprint, created_at,
+                    personal_dj_model_training_authorized, production_activation_authorized
+                FROM playlist_revisions
+                """
+            )
+            conn.execute("DROP TABLE playlist_revisions")  # type: ignore[attr-defined]
+            conn.execute("ALTER TABLE playlist_revisions_next RENAME TO playlist_revisions")  # type: ignore[attr-defined]
+            conn.execute(  # type: ignore[attr-defined]
+                "CREATE INDEX IF NOT EXISTS idx_playlist_revision_head ON playlist_revisions(playlist_id, revision_index)"
+            )
+            conn.execute(  # type: ignore[attr-defined]
+                "CREATE TRIGGER IF NOT EXISTS playlist_revisions_no_update BEFORE UPDATE ON playlist_revisions BEGIN SELECT RAISE(ABORT, 'playlist revisions are immutable'); END"
+            )
+            conn.execute(  # type: ignore[attr-defined]
+                "CREATE TRIGGER IF NOT EXISTS playlist_revisions_no_delete BEFORE DELETE ON playlist_revisions BEGIN SELECT RAISE(ABORT, 'playlist revisions are immutable'); END"
+            )
+            conn.commit()  # type: ignore[attr-defined]
+        except Exception:
+            conn.rollback()  # type: ignore[attr-defined]
+            raise
+        finally:
+            conn.execute("PRAGMA foreign_keys = ON")  # type: ignore[attr-defined]
+        violation = conn.execute("PRAGMA foreign_key_check").fetchone()  # type: ignore[attr-defined]
+        if violation is not None:
+            raise RuntimeError("playlist revision schema migration failed foreign-key verification")
 
     def append_root(
         self,

--- a/desktop/host-proof/playlist-editor.js
+++ b/desktop/host-proof/playlist-editor.js
@@ -14,7 +14,7 @@
   }
 
   const TOKEN = /^[A-Za-z0-9][A-Za-z0-9_.:+-]{0,255}$/;
-  const OPERATIONS = new Set(["accept", "reorder", "lock", "replace"]);
+  const OPERATIONS = new Set(["accept", "reorder", "lock", "replace", "regenerate"]);
   let lastProposal = null;
   let activeRevision = null;
   let replacementTracks = new Map();
@@ -210,6 +210,12 @@
     const result = await originalInvoke(command, args);
     if (validProposalContext(command, args, result)) {
       captureProposal(args, result);
+    }
+    if (command === "playlist_editor_regeneration_apply" && validRevision(result)) {
+      activeRevision = result;
+      await refreshReplacementTracks();
+      await refreshHistory();
+      setStatus("Regeneration appended as a new immutable revision.");
     }
     return result;
   }

--- a/desktop/host-proof/playlist-editor.js
+++ b/desktop/host-proof/playlist-editor.js
@@ -18,6 +18,8 @@
   let lastProposal = null;
   let activeRevision = null;
   let replacementTracks = new Map();
+  let regenerationPreview = null;
+  let regenerationCandidateIds = [];
   let busy = false;
 
   function exactKeys(value, keys) {
@@ -186,6 +188,100 @@
     );
   }
 
+  function validRegenerationPreview(value, revisionId, candidateIds) {
+    if (
+      !exactKeys(value, [
+        "schema",
+        "playlist_id",
+        "parent_revision_id",
+        "regeneration_id",
+        "candidate_pool_count",
+        "candidate_pool_sha256",
+        "locked_positions",
+        "alternatives",
+        "reason_codes",
+        "warning_codes",
+        "budget_exhausted",
+        "missing_evidence_detected",
+        "deterministic_ordering",
+        "playlist_mutation_authorized",
+        "personal_dj_model_training_authorized",
+        "production_activation_authorized",
+      ]) ||
+      value.schema !== "applaylist-desktop-playlist-regeneration-r1" ||
+      !validToken(value.playlist_id) ||
+      value.parent_revision_id !== revisionId ||
+      !validToken(value.regeneration_id) ||
+      value.candidate_pool_count !== candidateIds.length ||
+      !/^[0-9a-f]{64}$/.test(value.candidate_pool_sha256) ||
+      !Array.isArray(value.locked_positions) ||
+      value.locked_positions.length < 1 ||
+      value.locked_positions.length > 8 ||
+      !Array.isArray(value.alternatives) ||
+      value.alternatives.length > 3 ||
+      !Array.isArray(value.reason_codes) ||
+      !value.reason_codes.every(validToken) ||
+      !Array.isArray(value.warning_codes) ||
+      !value.warning_codes.every(validToken) ||
+      typeof value.budget_exhausted !== "boolean" ||
+      typeof value.missing_evidence_detected !== "boolean" ||
+      value.deterministic_ordering !== true ||
+      value.playlist_mutation_authorized !== false ||
+      value.personal_dj_model_training_authorized !== false ||
+      value.production_activation_authorized !== false
+    ) {
+      return false;
+    }
+    const expectedLocks = activeRevision.sequence
+      .filter((item) => item.locked)
+      .map((item) => ({ order_index: item.order_index, track_id: item.track_id }));
+    if (
+      expectedLocks.length !== value.locked_positions.length ||
+      expectedLocks.some((lock, index) =>
+        !exactKeys(value.locked_positions[index], ["order_index", "track_id"]) ||
+        value.locked_positions[index].order_index !== lock.order_index ||
+        value.locked_positions[index].track_id !== lock.track_id,
+      )
+    ) {
+      return false;
+    }
+    return value.alternatives.every((alternative, alternativeIndex) => {
+      if (
+        !exactKeys(alternative, ["path_id", "rank", "sequence", "objective", "explanation_codes"]) ||
+        !validToken(alternative.path_id) ||
+        alternative.rank !== alternativeIndex + 1 ||
+        !Array.isArray(alternative.sequence) ||
+        alternative.sequence.length !== activeRevision.sequence.length ||
+        !Array.isArray(alternative.explanation_codes) ||
+        !alternative.explanation_codes.every(validToken) ||
+        !exactKeys(alternative.objective, [
+          "depth",
+          "mean_candidate_score",
+          "minimum_candidate_score",
+          "required_track_completion",
+          "remaining_required_count",
+          "target_reached",
+        ])
+      ) {
+        return false;
+      }
+      const ids = new Set();
+      return alternative.sequence.every((step, index) => {
+        const locked = activeRevision.sequence[index].locked;
+        return (
+          exactKeys(step, ["order_index", "track_id", "display_name", "locked"]) &&
+          step.order_index === index &&
+          validToken(step.track_id) &&
+          validDisplayName(step.display_name) &&
+          step.locked === locked &&
+          (!locked || step.track_id === activeRevision.sequence[index].track_id) &&
+          !ids.has(step.track_id) &&
+          ids.add(step.track_id)
+        );
+      });
+    });
+  }
+
   function setStatus(message) {
     status.textContent = message;
   }
@@ -213,6 +309,8 @@
     }
     if (command === "playlist_editor_regeneration_apply" && validRevision(result)) {
       activeRevision = result;
+      regenerationPreview = null;
+      regenerationCandidateIds = [];
       await refreshReplacementTracks();
       await refreshHistory();
       setStatus("Regeneration appended as a new immutable revision.");
@@ -403,6 +501,186 @@
       list.appendChild(item);
     }
     current.appendChild(list);
+    renderRegenerationControls();
+  }
+
+  function renderRegenerationControls() {
+    if (!activeRevision) return;
+    const panel = document.createElement("section");
+    panel.className = "editor-regeneration";
+    const heading = document.createElement("h4");
+    heading.textContent = "Regenerate around locks";
+    const explanation = document.createElement("p");
+    explanation.textContent =
+      "R1 preserves locked positions exactly and regenerates only unlocked positions from an explicit analyzed-track pool. Position 1 must be locked.";
+    panel.append(heading, explanation);
+
+    const firstLocked = activeRevision.sequence[0]?.locked === true;
+    if (!firstLocked) {
+      const blocker = document.createElement("p");
+      blocker.className = "empty-state";
+      blocker.textContent = "Lock the first playlist track before regeneration R1 can run.";
+      panel.appendChild(blocker);
+      current.appendChild(panel);
+      return;
+    }
+
+    const currentIds = new Set(activeRevision.sequence.map((item) => item.track_id));
+    const lockedIds = new Set(activeRevision.sequence.filter((item) => item.locked).map((item) => item.track_id));
+    const candidates = new Map(activeRevision.sequence.map((item) => [item.track_id, item.display_name]));
+    for (const [trackId, label] of replacementTracks.entries()) {
+      candidates.set(trackId, label);
+    }
+
+    const list = document.createElement("div");
+    list.className = "regeneration-candidate-list";
+    for (const [trackId, label] of [...candidates.entries()].sort((a, b) => a[1].localeCompare(b[1]))) {
+      const row = document.createElement("label");
+      row.className = "regeneration-candidate";
+      const checkbox = document.createElement("input");
+      checkbox.type = "checkbox";
+      checkbox.value = trackId;
+      checkbox.checked = currentIds.has(trackId);
+      checkbox.disabled = lockedIds.has(trackId) || busy;
+      if (lockedIds.has(trackId)) checkbox.checked = true;
+      checkbox.addEventListener("change", () => {
+        regenerationPreview = null;
+        regenerationCandidateIds = [];
+        renderRegenerationResults(results);
+      });
+      row.append(checkbox, document.createTextNode(` ${label}${lockedIds.has(trackId) ? " · locked" : ""}`));
+      list.appendChild(row);
+    }
+
+    const actions = document.createElement("div");
+    actions.className = "actions";
+    const preview = document.createElement("button");
+    preview.type = "button";
+    preview.textContent = "Preview regeneration";
+    preview.disabled = busy || candidates.size < 3;
+    const selectedCount = document.createElement("span");
+    selectedCount.textContent = "Explicit candidate pool: current members selected; add analyzed alternatives if desired.";
+    actions.append(preview, selectedCount);
+
+    const results = document.createElement("div");
+    results.className = "regeneration-results";
+    preview.addEventListener("click", () => previewRegeneration(list, results));
+    panel.append(list, actions, results);
+    current.appendChild(panel);
+    renderRegenerationResults(results);
+  }
+
+  function selectedRegenerationCandidates(list) {
+    const values = [...list.querySelectorAll("input[type='checkbox']")]
+      .filter((input) => input.checked)
+      .map((input) => input.value);
+    return values.length >= 3 && values.length <= 24 && values.every(validToken) && new Set(values).size === values.length
+      ? values
+      : null;
+  }
+
+  async function previewRegeneration(list, results) {
+    if (busy || !activeRevision) return;
+    const candidateIds = selectedRegenerationCandidates(list);
+    if (!candidateIds) {
+      setStatus("Regeneration requires 3–24 unique analyzed candidate tracks.");
+      return;
+    }
+    const lockedIds = activeRevision.sequence.filter((item) => item.locked).map((item) => item.track_id);
+    if (lockedIds.some((trackId) => !candidateIds.includes(trackId))) {
+      setStatus("Every locked track must remain inside the regeneration candidate pool.");
+      return;
+    }
+    busy = true;
+    setStatus("Computing bounded regeneration preview from current evidence…");
+    try {
+      const response = await originalInvoke("playlist_editor_regeneration_preview", {
+        revisionId: activeRevision.revision_id,
+        candidateTrackIds: candidateIds,
+      });
+      if (!validRegenerationPreview(response, activeRevision.revision_id, candidateIds)) {
+        throw new Error("Invalid regeneration preview response.");
+      }
+      regenerationPreview = response;
+      regenerationCandidateIds = [...candidateIds];
+      renderRegenerationResults(results);
+      setStatus(
+        response.alternatives.length > 0
+          ? "Regeneration preview ready. Choose one path to append as a new immutable revision."
+          : "No bounded regeneration path satisfies the current locks and evidence.",
+      );
+    } catch (_error) {
+      regenerationPreview = null;
+      regenerationCandidateIds = [];
+      results.replaceChildren();
+      setStatus("Regeneration preview was rejected safely.");
+    } finally {
+      busy = false;
+    }
+  }
+
+  function renderRegenerationResults(results) {
+    results.replaceChildren();
+    if (!regenerationPreview || !activeRevision) return;
+    const heading = document.createElement("h5");
+    heading.textContent = `Regeneration ${regenerationPreview.regeneration_id}`;
+    results.appendChild(heading);
+    for (const alternative of regenerationPreview.alternatives) {
+      const card = document.createElement("article");
+      card.className = "editor-proposal-choice";
+      const title = document.createElement("h5");
+      title.textContent = `Regenerated alternative ${alternative.rank}`;
+      const sequence = document.createElement("ol");
+      for (const step of alternative.sequence) {
+        const row = document.createElement("li");
+        row.textContent = `${step.display_name}${step.locked ? " · locked" : ""}`;
+        sequence.appendChild(row);
+      }
+      const apply = document.createElement("button");
+      apply.type = "button";
+      apply.textContent = "Apply as new revision";
+      apply.disabled = busy;
+      apply.addEventListener("click", () => applyRegeneration(alternative.path_id));
+      card.append(title, sequence, apply);
+      results.appendChild(card);
+    }
+  }
+
+  async function applyRegeneration(pathId) {
+    if (
+      busy ||
+      !activeRevision ||
+      !regenerationPreview ||
+      !validToken(pathId) ||
+      regenerationCandidateIds.length < 3
+    ) {
+      return;
+    }
+    busy = true;
+    setStatus("Replaying regeneration evidence and appending immutable child revision…");
+    try {
+      const revision = await tauriCore.invoke("playlist_editor_regeneration_apply", {
+        revisionId: activeRevision.revision_id,
+        candidateTrackIds: regenerationCandidateIds,
+        regenerationId: regenerationPreview.regeneration_id,
+        pathId,
+      });
+      if (!validRevision(revision) || revision.operation !== "regenerate") {
+        throw new Error("Invalid regenerated revision response.");
+      }
+    } catch (_error) {
+      regenerationPreview = null;
+      regenerationCandidateIds = [];
+      setStatus("Regeneration apply was rejected safely. Preview again from the current revision.");
+      try {
+        await refreshHistory();
+      } catch (_ignored) {
+        // Keep the last trusted view if authoritative history is temporarily unavailable.
+      }
+    } finally {
+      busy = false;
+      renderCurrentRevision();
+    }
   }
 
   async function moveTrack(from, to) {
@@ -453,6 +731,8 @@
       return;
     }
     busy = true;
+    regenerationPreview = null;
+    regenerationCandidateIds = [];
     setStatus("Appending governed playlist revision…");
     try {
       const revision = await originalInvoke(command, args);

--- a/desktop/host-proof/playlist-evidence-export.js
+++ b/desktop/host-proof/playlist-evidence-export.js
@@ -25,7 +25,7 @@
   }
 
   const TOKEN = /^[A-Za-z0-9][A-Za-z0-9_.:+-]{0,255}$/;
-  const OPERATIONS = new Set(["accept", "reorder", "lock", "replace"]);
+  const OPERATIONS = new Set(["accept", "reorder", "lock", "replace", "regenerate"]);
   let trustedHistory = null;
   let trustedPreview = null;
   let busy = false;

--- a/desktop/host-proof/playlist-export.js
+++ b/desktop/host-proof/playlist-export.js
@@ -25,7 +25,7 @@
   }
 
   const TOKEN = /^[A-Za-z0-9][A-Za-z0-9_.:+-]{0,255}$/;
-  const OPERATIONS = new Set(["accept", "reorder", "lock", "replace"]);
+  const OPERATIONS = new Set(["accept", "reorder", "lock", "replace", "regenerate"]);
   let trustedHistory = null;
   let trustedPreview = null;
   let busy = false;

--- a/desktop/host-proof/transition-inspector.js
+++ b/desktop/host-proof/transition-inspector.js
@@ -23,7 +23,7 @@
   }
 
   const TOKEN = /^[A-Za-z0-9][A-Za-z0-9_.:+-]{0,255}$/;
-  const OPERATIONS = new Set(["accept", "reorder", "lock", "replace"]);
+  const OPERATIONS = new Set(["accept", "reorder", "lock", "replace", "regenerate"]);
   let trustedHistory = null;
   let busy = false;
 

--- a/docs/bundles/BUNDLE_62_REGENERATION_AROUND_LOCKS_R1.md
+++ b/docs/bundles/BUNDLE_62_REGENERATION_AROUND_LOCKS_R1.md
@@ -1,0 +1,143 @@
+# Bundle 62 — Regeneration Around Locks R1
+
+Status: governed implementation slice
+Issue: #143
+Canonical dependency: `f5747ee01a413cecac208d7051dce21fee6958ad`
+
+## Purpose
+
+Bundle 62 closes the remaining R4 manual-editor gap: regenerate the unlocked part of one exact current immutable `PlaylistRevision` while preserving explicit DJ locks and appending a new immutable child revision.
+
+```text
+current PlaylistRevision
+  + explicit analyzed candidate pool
+  + persisted lock positions
+  -> bounded Set Intelligence preview
+  -> human path selection
+  -> exact deterministic replay
+  -> immutable child revision(operation=regenerate)
+```
+
+## R1 anchor boundary
+
+R1 deliberately requires playlist position `0` to be locked. The existing Set Intelligence runtime is seeded from one actual track, so this restriction avoids inventing a synthetic pre-set root or a second path-search authority.
+
+Additional locks are represented by the canonical `LockedPosition(position_index=...)` contract and remain hard constraints in the existing bounded optimizer.
+
+A later governed slice may consider unanchored first-position regeneration only if the Set Intelligence contract gains an explicit neutral-root model.
+
+## Authority model
+
+The renderer may choose only:
+
+- the exact current revision,
+- a bounded explicit candidate pool of 3–24 already analyzed tracks,
+- one renderer-safe preview path.
+
+The renderer may not submit pairwise transition scores, filesystem paths, MusicDNA payloads, MIR results, optimizer scores, or arbitrary output sequences.
+
+The sidecar reconstructs candidate MusicDNA from current persisted AnalysisEvidence/corrections, creates request-local `TransitionAssessment` objects, and calls the existing bounded Set Intelligence optimizer. These transient assessments are not persisted as canonical transition evidence.
+
+## Preview
+
+`/v1/playlist/editor/regeneration/preview` requires:
+
+- exact current `revision_id`,
+- unique candidate track IDs,
+- all persisted locked tracks present in the candidate pool,
+- position 0 locked.
+
+The deterministic identity binds:
+
+- parent revision ID,
+- parent content fingerprint,
+- sorted candidate pool,
+- exact locked positions,
+- regeneration policy version,
+- current analysis/correction revisions through the optimizer result identity.
+
+The renderer-safe response exposes only IDs, display labels, locks, bounded objective data, explanation/warning codes, and authority-false flags.
+
+## Apply
+
+`/v1/playlist/editor/regeneration/apply` additionally requires the expected `regeneration_id` and selected `path_id`.
+
+Apply reruns the full preview from the current persisted state. A changed revision, lock, candidate pool, analysis result, or active correction invalidates the prior identity/path and fails closed.
+
+Successful apply appends exactly one child `PlaylistRevision` with:
+
+- `operation = regenerate`,
+- parent revision lineage,
+- selected path/rank,
+- candidate-pool count + SHA-256,
+- exact locked-position provenance,
+- deterministic content fingerprint,
+- Personal DJ Model training = false,
+- production activation = false.
+
+No in-place playlist mutation exists.
+
+## Revision-ledger compatibility
+
+Bundle 57 originally constrained SQLite revision operations to `accept`, `reorder`, `lock`, and `replace`. Bundle 62 adds a bounded compatibility migration that rebuilds only the revision header table with `regenerate` added to the CHECK constraint, copies existing rows, restores append-only triggers/indexes, re-enables foreign keys, and executes `PRAGMA foreign_key_check`.
+
+Existing revision items and their immutable triggers remain unchanged.
+
+## Desktop boundary
+
+Dedicated Tauri commands:
+
+- `playlist_editor_regeneration_preview`
+- `playlist_editor_regeneration_apply`
+
+Dedicated capability:
+
+- `main-playlist-regeneration`
+
+The command surface has no filesystem, shell, HTTP, save-dialog, release, deployment, or provider capability. The sidecar remains authenticated by the packaged loopback secret/readiness-nonce lifecycle.
+
+The Manual Set Editor exposes the candidate pool explicitly. Current members start selected, locked tracks cannot be deselected, and additional successfully analyzed tracks may be added up to the bounded maximum.
+
+## Cross-feature continuity
+
+Regenerated immutable revisions remain valid inputs for:
+
+- revision history,
+- Selected Transition Inspection,
+- M3U8 export,
+- JSON evidence export,
+- vendor interoperability handoff.
+
+Those consumers accept `regenerate` as a revision-history operation while keeping their existing read/write authority boundaries.
+
+## Fail-closed conditions
+
+Examples include:
+
+- stale/non-current revision,
+- missing first-position lock,
+- locked track omitted from candidate pool,
+- duplicate/out-of-bounds candidate pool,
+- missing/failed/incomplete current analysis evidence,
+- invalid renderer projection,
+- replay identity mismatch,
+- selected path no longer present,
+- no-op regeneration,
+- malformed or authority-escalating sidecar response.
+
+## Explicit non-scope
+
+- moving locked positions,
+- segment-level/strategy lock editing,
+- unanchored position-0 regeneration,
+- persisting transient regenerated transition assessments as canonical evidence,
+- audio read/hash,
+- MIR/provider execution,
+- Human DJ Review execution,
+- Personal DJ Model training,
+- production activation,
+- release/deploy/signing/notarization.
+
+## Next dependency
+
+After Bundle 62 is merged and independently green, R4 can proceed to the already-prepared **Human DJ Review execution** and aggregation/governance decision. That boundary requires separate authorization and is not implied by this bundle.

--- a/services/desktop/playlist_editor_sidecar.py
+++ b/services/desktop/playlist_editor_sidecar.py
@@ -7,22 +7,50 @@ from services.desktop.playlist_editor_transport import (
     DesktopPlaylistEditorTransport,
     DesktopPlaylistEditorTransportError,
 )
+from services.desktop.playlist_regeneration_service import (
+    DesktopPlaylistRegenerationService,
+    DesktopPlaylistRegenerationServiceError,
+)
 
 MAX_PLAYLIST_EDITOR_REQUEST_BYTES = 64 * 1024
 _INSTALLED = False
 
 _ROUTES = {
     "/v1/playlist/editor/accept": (
+        "playlist_editor",
         "accept",
         {"track_ids", "seed_track_id", "target_track_count", "proposal_id", "path_id"},
     ),
-    "/v1/playlist/editor/reorder": ("reorder", {"revision_id", "ordered_track_ids"}),
-    "/v1/playlist/editor/lock": ("lock", {"revision_id", "locked_track_ids"}),
+    "/v1/playlist/editor/reorder": (
+        "playlist_editor",
+        "reorder",
+        {"revision_id", "ordered_track_ids"},
+    ),
+    "/v1/playlist/editor/lock": (
+        "playlist_editor",
+        "lock",
+        {"revision_id", "locked_track_ids"},
+    ),
     "/v1/playlist/editor/replace": (
+        "playlist_editor",
         "replace",
         {"revision_id", "source_track_id", "replacement_track_id"},
     ),
-    "/v1/playlist/editor/history": ("history", {"playlist_id"}),
+    "/v1/playlist/editor/history": (
+        "playlist_editor",
+        "history",
+        {"playlist_id"},
+    ),
+    "/v1/playlist/editor/regeneration/preview": (
+        "playlist_regeneration",
+        "preview",
+        {"revision_id", "candidate_track_ids"},
+    ),
+    "/v1/playlist/editor/regeneration/apply": (
+        "playlist_regeneration",
+        "apply",
+        {"revision_id", "candidate_track_ids", "regeneration_id", "path_id"},
+    ),
 }
 
 _CONFLICT_CODES = {
@@ -38,6 +66,11 @@ _CONFLICT_CODES = {
     "playlist_replacement_analysis_missing",
     "playlist_replacement_analysis_failed",
     "playlist_replacement_analysis_incomplete",
+    "playlist_regeneration_anchor_required",
+    "playlist_regeneration_locked_track_missing",
+    "playlist_regeneration_evidence_unavailable",
+    "playlist_regeneration_projection_failed",
+    "playlist_regeneration_stale",
 }
 
 
@@ -56,9 +89,14 @@ def install_playlist_editor_sidecar() -> None:
             if route is None:
                 super().do_POST()
                 return
-            self._handle_playlist_editor(route[0], route[1])
+            self._handle_playlist_editor(route[0], route[1], route[2])
 
-        def _handle_playlist_editor(self, operation: str, expected_keys: set[str]) -> None:
+        def _handle_playlist_editor(
+            self,
+            service_name: str,
+            operation: str,
+            expected_keys: set[str],
+        ) -> None:
             if not self._authorized():
                 self._write_json(HTTPStatus.UNAUTHORIZED, {"error": "unauthorized"})
                 return
@@ -70,9 +108,10 @@ def install_playlist_editor_sidecar() -> None:
                 )
                 return
             try:
-                method = getattr(self.sidecar_server.playlist_editor, operation)
+                service = getattr(self.sidecar_server, service_name)
+                method = getattr(service, operation)
                 result = method(**payload)
-            except DesktopPlaylistEditorTransportError as exc:
+            except (DesktopPlaylistEditorTransportError, DesktopPlaylistRegenerationServiceError) as exc:
                 status = (
                     HTTPStatus.CONFLICT if exc.code in _CONFLICT_CODES else HTTPStatus.BAD_REQUEST
                 )
@@ -94,6 +133,7 @@ def install_playlist_editor_sidecar() -> None:
             self.playlist_editor = DesktopPlaylistEditorTransport(
                 proposal_transport=self.set_proposal,
             )
+            self.playlist_regeneration = DesktopPlaylistRegenerationService()
 
     sidecar._SidecarHTTPServer = PlaylistEditorHTTPServer
     _INSTALLED = True

--- a/services/desktop/playlist_regeneration_service.py
+++ b/services/desktop/playlist_regeneration_service.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import hashlib
+import json
 from collections.abc import Sequence
 
+from data.repositories.analysis_evidence_repository import AnalysisEvidenceRepository
 from data.repositories.playlist_revision_repository import (
     PlaylistRevisionRepository,
     PlaylistRevisionRepositoryError,
@@ -27,9 +30,11 @@ class DesktopPlaylistRegenerationService:
         *,
         generator: DesktopPlaylistRegenerationTransport | None = None,
         revision_repository: PlaylistRevisionRepository | None = None,
+        evidence_repository: AnalysisEvidenceRepository | None = None,
     ) -> None:
         self._generator = generator or DesktopPlaylistRegenerationTransport()
         self._revisions = revision_repository or PlaylistRevisionRepository()
+        self._evidence = evidence_repository or AnalysisEvidenceRepository()
 
     def preview(
         self,
@@ -39,12 +44,13 @@ class DesktopPlaylistRegenerationService:
     ) -> dict[str, object]:
         parent = self._required_current(revision_id)
         try:
-            return self._generator.generate(
+            preview = self._generator.generate(
                 parent_revision=parent,
                 candidate_track_ids=candidate_track_ids,
             )
         except DesktopPlaylistRegenerationTransportError as exc:
             raise DesktopPlaylistRegenerationServiceError(exc.code, exc.message) from exc
+        return self._bind_evidence_identity(preview, candidate_track_ids)
 
     def apply(
         self,
@@ -62,6 +68,7 @@ class DesktopPlaylistRegenerationService:
                 parent_revision=parent,
                 candidate_track_ids=candidate_track_ids,
             )
+            preview = self._bind_evidence_identity(preview, candidate_track_ids)
         except DesktopPlaylistRegenerationTransportError as exc:
             raise DesktopPlaylistRegenerationServiceError(
                 "playlist_regeneration_stale",
@@ -154,6 +161,49 @@ class DesktopPlaylistRegenerationService:
         except PlaylistRevisionRepositoryError as exc:
             raise self._repository_error(exc) from exc
         return self._revision_dto(revision)
+
+    def _bind_evidence_identity(
+        self,
+        preview: dict[str, object],
+        candidate_track_ids: Sequence[str],
+    ) -> dict[str, object]:
+        base_regeneration_id = preview.get("regeneration_id")
+        if not isinstance(base_regeneration_id, str):
+            raise DesktopPlaylistRegenerationServiceError(
+                "playlist_regeneration_stale",
+                "The regeneration preview identity is unavailable.",
+            )
+        evidence_state: list[dict[str, object]] = []
+        for raw_track_id in candidate_track_ids:
+            track_id = self._token(raw_track_id, "track_id")
+            attempt = self._evidence.latest_evidence_for_track(track_id)
+            success = self._evidence.latest_success_for_track(track_id)
+            correction = (
+                None
+                if success is None
+                else self._evidence.latest_active_correction(track_id, success.evidence_id)
+            )
+            evidence_state.append(
+                {
+                    "track_id": track_id,
+                    "latest_attempt_id": None if attempt is None else attempt.evidence_id,
+                    "latest_attempt_status": None if attempt is None else attempt.status,
+                    "latest_success_id": None if success is None else success.evidence_id,
+                    "active_correction_id": (
+                        None if correction is None else correction.correction_id
+                    ),
+                }
+            )
+        material = {
+            "base_regeneration_id": base_regeneration_id,
+            "candidate_evidence_state": evidence_state,
+        }
+        digest = hashlib.sha256(
+            json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        bound = dict(preview)
+        bound["regeneration_id"] = f"rgn_{digest[:32]}"
+        return bound
 
     def _required_current(self, revision_id: str) -> dict[str, object]:
         normalized = self._token(revision_id, "revision_id")

--- a/services/desktop/playlist_regeneration_service.py
+++ b/services/desktop/playlist_regeneration_service.py
@@ -174,7 +174,7 @@ class DesktopPlaylistRegenerationService:
                 "The regeneration preview identity is unavailable.",
             )
         evidence_state: list[dict[str, object]] = []
-        for raw_track_id in candidate_track_ids:
+        for raw_track_id in sorted(candidate_track_ids):
             track_id = self._token(raw_track_id, "track_id")
             attempt = self._evidence.latest_evidence_for_track(track_id)
             success = self._evidence.latest_success_for_track(track_id)

--- a/services/desktop/playlist_regeneration_service.py
+++ b/services/desktop/playlist_regeneration_service.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from data.repositories.playlist_revision_repository import (
+    PlaylistRevisionRepository,
+    PlaylistRevisionRepositoryError,
+)
+from services.desktop.playlist_regeneration_transport import (
+    DesktopPlaylistRegenerationTransport,
+    DesktopPlaylistRegenerationTransportError,
+)
+
+
+class DesktopPlaylistRegenerationServiceError(ValueError):
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+class DesktopPlaylistRegenerationService:
+    """Governed preview/apply boundary for Bundle 62 regeneration around locks."""
+
+    def __init__(
+        self,
+        *,
+        generator: DesktopPlaylistRegenerationTransport | None = None,
+        revision_repository: PlaylistRevisionRepository | None = None,
+    ) -> None:
+        self._generator = generator or DesktopPlaylistRegenerationTransport()
+        self._revisions = revision_repository or PlaylistRevisionRepository()
+
+    def preview(
+        self,
+        *,
+        revision_id: str,
+        candidate_track_ids: Sequence[str],
+    ) -> dict[str, object]:
+        parent = self._required_current(revision_id)
+        try:
+            return self._generator.generate(
+                parent_revision=parent,
+                candidate_track_ids=candidate_track_ids,
+            )
+        except DesktopPlaylistRegenerationTransportError as exc:
+            raise DesktopPlaylistRegenerationServiceError(exc.code, exc.message) from exc
+
+    def apply(
+        self,
+        *,
+        revision_id: str,
+        candidate_track_ids: Sequence[str],
+        regeneration_id: str,
+        path_id: str,
+    ) -> dict[str, object]:
+        parent = self._required_current(revision_id)
+        expected_regeneration = self._token(regeneration_id, "regeneration_id")
+        expected_path = self._token(path_id, "path_id")
+        try:
+            preview = self._generator.generate(
+                parent_revision=parent,
+                candidate_track_ids=candidate_track_ids,
+            )
+        except DesktopPlaylistRegenerationTransportError as exc:
+            raise DesktopPlaylistRegenerationServiceError(
+                "playlist_regeneration_stale",
+                "The regeneration preview can no longer be reproduced from current evidence.",
+            ) from exc
+        if preview.get("regeneration_id") != expected_regeneration:
+            raise DesktopPlaylistRegenerationServiceError(
+                "playlist_regeneration_stale",
+                "The regeneration identity no longer matches current evidence or locks.",
+            )
+        alternatives = preview.get("alternatives")
+        if not isinstance(alternatives, list):
+            raise DesktopPlaylistRegenerationServiceError(
+                "playlist_regeneration_stale",
+                "The regeneration alternatives are unavailable.",
+            )
+        selected = next(
+            (
+                item
+                for item in alternatives
+                if isinstance(item, dict) and item.get("path_id") == expected_path
+            ),
+            None,
+        )
+        if selected is None:
+            raise DesktopPlaylistRegenerationServiceError(
+                "playlist_regeneration_stale",
+                "The selected regeneration path no longer exists.",
+            )
+        sequence = selected.get("sequence")
+        rank = selected.get("rank")
+        if not isinstance(sequence, list) or not isinstance(rank, int):
+            raise DesktopPlaylistRegenerationServiceError(
+                "playlist_regeneration_stale",
+                "The selected regeneration path is invalid.",
+            )
+        items: list[tuple[str, str, bool]] = []
+        for index, step in enumerate(sequence):
+            if not isinstance(step, dict):
+                raise DesktopPlaylistRegenerationServiceError(
+                    "playlist_regeneration_stale",
+                    "The selected regeneration path is invalid.",
+                )
+            track_id = step.get("track_id")
+            display_name = step.get("display_name")
+            locked = step.get("locked")
+            if (
+                step.get("order_index") != index
+                or not isinstance(track_id, str)
+                or not isinstance(display_name, str)
+                or not isinstance(locked, bool)
+            ):
+                raise DesktopPlaylistRegenerationServiceError(
+                    "playlist_regeneration_stale",
+                    "The selected regeneration path is invalid.",
+                )
+            items.append((track_id, display_name, locked))
+
+        parent_items = parent.get("items")
+        if not isinstance(parent_items, tuple):
+            raise DesktopPlaylistRegenerationServiceError(
+                "playlist_regeneration_stale",
+                "The current playlist revision is invalid.",
+            )
+        parent_signature = tuple(
+            (str(item["track_id"]), str(item["display_name"]), bool(item["locked"]))
+            for item in parent_items
+        )
+        if tuple(items) == parent_signature:
+            raise DesktopPlaylistRegenerationServiceError(
+                "playlist_revision_noop",
+                "Regeneration must change at least one unlocked playlist position.",
+            )
+
+        metadata = {
+            "regeneration_id": expected_regeneration,
+            "path_id": expected_path,
+            "selected_rank": rank,
+            "candidate_pool_count": int(preview["candidate_pool_count"]),
+            "candidate_pool_sha256": str(preview["candidate_pool_sha256"]),
+            "locked_positions": list(preview["locked_positions"]),
+        }
+        try:
+            revision = self._revisions.append_child(
+                parent_revision_id=str(parent["revision_id"]),
+                operation="regenerate",
+                items=tuple(items),
+                operation_metadata=metadata,
+            )
+        except PlaylistRevisionRepositoryError as exc:
+            raise self._repository_error(exc) from exc
+        return self._revision_dto(revision)
+
+    def _required_current(self, revision_id: str) -> dict[str, object]:
+        normalized = self._token(revision_id, "revision_id")
+        try:
+            parent = self._revisions.get_revision(normalized)
+        except PlaylistRevisionRepositoryError as exc:
+            raise self._repository_error(exc) from exc
+        if parent is None:
+            raise DesktopPlaylistRegenerationServiceError(
+                "playlist_revision_not_found",
+                "The playlist revision does not exist.",
+            )
+        current = self._revisions.current_revision(str(parent["playlist_id"]))
+        if current is None or str(current["revision_id"]) != str(parent["revision_id"]):
+            raise DesktopPlaylistRegenerationServiceError(
+                "playlist_revision_stale",
+                "The requested playlist revision is not current.",
+            )
+        return parent
+
+    @staticmethod
+    def _revision_dto(record: dict[str, object]) -> dict[str, object]:
+        return {
+            "schema": "applaylist-desktop-playlist-revision-r1",
+            "playlist_id": str(record["playlist_id"]),
+            "revision_id": str(record["revision_id"]),
+            "parent_revision_id": record["parent_revision_id"],
+            "revision_index": int(record["revision_index"]),
+            "source_proposal_id": str(record["source_proposal_id"]),
+            "source_path_id": str(record["source_path_id"]),
+            "operation": str(record["operation"]),
+            "content_fingerprint": str(record["content_fingerprint"]),
+            "created_at": str(record["created_at"]),
+            "sequence": [
+                {
+                    "order_index": int(item["order_index"]),
+                    "track_id": str(item["track_id"]),
+                    "display_name": str(item["display_name"]),
+                    "locked": bool(item["locked"]),
+                }
+                for item in record["items"]
+            ],
+            "personal_dj_model_training_authorized": False,
+            "production_activation_authorized": False,
+        }
+
+    @staticmethod
+    def _repository_error(
+        exc: PlaylistRevisionRepositoryError,
+    ) -> DesktopPlaylistRegenerationServiceError:
+        return DesktopPlaylistRegenerationServiceError(exc.code, exc.message)
+
+    @staticmethod
+    def _token(value: str, field: str) -> str:
+        if not isinstance(value, str):
+            raise DesktopPlaylistRegenerationServiceError(
+                "invalid_playlist_regeneration_request",
+                f"{field} must be text.",
+            )
+        normalized = value.strip()
+        if (
+            not normalized
+            or normalized != value
+            or len(normalized) > 256
+            or "/" in normalized
+            or "\\" in normalized
+            or any(character.isspace() or ord(character) < 32 for character in normalized)
+        ):
+            raise DesktopPlaylistRegenerationServiceError(
+                "invalid_playlist_regeneration_request",
+                f"{field} is invalid.",
+            )
+        return normalized
+
+
+__all__ = [
+    "DesktopPlaylistRegenerationService",
+    "DesktopPlaylistRegenerationServiceError",
+]

--- a/services/desktop/playlist_regeneration_transport.py
+++ b/services/desktop/playlist_regeneration_transport.py
@@ -1,0 +1,465 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Sequence
+
+from core.intelligence.set_contract import (
+    EligibleLibraryScope,
+    EnergyControlPoint,
+    EnergyTrajectory,
+    LockedPosition,
+    PlaylistContext,
+    PlaylistIntent,
+    SequenceState,
+    SetGoal,
+    SetPhase,
+    SetPhaseType,
+    SetStep,
+)
+from core.intelligence.set_optimizer_contract import SetOptimizerPolicy
+from core.intelligence.transition_contract import TransitionAssessment
+from services.desktop.set_proposal_projection import project_set_optimizer_result
+from services.desktop.set_proposal_transport import (
+    DesktopSetProposalTransport,
+    DesktopSetProposalTransportError,
+)
+from services.intelligence.phase_context import transition_context_for_phase
+from services.intelligence.set_engine import balanced_set_ranking_policy_v1
+from services.intelligence.set_path_optimizer import optimize_set_lookahead
+from services.intelligence.transition_engine import assess_transition, preserve_groove_context_v1
+
+PLAYLIST_REGENERATION_SCHEMA = "applaylist-desktop-playlist-regeneration-r1"
+PLAYLIST_REGENERATION_POLICY_VERSION = "desktop-playlist-regeneration-r1"
+PLAYLIST_REGENERATION_PHASE_ID = "phase:regeneration-groove"
+PLAYLIST_REGENERATION_GENERATED_AT = "desktop-playlist-regeneration-r1"
+
+
+class DesktopPlaylistRegenerationTransportError(ValueError):
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+class _TransientTransitionRepository:
+    """Request-local adjacency used only by bounded regeneration preview."""
+
+    def __init__(self, assessments: Sequence[TransitionAssessment]) -> None:
+        self._assessments = tuple(assessments)
+
+    def list_outgoing(
+        self,
+        *,
+        source_track_id: str,
+        source_segment_id: str,
+        context_id: str | None = None,
+        context_version: str | None = None,
+        assessment_version: str | None = None,
+        policy_version: str | None = None,
+    ) -> tuple[TransitionAssessment, ...]:
+        if (context_id is None) != (context_version is None):
+            raise ValueError("context_id and context_version must be supplied together")
+        matches = [
+            item
+            for item in self._assessments
+            if item.identity.source_track_id == source_track_id
+            and item.identity.source_segment_id == source_segment_id
+            and (context_id is None or item.contextual_projection.context_id == context_id)
+            and (
+                context_version is None
+                or item.contextual_projection.context_version == context_version
+            )
+            and (
+                assessment_version is None
+                or item.identity.assessment_version == assessment_version
+            )
+            and (policy_version is None or item.identity.policy_version == policy_version)
+        ]
+        return tuple(
+            sorted(
+                matches,
+                key=lambda item: (
+                    item.identity.transition_id,
+                    item.identity.target_track_id,
+                    item.identity.target_segment_id,
+                ),
+            )
+        )
+
+
+class DesktopPlaylistRegenerationTransport(DesktopSetProposalTransport):
+    """Deterministic bounded regeneration around immutable playlist locks.
+
+    R1 deliberately requires position zero to be locked so the existing seeded Set
+    Intelligence optimizer remains the only path-search authority. Transition
+    assessments are rebuilt request-locally from persisted analysis evidence exactly
+    like the desktop set proposal preview and are never persisted by this transport.
+    """
+
+    def generate(
+        self,
+        *,
+        parent_revision: dict[str, object],
+        candidate_track_ids: Sequence[str],
+    ) -> dict[str, object]:
+        parent_id, playlist_id, parent_fingerprint, parent_items = self._parent(parent_revision)
+        locked = tuple(
+            (index, str(item["track_id"]))
+            for index, item in enumerate(parent_items)
+            if bool(item["locked"])
+        )
+        if not locked or locked[0][0] != 0:
+            raise DesktopPlaylistRegenerationTransportError(
+                "playlist_regeneration_anchor_required",
+                "Regeneration R1 requires the first playlist position to be locked.",
+            )
+
+        try:
+            scope = self._validated_track_ids(candidate_track_ids)
+            target = self._validated_target_track_count(len(parent_items), len(scope))
+        except DesktopSetProposalTransportError as exc:
+            raise DesktopPlaylistRegenerationTransportError(
+                "invalid_playlist_regeneration_request",
+                "The regeneration candidate pool is invalid.",
+            ) from exc
+
+        locked_ids = tuple(track_id for _, track_id in locked)
+        if any(track_id not in scope for track_id in locked_ids):
+            raise DesktopPlaylistRegenerationTransportError(
+                "playlist_regeneration_locked_track_missing",
+                "The candidate pool must include every locked playlist track.",
+            )
+
+        seed = str(parent_items[0]["track_id"])
+        revisions = {}
+        durations: dict[str, float] = {}
+        labels: dict[str, str] = {}
+        for track_id in scope:
+            try:
+                revision, duration, label = self._revision_for_track(track_id)
+            except DesktopSetProposalTransportError as exc:
+                raise DesktopPlaylistRegenerationTransportError(
+                    "playlist_regeneration_evidence_unavailable",
+                    "A candidate track cannot be regenerated from current analysis evidence.",
+                ) from exc
+            revisions[track_id] = revision
+            durations[track_id] = duration
+            labels[track_id] = label
+
+        request_fingerprint = self._request_fingerprint_r1(
+            parent_revision_id=parent_id,
+            parent_content_fingerprint=parent_fingerprint,
+            scope=scope,
+            locked=locked,
+        )
+        phase = SetPhase(
+            phase_id=PLAYLIST_REGENERATION_PHASE_ID,
+            phase_type=SetPhaseType.GROOVE,
+            ordinal=0,
+            target_fraction_start=0.0,
+            target_fraction_end=1.0,
+            explanation_label="Governed regeneration around immutable locks",
+        )
+        seed_revision = revisions[seed]
+        seed_energy = seed_revision.energy.baseline_energy
+        if seed_energy is None:
+            raise DesktopPlaylistRegenerationTransportError(
+                "playlist_regeneration_evidence_unavailable",
+                "The locked seed track is missing required energy evidence.",
+            )
+        trajectory = EnergyTrajectory(
+            trajectory_id=f"trajectory:{request_fingerprint[:24]}",
+            trajectory_version=PLAYLIST_REGENERATION_POLICY_VERSION,
+            control_points=(
+                EnergyControlPoint(
+                    normalized_set_position=0.0,
+                    target_energy=seed_energy,
+                    tolerance=0.35,
+                    phase_id=PLAYLIST_REGENERATION_PHASE_ID,
+                ),
+                EnergyControlPoint(
+                    normalized_set_position=1.0,
+                    target_energy=seed_energy,
+                    tolerance=0.35,
+                    phase_id=PLAYLIST_REGENERATION_PHASE_ID,
+                ),
+            ),
+        )
+        lock_contract = tuple(
+            LockedPosition(
+                track_id=track_id,
+                lock_version=f"revision:{parent_id}",
+                position_index=index,
+            )
+            for index, track_id in locked
+        )
+        intent = PlaylistIntent(
+            intent_id=f"intent:{request_fingerprint[:24]}",
+            intent_version=PLAYLIST_REGENERATION_POLICY_VERSION,
+            goal=SetGoal.CLUB_FLOW,
+            eligible_library_scope=EligibleLibraryScope(
+                scope_revision=f"scope:{request_fingerprint[:24]}",
+                explicit_track_ids=scope,
+            ),
+            phase_plan=(phase,),
+            energy_trajectory=trajectory,
+            target_track_count=target,
+            required_track_ids=locked_ids,
+            locked_positions=lock_contract,
+            allow_track_repeats=False,
+            reject_critical_warnings=True,
+        )
+
+        seed_segment = seed_revision.segments[0]
+        root_step = SetStep(
+            order_index=0,
+            track_id=seed,
+            segment_id=seed_segment.segment_id,
+            phase_id=PLAYLIST_REGENERATION_PHASE_ID,
+            evidence_refs=seed_revision.identity.evidence_refs,
+        )
+        root_state = SequenceState(
+            state_id=f"state:{request_fingerprint[:24]}",
+            state_version=PLAYLIST_REGENERATION_POLICY_VERSION,
+            selected_steps=(root_step,),
+            current_track_id=seed,
+            current_segment_id=seed_segment.segment_id,
+            used_track_ids=(seed,),
+            cumulative_duration_seconds=durations[seed],
+            current_energy_state=seed_energy,
+            satisfied_required_track_ids=(seed,),
+            remaining_required_track_ids=tuple(item for item in locked_ids if item != seed),
+            evidence_refs=seed_revision.identity.evidence_refs,
+        )
+        root_context = PlaylistContext(
+            context_id=f"context:{request_fingerprint[:24]}",
+            context_version=PLAYLIST_REGENERATION_POLICY_VERSION,
+            current_phase_id=PLAYLIST_REGENERATION_PHASE_ID,
+            current_position_index=0,
+            elapsed_duration_seconds=durations[seed],
+            phase_progress=min(1.0, 1.0 / target),
+            current_track_id=seed,
+            current_segment_id=seed_segment.segment_id,
+            current_energy_state=seed_energy,
+            remaining_track_count=max(0, target - 1),
+            context_evidence_refs=seed_revision.identity.evidence_refs,
+        )
+
+        base_transition_context = preserve_groove_context_v1()
+        phase_transition_context = transition_context_for_phase(
+            phase=phase,
+            base_context=base_transition_context,
+        )
+        assessments: list[TransitionAssessment] = []
+        for source_id in scope:
+            source = revisions[source_id]
+            source_segment = source.segments[0]
+            for target_id in scope:
+                if target_id == source_id:
+                    continue
+                target_revision = revisions[target_id]
+                target_segment = target_revision.segments[0]
+                assessments.append(
+                    assess_transition(
+                        source=source,
+                        source_segment_id=source_segment.segment_id,
+                        target=target_revision,
+                        target_segment_id=target_segment.segment_id,
+                        context=phase_transition_context,
+                        created_at=PLAYLIST_REGENERATION_GENERATED_AT,
+                    )
+                )
+
+        repository = _TransientTransitionRepository(assessments)
+        optimizer_policy = SetOptimizerPolicy(
+            beam_width=8,
+            max_depth=target - 1,
+            per_state_candidate_limit=min(16, len(scope) - 1),
+            max_expanded_candidates=2_048,
+            alternative_limit=3,
+        )
+        result = optimize_set_lookahead(
+            repository=repository,  # type: ignore[arg-type]
+            intent=intent,
+            root_context=root_context,
+            root_state=root_state,
+            base_transition_context=base_transition_context,
+            ranking_policy=balanced_set_ranking_policy_v1(),
+            optimizer_policy=optimizer_policy,
+            target_duration_seconds_by_track=durations,
+            generated_at=PLAYLIST_REGENERATION_GENERATED_AT,
+            style_tags_by_track=None,
+            critical_warnings_by_track={track_id: () for track_id in scope},
+        )
+        try:
+            projected = project_set_optimizer_result(
+                result=self._renderer_safe_result(result),
+                display_name_by_track_id=labels,
+            )
+        except (DesktopSetProposalTransportError, ValueError) as exc:
+            raise DesktopPlaylistRegenerationTransportError(
+                "playlist_regeneration_projection_failed",
+                "The regeneration result could not be projected safely.",
+            ) from exc
+
+        alternatives = self._alternatives(
+            projected=projected,
+            parent_items=parent_items,
+            locked=locked,
+        )
+        candidate_pool_sha256 = hashlib.sha256("\n".join(scope).encode("utf-8")).hexdigest()
+        return {
+            "schema": PLAYLIST_REGENERATION_SCHEMA,
+            "playlist_id": playlist_id,
+            "parent_revision_id": parent_id,
+            "regeneration_id": str(projected["proposal_id"]),
+            "candidate_pool_count": len(scope),
+            "candidate_pool_sha256": candidate_pool_sha256,
+            "locked_positions": [
+                {"order_index": index, "track_id": track_id}
+                for index, track_id in locked
+            ],
+            "alternatives": alternatives,
+            "reason_codes": list(projected["reason_codes"]),
+            "warning_codes": list(projected["warning_codes"]),
+            "budget_exhausted": bool(projected["budget_exhausted"]),
+            "missing_evidence_detected": bool(projected["missing_evidence_detected"]),
+            "deterministic_ordering": bool(projected["deterministic_ordering"]),
+            "playlist_mutation_authorized": False,
+            "personal_dj_model_training_authorized": False,
+            "production_activation_authorized": False,
+        }
+
+    @staticmethod
+    def _parent(
+        parent_revision: dict[str, object],
+    ) -> tuple[str, str, str, tuple[dict[str, object], ...]]:
+        if not isinstance(parent_revision, dict):
+            raise DesktopPlaylistRegenerationTransportError(
+                "invalid_playlist_regeneration_request",
+                "The parent revision is invalid.",
+            )
+        parent_id = parent_revision.get("revision_id")
+        playlist_id = parent_revision.get("playlist_id")
+        fingerprint = parent_revision.get("content_fingerprint")
+        items = parent_revision.get("items")
+        if (
+            not isinstance(parent_id, str)
+            or not isinstance(playlist_id, str)
+            or not isinstance(fingerprint, str)
+            or len(fingerprint) != 64
+            or not isinstance(items, tuple)
+            or not 3 <= len(items) <= 8
+            or any(not isinstance(item, dict) for item in items)
+        ):
+            raise DesktopPlaylistRegenerationTransportError(
+                "invalid_playlist_regeneration_request",
+                "The parent revision is invalid.",
+            )
+        normalized: list[dict[str, object]] = []
+        for index, item in enumerate(items):
+            if (
+                item.get("order_index") != index
+                or not isinstance(item.get("track_id"), str)
+                or not isinstance(item.get("display_name"), str)
+                or not isinstance(item.get("locked"), bool)
+            ):
+                raise DesktopPlaylistRegenerationTransportError(
+                    "invalid_playlist_regeneration_request",
+                    "The parent revision sequence is invalid.",
+                )
+            normalized.append(item)
+        return parent_id, playlist_id, fingerprint, tuple(normalized)
+
+    @staticmethod
+    def _request_fingerprint_r1(
+        *,
+        parent_revision_id: str,
+        parent_content_fingerprint: str,
+        scope: tuple[str, ...],
+        locked: tuple[tuple[int, str], ...],
+    ) -> str:
+        material = {
+            "parent_revision_id": parent_revision_id,
+            "parent_content_fingerprint": parent_content_fingerprint,
+            "candidate_track_ids": scope,
+            "locked_positions": locked,
+            "policy_version": PLAYLIST_REGENERATION_POLICY_VERSION,
+        }
+        encoded = json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    @staticmethod
+    def _alternatives(
+        *,
+        projected: dict[str, object],
+        parent_items: tuple[dict[str, object], ...],
+        locked: tuple[tuple[int, str], ...],
+    ) -> list[dict[str, object]]:
+        raw = projected.get("alternatives")
+        if not isinstance(raw, list):
+            raise DesktopPlaylistRegenerationTransportError(
+                "playlist_regeneration_projection_failed",
+                "The regeneration alternatives are invalid.",
+            )
+        locked_by_position = dict(locked)
+        alternatives: list[dict[str, object]] = []
+        for alternative in raw:
+            if not isinstance(alternative, dict):
+                raise DesktopPlaylistRegenerationTransportError(
+                    "playlist_regeneration_projection_failed",
+                    "The regeneration alternatives are invalid.",
+                )
+            sequence = alternative.get("sequence")
+            if not isinstance(sequence, list) or len(sequence) != len(parent_items):
+                raise DesktopPlaylistRegenerationTransportError(
+                    "playlist_regeneration_projection_failed",
+                    "A regeneration path has the wrong length.",
+                )
+            safe_sequence: list[dict[str, object]] = []
+            for index, step in enumerate(sequence):
+                if not isinstance(step, dict):
+                    raise DesktopPlaylistRegenerationTransportError(
+                        "playlist_regeneration_projection_failed",
+                        "A regeneration path is invalid.",
+                    )
+                track_id = step.get("track_id")
+                display_name = step.get("display_name")
+                if not isinstance(track_id, str) or not isinstance(display_name, str):
+                    raise DesktopPlaylistRegenerationTransportError(
+                        "playlist_regeneration_projection_failed",
+                        "A regeneration path is invalid.",
+                    )
+                expected_locked = locked_by_position.get(index)
+                if expected_locked is not None and track_id != expected_locked:
+                    raise DesktopPlaylistRegenerationTransportError(
+                        "playlist_regeneration_projection_failed",
+                        "A regeneration path violates an immutable lock.",
+                    )
+                safe_sequence.append(
+                    {
+                        "order_index": index,
+                        "track_id": track_id,
+                        "display_name": display_name,
+                        "locked": expected_locked is not None,
+                    }
+                )
+            alternatives.append(
+                {
+                    "path_id": alternative["path_id"],
+                    "rank": alternative["rank"],
+                    "sequence": safe_sequence,
+                    "objective": alternative["objective"],
+                    "explanation_codes": alternative["explanation_codes"],
+                }
+            )
+        return alternatives
+
+
+__all__ = [
+    "DesktopPlaylistRegenerationTransport",
+    "DesktopPlaylistRegenerationTransportError",
+    "PLAYLIST_REGENERATION_POLICY_VERSION",
+    "PLAYLIST_REGENERATION_SCHEMA",
+]

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -18,6 +18,8 @@ fn main() {
             "playlist_editor_lock",
             "playlist_editor_replace",
             "playlist_editor_history",
+            "playlist_editor_regeneration_preview",
+            "playlist_editor_regeneration_apply",
             "playlist_export_preview",
             "playlist_export_m3u8",
             "playlist_evidence_preview",

--- a/src-tauri/capabilities/main-playlist-regeneration.json
+++ b/src-tauri/capabilities/main-playlist-regeneration.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "main-playlist-regeneration",
+  "description": "Allow the local main window to preview and explicitly apply governed regeneration around immutable playlist locks.",
+  "local": true,
+  "windows": [
+    "main"
+  ],
+  "platforms": [
+    "macOS"
+  ],
+  "permissions": [
+    "core:default",
+    "allow-playlist-editor-regeneration-preview",
+    "allow-playlist-editor-regeneration-apply"
+  ]
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod library_capability;
 mod playlist_editor;
 mod playlist_evidence_export;
 mod playlist_export;
+mod playlist_regeneration;
 mod playlist_vendor_interop;
 mod set_proposal;
 mod sidecar_bridge;
@@ -17,6 +18,7 @@ use library_capability::LibraryCapabilityRegistry;
 use playlist_editor::PlaylistEditorBridge;
 use playlist_evidence_export::PlaylistEvidenceExportBridge;
 use playlist_export::PlaylistExportBridge;
+use playlist_regeneration::PlaylistRegenerationBridge;
 use playlist_vendor_interop::PlaylistVendorInteropBridge;
 use set_proposal::SetProposalBridge;
 use sidecar_bridge::SidecarBridge;
@@ -33,6 +35,7 @@ pub fn run() {
         .manage(AnalysisSidecarBridge::from_environment())
         .manage(SetProposalBridge::from_environment())
         .manage(PlaylistEditorBridge::from_environment())
+        .manage(PlaylistRegenerationBridge::from_environment())
         .manage(PlaylistExportBridge::from_environment())
         .manage(PlaylistEvidenceExportBridge::from_environment())
         .manage(PlaylistVendorInteropBridge::from_environment())
@@ -55,6 +58,8 @@ pub fn run() {
             playlist_editor::playlist_editor_lock,
             playlist_editor::playlist_editor_replace,
             playlist_editor::playlist_editor_history,
+            playlist_regeneration::playlist_editor_regeneration_preview,
+            playlist_regeneration::playlist_editor_regeneration_apply,
             playlist_export::playlist_export_preview,
             playlist_export::playlist_export_m3u8,
             playlist_evidence_export::playlist_evidence_preview,

--- a/src-tauri/src/playlist_regeneration.rs
+++ b/src-tauri/src/playlist_regeneration.rs
@@ -82,12 +82,14 @@ impl PlaylistRegenerationBridge {
         session.shutdown();
         let (status, bytes) = response?;
         if status != 200 {
-            let code = serde_json::from_slice::<Value>(&bytes).ok().and_then(|value| {
-                value
-                    .get("error")
-                    .and_then(Value::as_str)
-                    .map(str::to_owned)
-            });
+            let code = serde_json::from_slice::<Value>(&bytes)
+                .ok()
+                .and_then(|value| {
+                    value
+                        .get("error")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned)
+                });
             return Err(RegenerationError::rejected(code.as_deref()));
         }
         serde_json::from_slice(&bytes).map_err(|_| RegenerationError::invalid_response())
@@ -552,7 +554,13 @@ fn validate_regeneration(value: &Value, revision_id: &str) -> Result<(), Regener
     for (alternative_index, alternative) in alternatives.iter().enumerate() {
         let row = exact(
             alternative,
-            &["path_id", "rank", "sequence", "objective", "explanation_codes"],
+            &[
+                "path_id",
+                "rank",
+                "sequence",
+                "objective",
+                "explanation_codes",
+            ],
         )
         .ok_or_else(RegenerationError::invalid_response)?;
         if !row["path_id"].as_str().is_some_and(token)
@@ -600,14 +608,13 @@ fn validate_regeneration(value: &Value, revision_id: &str) -> Result<(), Regener
             {
                 return Err(RegenerationError::invalid_response());
             }
-            let expected_lock = locks.iter().find(|lock| {
-                lock.get("order_index").and_then(Value::as_u64) == Some(index as u64)
-            });
+            let expected_lock = locks
+                .iter()
+                .find(|lock| lock.get("order_index").and_then(Value::as_u64) == Some(index as u64));
             match expected_lock {
                 Some(lock) => {
                     if item["locked"].as_bool() != Some(true)
-                        || item["track_id"].as_str()
-                            != lock.get("track_id").and_then(Value::as_str)
+                        || item["track_id"].as_str() != lock.get("track_id").and_then(Value::as_str)
                     {
                         return Err(RegenerationError::invalid_response());
                     }

--- a/src-tauri/src/playlist_regeneration.rs
+++ b/src-tauri/src/playlist_regeneration.rs
@@ -1,0 +1,792 @@
+use std::{
+    collections::HashSet,
+    env,
+    io::{Read, Write},
+    net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream},
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    sync::mpsc,
+    thread,
+    time::{Duration, Instant},
+};
+
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+use tauri::{AppHandle, Manager, State};
+use uuid::Uuid;
+
+use crate::library_capability::DesktopHostError;
+
+const SIDECAR_EXECUTABLE_ENV: &str = "APPLAYLIST_DESKTOP_SIDECAR_EXECUTABLE";
+const BUNDLED_SIDECAR_RESOURCE: &str = "applaylist-sidecar/applaylist-sidecar";
+const PROTOCOL_VERSION: &str = "applaylist-sidecar-v1";
+const SECRET_HEADER: &str = "X-APPLAYLIST-Sidecar-Secret";
+const NONCE_HEADER: &str = "X-APPLAYLIST-Readiness-Nonce";
+const READY_TIMEOUT: Duration = Duration::from_secs(5);
+const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_READY_BYTES: usize = 8_192;
+const MAX_HTTP_RESPONSE_BYTES: u64 = 4 * 1024 * 1024;
+const MAX_TOKEN: usize = 256;
+
+#[derive(Debug, Clone)]
+pub struct PlaylistRegenerationBridge {
+    executable: Option<PathBuf>,
+}
+
+impl PlaylistRegenerationBridge {
+    pub fn from_environment() -> Self {
+        Self {
+            executable: if cfg!(debug_assertions) {
+                env::var_os(SIDECAR_EXECUTABLE_ENV).map(PathBuf::from)
+            } else {
+                None
+            },
+        }
+    }
+
+    fn executable(&self, resource_dir: Option<&Path>) -> Result<PathBuf, RegenerationError> {
+        if let Some(path) = self.executable.as_ref() {
+            let canonical = path
+                .canonicalize()
+                .map_err(|_| RegenerationError::unavailable())?;
+            return canonical
+                .is_file()
+                .then_some(canonical)
+                .ok_or_else(RegenerationError::unavailable);
+        }
+        let root = resource_dir.ok_or_else(RegenerationError::not_configured)?;
+        let root = root
+            .canonicalize()
+            .map_err(|_| RegenerationError::unavailable())?;
+        let binary = root
+            .join(BUNDLED_SIDECAR_RESOURCE)
+            .canonicalize()
+            .map_err(|_| RegenerationError::unavailable())?;
+        if !binary.starts_with(&root) || !binary.is_file() {
+            return Err(RegenerationError::unavailable());
+        }
+        Ok(binary)
+    }
+
+    fn request(
+        &self,
+        path: &str,
+        body: Value,
+        resource_dir: Option<&Path>,
+    ) -> Result<Value, RegenerationError> {
+        let executable = self.executable(resource_dir)?;
+        let mut session = Session::connect(&executable)?;
+        let payload = serde_json::to_vec(&body).map_err(|_| RegenerationError::request_failed())?;
+        let response = session.post(path, &payload);
+        session.shutdown();
+        let (status, bytes) = response?;
+        if status != 200 {
+            let code = serde_json::from_slice::<Value>(&bytes).ok().and_then(|value| {
+                value
+                    .get("error")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned)
+            });
+            return Err(RegenerationError::rejected(code.as_deref()));
+        }
+        serde_json::from_slice(&bytes).map_err(|_| RegenerationError::invalid_response())
+    }
+}
+
+impl Default for PlaylistRegenerationBridge {
+    fn default() -> Self {
+        Self::from_environment()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RegenerationError {
+    code: &'static str,
+    message: &'static str,
+}
+
+impl RegenerationError {
+    const fn new(code: &'static str, message: &'static str) -> Self {
+        Self { code, message }
+    }
+    const fn not_configured() -> Self {
+        Self::new(
+            "desktop_playlist_regeneration_sidecar_not_configured",
+            "The playlist regeneration service is not configured.",
+        )
+    }
+    const fn unavailable() -> Self {
+        Self::new(
+            "desktop_playlist_regeneration_sidecar_unavailable",
+            "The playlist regeneration service is unavailable.",
+        )
+    }
+    const fn startup_failed() -> Self {
+        Self::new(
+            "desktop_playlist_regeneration_sidecar_startup_failed",
+            "The playlist regeneration service could not start.",
+        )
+    }
+    const fn readiness_failed() -> Self {
+        Self::new(
+            "desktop_playlist_regeneration_sidecar_readiness_failed",
+            "The playlist regeneration service did not become ready.",
+        )
+    }
+    const fn request_failed() -> Self {
+        Self::new(
+            "desktop_playlist_regeneration_request_failed",
+            "The playlist regeneration request failed.",
+        )
+    }
+    const fn invalid_request() -> Self {
+        Self::new(
+            "invalid_playlist_regeneration_request",
+            "The playlist regeneration request is invalid.",
+        )
+    }
+    const fn invalid_response() -> Self {
+        Self::new(
+            "desktop_playlist_regeneration_response_invalid",
+            "The playlist regeneration response is invalid.",
+        )
+    }
+    fn rejected(code: Option<&str>) -> Self {
+        match code {
+            Some("playlist_revision_stale") => Self::new(
+                "playlist_revision_stale",
+                "The selected playlist revision is stale.",
+            ),
+            Some("playlist_revision_not_found") => Self::new(
+                "playlist_revision_not_found",
+                "The selected playlist revision was not found.",
+            ),
+            Some("playlist_regeneration_anchor_required") => Self::new(
+                "playlist_regeneration_anchor_required",
+                "Regeneration R1 requires the first playlist position to be locked.",
+            ),
+            Some("playlist_regeneration_locked_track_missing") => Self::new(
+                "playlist_regeneration_locked_track_missing",
+                "The regeneration scope must contain every locked track.",
+            ),
+            Some("playlist_regeneration_evidence_unavailable") => Self::new(
+                "playlist_regeneration_evidence_unavailable",
+                "Required regeneration evidence is unavailable.",
+            ),
+            Some("playlist_regeneration_projection_failed") => Self::new(
+                "playlist_regeneration_projection_failed",
+                "No safe regeneration projection is available.",
+            ),
+            Some("playlist_regeneration_stale") => Self::new(
+                "playlist_regeneration_stale",
+                "The displayed regeneration preview is stale.",
+            ),
+            Some("playlist_revision_noop") => Self::new(
+                "playlist_revision_noop",
+                "The regeneration does not change the current revision.",
+            ),
+            Some("invalid_playlist_editor_request" | "invalid_playlist_regeneration_request") => {
+                Self::invalid_request()
+            }
+            _ => Self::new(
+                "desktop_playlist_regeneration_rejected",
+                "The playlist regeneration request was rejected.",
+            ),
+        }
+    }
+}
+
+impl From<RegenerationError> for DesktopHostError {
+    fn from(value: RegenerationError) -> Self {
+        DesktopHostError::new(value.code, value.message)
+    }
+}
+
+struct Session {
+    child: Child,
+    port: u16,
+    secret: String,
+    nonce: String,
+}
+
+impl Session {
+    fn connect(executable: &Path) -> Result<Self, RegenerationError> {
+        let secret = random_token();
+        let nonce = random_token();
+        let mut child = Command::new(executable)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|_| RegenerationError::startup_failed())?;
+        let envelope = serde_json::to_vec(&json!({
+            "protocol": PROTOCOL_VERSION,
+            "secret": secret,
+            "nonce": nonce,
+        }))
+        .map_err(|_| RegenerationError::startup_failed())?;
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(RegenerationError::startup_failed)?;
+        stdin
+            .write_all(&envelope)
+            .and_then(|_| stdin.write_all(b"\n"))
+            .and_then(|_| stdin.flush())
+            .map_err(|_| RegenerationError::startup_failed())?;
+        drop(stdin);
+
+        let line = read_ready(&mut child)?;
+        let ready: Value =
+            serde_json::from_slice(&line).map_err(|_| RegenerationError::readiness_failed())?;
+        let port = validate_ready(&ready, &nonce)?;
+        let (status, health) = request_json(port, "GET", "/v1/health", &secret, &nonce, None)?;
+        if status != 200 {
+            return Err(RegenerationError::readiness_failed());
+        }
+        let health: Value =
+            serde_json::from_slice(&health).map_err(|_| RegenerationError::readiness_failed())?;
+        let nonce_hash = sha256_hex(nonce.as_bytes());
+        if health.get("status").and_then(Value::as_str) != Some("ready")
+            || health.get("protocol").and_then(Value::as_str) != Some(PROTOCOL_VERSION)
+            || health.get("nonce_sha256").and_then(Value::as_str) != Some(nonce_hash.as_str())
+        {
+            return Err(RegenerationError::readiness_failed());
+        }
+        Ok(Self {
+            child,
+            port,
+            secret,
+            nonce,
+        })
+    }
+
+    fn post(&mut self, path: &str, body: &[u8]) -> Result<(u16, Vec<u8>), RegenerationError> {
+        request_json(
+            self.port,
+            "POST",
+            path,
+            &self.secret,
+            &self.nonce,
+            Some(body),
+        )
+    }
+
+    fn shutdown(&mut self) {
+        let _ = request_json(
+            self.port,
+            "POST",
+            "/v1/shutdown",
+            &self.secret,
+            &self.nonce,
+            Some(&[]),
+        );
+        let deadline = Instant::now() + SHUTDOWN_TIMEOUT;
+        while Instant::now() < deadline {
+            match self.child.try_wait() {
+                Ok(Some(_)) => return,
+                Ok(None) => thread::sleep(Duration::from_millis(25)),
+                Err(_) => break,
+            }
+        }
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        if matches!(self.child.try_wait(), Ok(None)) {
+            let _ = self.child.kill();
+        }
+        let _ = self.child.wait();
+    }
+}
+
+fn read_ready(child: &mut Child) -> Result<Vec<u8>, RegenerationError> {
+    let mut stdout = child
+        .stdout
+        .take()
+        .ok_or_else(RegenerationError::readiness_failed)?;
+    let (sender, receiver) = mpsc::sync_channel(1);
+    thread::spawn(move || {
+        let mut line = Vec::new();
+        let result = (|| -> std::io::Result<Vec<u8>> {
+            for _ in 0..=MAX_READY_BYTES {
+                let mut byte = [0_u8; 1];
+                if stdout.read(&mut byte)? == 0 {
+                    break;
+                }
+                if byte[0] == b'\n' {
+                    return Ok(line);
+                }
+                line.push(byte[0]);
+            }
+            Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "invalid readiness line",
+            ))
+        })();
+        let _ = sender.send(result);
+    });
+    receiver
+        .recv_timeout(READY_TIMEOUT)
+        .map_err(|_| RegenerationError::readiness_failed())?
+        .map_err(|_| RegenerationError::readiness_failed())
+}
+
+fn validate_ready(value: &Value, nonce: &str) -> Result<u16, RegenerationError> {
+    let nonce_hash = sha256_hex(nonce.as_bytes());
+    if value.get("event").and_then(Value::as_str) != Some("ready")
+        || value.get("protocol").and_then(Value::as_str) != Some(PROTOCOL_VERSION)
+        || value.get("host").and_then(Value::as_str) != Some("127.0.0.1")
+        || value.get("nonce_sha256").and_then(Value::as_str) != Some(nonce_hash.as_str())
+        || value.get("process_id").and_then(Value::as_u64).unwrap_or(0) == 0
+    {
+        return Err(RegenerationError::readiness_failed());
+    }
+    value
+        .get("port")
+        .and_then(Value::as_u64)
+        .filter(|port| (1..=u16::MAX as u64).contains(port))
+        .map(|port| port as u16)
+        .ok_or_else(RegenerationError::readiness_failed)
+}
+
+fn request_json(
+    port: u16,
+    method: &str,
+    path: &str,
+    secret: &str,
+    nonce: &str,
+    body: Option<&[u8]>,
+) -> Result<(u16, Vec<u8>), RegenerationError> {
+    let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+    let mut stream = TcpStream::connect_timeout(&address, HTTP_TIMEOUT)
+        .map_err(|_| RegenerationError::request_failed())?;
+    stream
+        .set_read_timeout(Some(HTTP_TIMEOUT))
+        .map_err(|_| RegenerationError::request_failed())?;
+    stream
+        .set_write_timeout(Some(HTTP_TIMEOUT))
+        .map_err(|_| RegenerationError::request_failed())?;
+    let payload = body.unwrap_or(&[]);
+    let content_type = if body.is_some() {
+        "Content-Type: application/json\r\n"
+    } else {
+        ""
+    };
+    let request = format!(
+        "{method} {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\n{SECRET_HEADER}: {secret}\r\n{NONCE_HEADER}: {nonce}\r\n{content_type}Content-Length: {}\r\n\r\n",
+        payload.len()
+    );
+    stream
+        .write_all(request.as_bytes())
+        .and_then(|_| stream.write_all(payload))
+        .and_then(|_| stream.flush())
+        .map_err(|_| RegenerationError::request_failed())?;
+    let mut response = Vec::new();
+    std::io::Read::by_ref(&mut stream)
+        .take(MAX_HTTP_RESPONSE_BYTES + 1)
+        .read_to_end(&mut response)
+        .map_err(|_| RegenerationError::request_failed())?;
+    if response.len() as u64 > MAX_HTTP_RESPONSE_BYTES {
+        return Err(RegenerationError::request_failed());
+    }
+    let boundary = response
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .ok_or_else(RegenerationError::request_failed)?;
+    let headers = std::str::from_utf8(&response[..boundary])
+        .map_err(|_| RegenerationError::request_failed())?;
+    let mut lines = headers.split("\r\n");
+    let mut parts = lines
+        .next()
+        .ok_or_else(RegenerationError::request_failed)?
+        .split_whitespace();
+    if parts.next() != Some("HTTP/1.1") {
+        return Err(RegenerationError::request_failed());
+    }
+    let status = parts
+        .next()
+        .and_then(|value| value.parse::<u16>().ok())
+        .ok_or_else(RegenerationError::request_failed)?;
+    let mut length = None;
+    for line in lines {
+        let Some((name, value)) = line.split_once(':') else {
+            return Err(RegenerationError::request_failed());
+        };
+        if name.eq_ignore_ascii_case("Content-Length") {
+            length = value.trim().parse::<usize>().ok();
+        }
+    }
+    let body = &response[boundary + 4..];
+    if length != Some(body.len()) {
+        return Err(RegenerationError::request_failed());
+    }
+    Ok((status, body.to_vec()))
+}
+
+fn random_token() -> String {
+    format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple())
+}
+
+fn sha256_hex(value: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(value))
+}
+
+fn token(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_TOKEN
+        && value.trim() == value
+        && !value.contains('/')
+        && !value.contains('\\')
+        && !value.chars().any(char::is_whitespace)
+        && !value.chars().any(char::is_control)
+}
+
+fn display(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 512
+        && value.trim() == value
+        && !value.chars().any(char::is_control)
+        && !value.starts_with('/')
+        && !value.starts_with("\\\\")
+        && !(value.len() >= 3
+            && value.as_bytes()[0].is_ascii_alphabetic()
+            && value.as_bytes()[1] == b':'
+            && matches!(value.as_bytes()[2], b'/' | b'\\'))
+}
+
+fn digest(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn exact<'a>(value: &'a Value, keys: &[&str]) -> Option<&'a Map<String, Value>> {
+    let object = value.as_object()?;
+    if object.len() != keys.len() || keys.iter().any(|key| !object.contains_key(*key)) {
+        return None;
+    }
+    Some(object)
+}
+
+fn token_array(value: &Value, maximum: usize) -> bool {
+    value.as_array().is_some_and(|items| {
+        items.len() <= maximum && items.iter().all(|item| item.as_str().is_some_and(token))
+    })
+}
+
+fn validate_regeneration(value: &Value, revision_id: &str) -> Result<(), RegenerationError> {
+    let object = exact(
+        value,
+        &[
+            "schema",
+            "playlist_id",
+            "parent_revision_id",
+            "regeneration_id",
+            "candidate_pool_count",
+            "candidate_pool_sha256",
+            "locked_positions",
+            "alternatives",
+            "reason_codes",
+            "warning_codes",
+            "budget_exhausted",
+            "missing_evidence_detected",
+            "deterministic_ordering",
+            "playlist_mutation_authorized",
+            "personal_dj_model_training_authorized",
+            "production_activation_authorized",
+        ],
+    )
+    .ok_or_else(RegenerationError::invalid_response)?;
+    if object["schema"].as_str() != Some("applaylist-desktop-playlist-regeneration-r1")
+        || !object["playlist_id"].as_str().is_some_and(token)
+        || object["parent_revision_id"].as_str() != Some(revision_id)
+        || !object["regeneration_id"].as_str().is_some_and(token)
+        || !(3..=24).contains(&object["candidate_pool_count"].as_u64().unwrap_or(0))
+        || !object["candidate_pool_sha256"].as_str().is_some_and(digest)
+        || object["budget_exhausted"].as_bool().is_none()
+        || object["missing_evidence_detected"].as_bool().is_none()
+        || object["deterministic_ordering"].as_bool() != Some(true)
+        || object["playlist_mutation_authorized"].as_bool() != Some(false)
+        || object["personal_dj_model_training_authorized"].as_bool() != Some(false)
+        || object["production_activation_authorized"].as_bool() != Some(false)
+        || !token_array(&object["reason_codes"], 128)
+        || !token_array(&object["warning_codes"], 128)
+    {
+        return Err(RegenerationError::invalid_response());
+    }
+
+    let locks = object["locked_positions"]
+        .as_array()
+        .ok_or_else(RegenerationError::invalid_response)?;
+    if locks.is_empty() || locks.len() > 8 {
+        return Err(RegenerationError::invalid_response());
+    }
+    let mut lock_positions = HashSet::new();
+    for lock in locks {
+        let row = exact(lock, &["order_index", "track_id"])
+            .ok_or_else(RegenerationError::invalid_response)?;
+        let index = row["order_index"]
+            .as_u64()
+            .ok_or_else(RegenerationError::invalid_response)?;
+        if index > 7
+            || !row["track_id"].as_str().is_some_and(token)
+            || !lock_positions.insert(index)
+        {
+            return Err(RegenerationError::invalid_response());
+        }
+    }
+    if !lock_positions.contains(&0) {
+        return Err(RegenerationError::invalid_response());
+    }
+
+    let alternatives = object["alternatives"]
+        .as_array()
+        .ok_or_else(RegenerationError::invalid_response)?;
+    if alternatives.len() > 3 {
+        return Err(RegenerationError::invalid_response());
+    }
+    for (alternative_index, alternative) in alternatives.iter().enumerate() {
+        let row = exact(
+            alternative,
+            &["path_id", "rank", "sequence", "objective", "explanation_codes"],
+        )
+        .ok_or_else(RegenerationError::invalid_response)?;
+        if !row["path_id"].as_str().is_some_and(token)
+            || row["rank"].as_u64() != Some((alternative_index + 1) as u64)
+            || !token_array(&row["explanation_codes"], 128)
+        {
+            return Err(RegenerationError::invalid_response());
+        }
+        let objective = exact(
+            &row["objective"],
+            &[
+                "depth",
+                "mean_candidate_score",
+                "minimum_candidate_score",
+                "required_track_completion",
+                "remaining_required_count",
+                "target_reached",
+            ],
+        )
+        .ok_or_else(RegenerationError::invalid_response)?;
+        if objective["depth"].as_u64().is_none()
+            || objective["mean_candidate_score"].as_f64().is_none()
+            || objective["minimum_candidate_score"].as_f64().is_none()
+            || objective["required_track_completion"].as_f64().is_none()
+            || objective["remaining_required_count"].as_u64().is_none()
+            || objective["target_reached"].as_bool().is_none()
+        {
+            return Err(RegenerationError::invalid_response());
+        }
+        let sequence = row["sequence"]
+            .as_array()
+            .ok_or_else(RegenerationError::invalid_response)?;
+        if !(3..=8).contains(&sequence.len()) {
+            return Err(RegenerationError::invalid_response());
+        }
+        let mut ids = HashSet::new();
+        for (index, step) in sequence.iter().enumerate() {
+            let item = exact(step, &["order_index", "track_id", "display_name", "locked"])
+                .ok_or_else(RegenerationError::invalid_response)?;
+            if item["order_index"].as_u64() != Some(index as u64)
+                || !item["track_id"].as_str().is_some_and(token)
+                || !item["display_name"].as_str().is_some_and(display)
+                || item["locked"].as_bool().is_none()
+                || !ids.insert(item["track_id"].as_str().unwrap())
+            {
+                return Err(RegenerationError::invalid_response());
+            }
+            let expected_lock = locks.iter().find(|lock| {
+                lock.get("order_index").and_then(Value::as_u64) == Some(index as u64)
+            });
+            match expected_lock {
+                Some(lock) => {
+                    if item["locked"].as_bool() != Some(true)
+                        || item["track_id"].as_str()
+                            != lock.get("track_id").and_then(Value::as_str)
+                    {
+                        return Err(RegenerationError::invalid_response());
+                    }
+                }
+                None if item["locked"].as_bool() != Some(false) => {
+                    return Err(RegenerationError::invalid_response());
+                }
+                None => {}
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_revision(value: &Value, parent_revision_id: &str) -> Result<(), RegenerationError> {
+    let object = exact(
+        value,
+        &[
+            "schema",
+            "playlist_id",
+            "revision_id",
+            "parent_revision_id",
+            "revision_index",
+            "source_proposal_id",
+            "source_path_id",
+            "operation",
+            "content_fingerprint",
+            "created_at",
+            "sequence",
+            "personal_dj_model_training_authorized",
+            "production_activation_authorized",
+        ],
+    )
+    .ok_or_else(RegenerationError::invalid_response)?;
+    if object["schema"].as_str() != Some("applaylist-desktop-playlist-revision-r1")
+        || !object["playlist_id"].as_str().is_some_and(token)
+        || !object["revision_id"].as_str().is_some_and(token)
+        || object["parent_revision_id"].as_str() != Some(parent_revision_id)
+        || object["revision_index"].as_u64().unwrap_or(0) == 0
+        || !object["source_proposal_id"].as_str().is_some_and(token)
+        || !object["source_path_id"].as_str().is_some_and(token)
+        || object["operation"].as_str() != Some("regenerate")
+        || !object["content_fingerprint"].as_str().is_some_and(digest)
+        || object["personal_dj_model_training_authorized"].as_bool() != Some(false)
+        || object["production_activation_authorized"].as_bool() != Some(false)
+    {
+        return Err(RegenerationError::invalid_response());
+    }
+    let sequence = object["sequence"]
+        .as_array()
+        .ok_or_else(RegenerationError::invalid_response)?;
+    if !(3..=8).contains(&sequence.len()) {
+        return Err(RegenerationError::invalid_response());
+    }
+    let mut ids = HashSet::new();
+    for (index, step) in sequence.iter().enumerate() {
+        let item = exact(step, &["order_index", "track_id", "display_name", "locked"])
+            .ok_or_else(RegenerationError::invalid_response)?;
+        if item["order_index"].as_u64() != Some(index as u64)
+            || !item["track_id"].as_str().is_some_and(token)
+            || !item["display_name"].as_str().is_some_and(display)
+            || item["locked"].as_bool().is_none()
+            || !ids.insert(item["track_id"].as_str().unwrap())
+        {
+            return Err(RegenerationError::invalid_response());
+        }
+    }
+    Ok(())
+}
+
+fn validate_ids(values: &[String]) -> Result<(), RegenerationError> {
+    if !(3..=24).contains(&values.len()) || values.iter().any(|value| !token(value)) {
+        return Err(RegenerationError::invalid_request());
+    }
+    let unique: HashSet<&str> = values.iter().map(String::as_str).collect();
+    (unique.len() == values.len())
+        .then_some(())
+        .ok_or_else(RegenerationError::invalid_request)
+}
+
+async fn call(
+    bridge: State<'_, PlaylistRegenerationBridge>,
+    app: AppHandle,
+    path: &'static str,
+    body: Value,
+) -> Result<Value, DesktopHostError> {
+    let resource_dir = app.path().resource_dir().ok();
+    let bridge = bridge.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        bridge.request(path, body, resource_dir.as_deref())
+    })
+    .await
+    .map_err(|_| {
+        DesktopHostError::new(
+            "desktop_playlist_regeneration_task_failed",
+            "The playlist regeneration task failed.",
+        )
+    })?
+    .map_err(DesktopHostError::from)
+}
+
+#[tauri::command]
+pub async fn playlist_editor_regeneration_preview(
+    revision_id: String,
+    candidate_track_ids: Vec<String>,
+    bridge: State<'_, PlaylistRegenerationBridge>,
+    app: AppHandle,
+) -> Result<Value, DesktopHostError> {
+    if !token(&revision_id) {
+        return Err(RegenerationError::invalid_request().into());
+    }
+    validate_ids(&candidate_track_ids).map_err(DesktopHostError::from)?;
+    let result = call(
+        bridge,
+        app,
+        "/v1/playlist/editor/regeneration/preview",
+        json!({"revision_id":revision_id,"candidate_track_ids":candidate_track_ids}),
+    )
+    .await?;
+    validate_regeneration(&result, &revision_id).map_err(DesktopHostError::from)?;
+    Ok(result)
+}
+
+#[tauri::command]
+pub async fn playlist_editor_regeneration_apply(
+    revision_id: String,
+    candidate_track_ids: Vec<String>,
+    regeneration_id: String,
+    path_id: String,
+    bridge: State<'_, PlaylistRegenerationBridge>,
+    app: AppHandle,
+) -> Result<Value, DesktopHostError> {
+    if !token(&revision_id) || !token(&regeneration_id) || !token(&path_id) {
+        return Err(RegenerationError::invalid_request().into());
+    }
+    validate_ids(&candidate_track_ids).map_err(DesktopHostError::from)?;
+    let expected_parent = revision_id.clone();
+    let result = call(
+        bridge,
+        app,
+        "/v1/playlist/editor/regeneration/apply",
+        json!({
+            "revision_id":revision_id,
+            "candidate_track_ids":candidate_track_ids,
+            "regeneration_id":regeneration_id,
+            "path_id":path_id,
+        }),
+    )
+    .await?;
+    validate_revision(&result, &expected_parent).map_err(DesktopHostError::from)?;
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preview_validation_rejects_authority_escalation() {
+        let mut value = json!({
+            "schema":"applaylist-desktop-playlist-regeneration-r1",
+            "playlist_id":"plr_abc",
+            "parent_revision_id":"prv_parent",
+            "regeneration_id":"spr_abc",
+            "candidate_pool_count":3,
+            "candidate_pool_sha256":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            "locked_positions":[{"order_index":0,"track_id":"track:a"}],
+            "alternatives":[],
+            "reason_codes":[],
+            "warning_codes":[],
+            "budget_exhausted":false,
+            "missing_evidence_detected":false,
+            "deterministic_ordering":true,
+            "playlist_mutation_authorized":false,
+            "personal_dj_model_training_authorized":false,
+            "production_activation_authorized":false
+        });
+        assert!(validate_regeneration(&value, "prv_parent").is_ok());
+        value["playlist_mutation_authorized"] = Value::Bool(true);
+        assert!(validate_regeneration(&value, "prv_parent").is_err());
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,6 +22,7 @@
         "main-library-root",
         "main-set-proposal",
         "main-playlist-editor",
+        "main-playlist-regeneration",
         "main-playlist-export",
         "main-playlist-evidence-export",
         "main-playlist-vendor-interop",

--- a/tests/test_desktop_playlist_regeneration.py
+++ b/tests/test_desktop_playlist_regeneration.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from data.connection import get_sqlite_connection
+from data.repositories.analysis_evidence_repository import AnalysisEvidenceRepository
+from data.repositories.playlist_revision_repository import PlaylistRevisionRepository
+from services.desktop.playlist_editor_transport import DesktopPlaylistEditorTransport
+from services.desktop.playlist_regeneration_service import (
+    DesktopPlaylistRegenerationService,
+    DesktopPlaylistRegenerationServiceError,
+)
+from tests.test_desktop_playlist_editor_transport import _accept
+from tests.test_desktop_readiness_sidecar import _finish, _request
+from tests.test_desktop_set_proposal_transport import (
+    _configure_database,
+    _seed_tracks,
+    _start_extended_sidecar,
+)
+
+
+def _locked_root(
+    editor: DesktopPlaylistEditorTransport,
+    track_ids: tuple[str, ...],
+) -> dict[str, object]:
+    root = _accept(editor, track_ids)
+    first = root["sequence"][0]["track_id"]
+    return editor.lock(
+        revision_id=root["revision_id"],
+        locked_track_ids=[first],
+    )
+
+
+def test_regeneration_preview_is_deterministic_locked_and_path_safe(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    _configure_database(monkeypatch, tmp_path)
+    track_ids = _seed_tracks(count=6)
+    parent = _locked_root(DesktopPlaylistEditorTransport(), track_ids)
+    service = DesktopPlaylistRegenerationService()
+
+    first = service.preview(
+        revision_id=parent["revision_id"],
+        candidate_track_ids=track_ids,
+    )
+    second = service.preview(
+        revision_id=parent["revision_id"],
+        candidate_track_ids=tuple(reversed(track_ids)),
+    )
+
+    assert first == second
+    assert first["schema"] == "applaylist-desktop-playlist-regeneration-r1"
+    assert first["parent_revision_id"] == parent["revision_id"]
+    assert first["candidate_pool_count"] == 6
+    assert first["locked_positions"] == [
+        {"order_index": 0, "track_id": parent["sequence"][0]["track_id"]}
+    ]
+    assert first["deterministic_ordering"] is True
+    assert first["playlist_mutation_authorized"] is False
+    assert first["personal_dj_model_training_authorized"] is False
+    assert first["production_activation_authorized"] is False
+    assert first["alternatives"]
+    for alternative in first["alternatives"]:
+        assert len(alternative["sequence"]) == len(parent["sequence"])
+        assert alternative["sequence"][0]["track_id"] == parent["sequence"][0]["track_id"]
+        assert alternative["sequence"][0]["locked"] is True
+        assert all(item["locked"] is False for item in alternative["sequence"][1:])
+
+    encoded = json.dumps(first, sort_keys=True)
+    assert "/definitely/not-present" not in encoded
+    assert "fixture-provider" not in encoded
+    assert "payload_json" not in encoded
+    assert "content_utf8" not in encoded
+
+
+def test_regeneration_requires_anchor_and_every_locked_track_in_scope(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    _configure_database(monkeypatch, tmp_path)
+    track_ids = _seed_tracks(count=6)
+    editor = DesktopPlaylistEditorTransport()
+    root = _accept(editor, track_ids)
+    service = DesktopPlaylistRegenerationService()
+
+    with pytest.raises(DesktopPlaylistRegenerationServiceError) as anchor:
+        service.preview(
+            revision_id=root["revision_id"],
+            candidate_track_ids=track_ids,
+        )
+    assert anchor.value.code == "playlist_regeneration_anchor_required"
+
+    parent = editor.lock(
+        revision_id=root["revision_id"],
+        locked_track_ids=[root["sequence"][0]["track_id"]],
+    )
+    without_anchor = tuple(
+        track_id for track_id in track_ids if track_id != parent["sequence"][0]["track_id"]
+    )
+    with pytest.raises(DesktopPlaylistRegenerationServiceError) as missing:
+        service.preview(
+            revision_id=parent["revision_id"],
+            candidate_track_ids=without_anchor,
+        )
+    assert missing.value.code == "playlist_regeneration_locked_track_missing"
+
+
+def test_regeneration_apply_replays_preview_and_appends_one_child_revision(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    _configure_database(monkeypatch, tmp_path)
+    track_ids = _seed_tracks(count=7)
+    parent = _locked_root(DesktopPlaylistEditorTransport(), track_ids)
+    service = DesktopPlaylistRegenerationService()
+    preview = service.preview(
+        revision_id=parent["revision_id"],
+        candidate_track_ids=track_ids,
+    )
+    parent_ids = [item["track_id"] for item in parent["sequence"]]
+    alternative = next(
+        item
+        for item in preview["alternatives"]
+        if [step["track_id"] for step in item["sequence"]] != parent_ids
+    )
+
+    before = PlaylistRevisionRepository().count_revisions(parent["playlist_id"])
+    child = service.apply(
+        revision_id=parent["revision_id"],
+        candidate_track_ids=track_ids,
+        regeneration_id=preview["regeneration_id"],
+        path_id=alternative["path_id"],
+    )
+    after = PlaylistRevisionRepository().count_revisions(parent["playlist_id"])
+
+    assert after == before + 1
+    assert child["operation"] == "regenerate"
+    assert child["parent_revision_id"] == parent["revision_id"]
+    assert child["revision_index"] == parent["revision_index"] + 1
+    assert child["sequence"] == alternative["sequence"]
+    assert child["sequence"][0]["locked"] is True
+    assert child["sequence"][0]["track_id"] == parent["sequence"][0]["track_id"]
+    assert child["personal_dj_model_training_authorized"] is False
+    assert child["production_activation_authorized"] is False
+
+    with pytest.raises(DesktopPlaylistRegenerationServiceError) as stale_parent:
+        service.preview(
+            revision_id=parent["revision_id"],
+            candidate_track_ids=track_ids,
+        )
+    assert stale_parent.value.code == "playlist_revision_stale"
+
+
+def test_regeneration_apply_fails_closed_when_evidence_changes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    _configure_database(monkeypatch, tmp_path)
+    track_ids = _seed_tracks(count=6)
+    parent = _locked_root(DesktopPlaylistEditorTransport(), track_ids)
+    service = DesktopPlaylistRegenerationService()
+    preview = service.preview(
+        revision_id=parent["revision_id"],
+        candidate_track_ids=track_ids,
+    )
+    evidence = AnalysisEvidenceRepository()
+    changed_track = track_ids[-1]
+    base = evidence.latest_success_for_track(changed_track)
+    assert base is not None
+    evidence.append_correction(
+        track_id=changed_track,
+        base_evidence_id=base.evidence_id,
+        values={"energy": 0.19},
+        reason="invalidate regeneration replay identity",
+    )
+
+    with pytest.raises(DesktopPlaylistRegenerationServiceError) as stale:
+        service.apply(
+            revision_id=parent["revision_id"],
+            candidate_track_ids=track_ids,
+            regeneration_id=preview["regeneration_id"],
+            path_id=preview["alternatives"][0]["path_id"],
+        )
+    assert stale.value.code == "playlist_regeneration_stale"
+    assert PlaylistRevisionRepository().current_revision(parent["playlist_id"])["revision_id"] == parent["revision_id"]
+
+
+def test_legacy_revision_schema_migrates_without_losing_immutability(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    _configure_database(monkeypatch, tmp_path)
+    with get_sqlite_connection() as conn:
+        conn.executescript(
+            """
+            PRAGMA foreign_keys = ON;
+            CREATE TABLE playlist_revisions (
+                revision_id TEXT PRIMARY KEY,
+                playlist_id TEXT NOT NULL,
+                parent_revision_id TEXT,
+                revision_index INTEGER NOT NULL CHECK (revision_index >= 0),
+                source_proposal_id TEXT NOT NULL,
+                source_path_id TEXT NOT NULL,
+                operation TEXT NOT NULL CHECK (operation IN ('accept','reorder','lock','replace')),
+                operation_json TEXT NOT NULL,
+                content_fingerprint TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                personal_dj_model_training_authorized INTEGER NOT NULL DEFAULT 0 CHECK (personal_dj_model_training_authorized = 0),
+                production_activation_authorized INTEGER NOT NULL DEFAULT 0 CHECK (production_activation_authorized = 0),
+                UNIQUE (playlist_id, revision_index),
+                FOREIGN KEY(parent_revision_id) REFERENCES playlist_revisions(revision_id)
+            );
+            CREATE TABLE playlist_revision_items (
+                revision_id TEXT NOT NULL,
+                order_index INTEGER NOT NULL CHECK (order_index >= 0),
+                track_id TEXT NOT NULL,
+                display_name TEXT NOT NULL,
+                locked INTEGER NOT NULL DEFAULT 0 CHECK (locked IN (0,1)),
+                PRIMARY KEY (revision_id, order_index),
+                UNIQUE (revision_id, track_id),
+                FOREIGN KEY(revision_id) REFERENCES playlist_revisions(revision_id)
+            );
+            CREATE TRIGGER playlist_revisions_no_update BEFORE UPDATE ON playlist_revisions BEGIN SELECT RAISE(ABORT, 'playlist revisions are immutable'); END;
+            CREATE TRIGGER playlist_revisions_no_delete BEFORE DELETE ON playlist_revisions BEGIN SELECT RAISE(ABORT, 'playlist revisions are immutable'); END;
+            CREATE TRIGGER playlist_revision_items_no_update BEFORE UPDATE ON playlist_revision_items BEGIN SELECT RAISE(ABORT, 'playlist revision items are immutable'); END;
+            CREATE TRIGGER playlist_revision_items_no_delete BEFORE DELETE ON playlist_revision_items BEGIN SELECT RAISE(ABORT, 'playlist revision items are immutable'); END;
+            INSERT INTO playlist_revisions (
+                revision_id, playlist_id, parent_revision_id, revision_index,
+                source_proposal_id, source_path_id, operation, operation_json,
+                content_fingerprint, personal_dj_model_training_authorized,
+                production_activation_authorized
+            ) VALUES (
+                'prv_legacy', 'plr_legacy', NULL, 0,
+                'proposal_legacy', 'path_legacy', 'accept', '{}',
+                '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef', 0, 0
+            );
+            INSERT INTO playlist_revision_items VALUES ('prv_legacy',0,'track:a','A',1);
+            INSERT INTO playlist_revision_items VALUES ('prv_legacy',1,'track:b','B',0);
+            INSERT INTO playlist_revision_items VALUES ('prv_legacy',2,'track:c','C',0);
+            """
+        )
+        conn.commit()
+
+    repository = PlaylistRevisionRepository()
+    repository.ensure_schema()
+    legacy = repository.get_revision("prv_legacy")
+    assert legacy is not None
+    assert legacy["operation"] == "accept"
+
+    child = repository.append_child(
+        parent_revision_id="prv_legacy",
+        operation="regenerate",
+        items=(("track:a", "A", True), ("track:d", "D", False), ("track:c", "C", False)),
+        operation_metadata={"regeneration_id": "regen_test", "path_id": "path_test"},
+    )
+    assert child["operation"] == "regenerate"
+
+    with get_sqlite_connection() as conn:
+        with pytest.raises(sqlite3.DatabaseError, match="playlist revisions are immutable"):
+            conn.execute(
+                "UPDATE playlist_revisions SET operation='lock' WHERE revision_id=?",
+                (child["revision_id"],),
+            )
+
+
+def test_authenticated_regeneration_sidecar_routes_are_strict(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    database = _configure_database(monkeypatch, tmp_path)
+    track_ids = _seed_tracks(count=6)
+    parent = _locked_root(DesktopPlaylistEditorTransport(), track_ids)
+    process, ready = _start_extended_sidecar(database)
+    body = {
+        "revision_id": parent["revision_id"],
+        "candidate_track_ids": list(track_ids),
+    }
+    try:
+        status, payload = _request(
+            ready,
+            method="POST",
+            path="/v1/playlist/editor/regeneration/preview",
+            secret="X" * 48,
+            body=json.dumps(body).encode("utf-8"),
+        )
+        assert status == 401
+        assert payload == {"error": "unauthorized"}
+
+        status, payload = _request(
+            ready,
+            method="POST",
+            path="/v1/playlist/editor/regeneration/preview",
+            body=json.dumps({**body, "path": "/must/not-pass"}).encode("utf-8"),
+        )
+        assert status == 400
+        assert payload == {"error": "invalid_playlist_editor_request"}
+
+        status, preview = _request(
+            ready,
+            method="POST",
+            path="/v1/playlist/editor/regeneration/preview",
+            body=json.dumps(body).encode("utf-8"),
+        )
+        assert status == 200
+        assert preview["schema"] == "applaylist-desktop-playlist-regeneration-r1"
+        assert preview["parent_revision_id"] == parent["revision_id"]
+        assert preview["playlist_mutation_authorized"] is False
+
+        status, shutdown = _request(ready, method="POST", path="/v1/shutdown")
+        assert status == 202
+        assert shutdown == {"status": "shutting_down"}
+        _finish(process)
+    finally:
+        if process.poll() is None:
+            process.kill()
+            _finish(process)

--- a/tests/test_desktop_playlist_regeneration_renderer.py
+++ b/tests/test_desktop_playlist_regeneration_renderer.py
@@ -21,7 +21,7 @@ def test_regeneration_renderer_is_explicit_dom_safe_and_path_free() -> None:
     assert "applaylist-desktop-playlist-regeneration-r1" in editor
     assert '"regenerate"' in editor
     assert "Regenerate around locks" in editor
-    assert "position 1 must be locked" in editor
+    assert "position 1 must be locked" in editor.lower()
     assert "document.createElement" in editor
     assert ".textContent" in editor
     assert "innerHTML" not in editor

--- a/tests/test_desktop_playlist_regeneration_renderer.py
+++ b/tests/test_desktop_playlist_regeneration_renderer.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EDITOR_JS = ROOT / "desktop" / "host-proof" / "playlist-editor.js"
+RUST = ROOT / "src-tauri" / "src" / "playlist_regeneration.rs"
+BUILD = ROOT / "src-tauri" / "build.rs"
+LIB = ROOT / "src-tauri" / "src" / "lib.rs"
+CAPABILITY = ROOT / "src-tauri" / "capabilities" / "main-playlist-regeneration.json"
+CONFIG = ROOT / "src-tauri" / "tauri.conf.json"
+SIDECAR = ROOT / "services" / "desktop" / "playlist_editor_sidecar.py"
+
+
+def test_regeneration_renderer_is_explicit_dom_safe_and_path_free() -> None:
+    editor = EDITOR_JS.read_text(encoding="utf-8")
+
+    assert "playlist_editor_regeneration_preview" in editor
+    assert "playlist_editor_regeneration_apply" in editor
+    assert "applaylist-desktop-playlist-regeneration-r1" in editor
+    assert '"regenerate"' in editor
+    assert "Regenerate around locks" in editor
+    assert "position 1 must be locked" in editor
+    assert "document.createElement" in editor
+    assert ".textContent" in editor
+    assert "innerHTML" not in editor
+    assert "insertAdjacentHTML" not in editor
+    assert "fetch(" not in editor
+    assert "XMLHttpRequest" not in editor
+    assert "WebSocket" not in editor
+    assert "localStorage" not in editor
+    assert "sessionStorage" not in editor
+    for forbidden in (
+        "/v1/playlist/editor/regeneration/",
+        "X-APPLAYLIST-Sidecar-Secret",
+        "X-APPLAYLIST-Readiness-Nonce",
+        "127.0.0.1",
+        "payload_json",
+        "content_utf8",
+        "filesystem_path",
+    ):
+        assert forbidden not in editor
+
+
+def test_regeneration_tauri_surface_is_narrow_and_separate() -> None:
+    rust = RUST.read_text(encoding="utf-8")
+    build = BUILD.read_text(encoding="utf-8")
+    lib = LIB.read_text(encoding="utf-8")
+    capability = json.loads(CAPABILITY.read_text(encoding="utf-8"))
+    config = json.loads(CONFIG.read_text(encoding="utf-8"))
+    sidecar = SIDECAR.read_text(encoding="utf-8")
+
+    commands = (
+        "playlist_editor_regeneration_preview",
+        "playlist_editor_regeneration_apply",
+    )
+    for command in commands:
+        assert command in rust
+        assert command in build
+        assert command in lib
+    assert capability["permissions"] == [
+        "core:default",
+        "allow-playlist-editor-regeneration-preview",
+        "allow-playlist-editor-regeneration-apply",
+    ]
+    assert "main-playlist-regeneration" in config["app"]["security"]["capabilities"]
+    assert "connect-src 'none'" in config["app"]["security"]["csp"]
+
+    assert '"/v1/playlist/editor/regeneration/preview"' in rust
+    assert '"/v1/playlist/editor/regeneration/apply"' in rust
+    assert '"/v1/playlist/editor/regeneration/preview"' in sidecar
+    assert '"/v1/playlist/editor/regeneration/apply"' in sidecar
+    assert "blocking_save_file" not in rust
+    assert "write_atomic" not in rust
+    assert "tauri_plugin_fs" not in rust
+
+
+def test_existing_revision_consumers_accept_regenerated_history() -> None:
+    for relative in (
+        "desktop/host-proof/playlist-editor.js",
+        "desktop/host-proof/playlist-export.js",
+        "desktop/host-proof/playlist-evidence-export.js",
+        "desktop/host-proof/transition-inspector.js",
+    ):
+        content = (ROOT / relative).read_text(encoding="utf-8")
+        assert '"regenerate"' in content

--- a/tests/test_desktop_set_proposal_renderer.py
+++ b/tests/test_desktop_set_proposal_renderer.py
@@ -86,6 +86,7 @@ def test_set_proposal_tauri_surface_is_separate_and_narrow() -> None:
         "main-library-root",
         "main-set-proposal",
         "main-playlist-editor",
+        "main-playlist-regeneration",
         "main-playlist-export",
         "main-playlist-evidence-export",
         "main-playlist-vendor-interop",


### PR DESCRIPTION
## Summary

Adds governed regeneration of unlocked playlist positions around explicit immutable locks.

- exact current immutable `PlaylistRevision`
- R1 requires position 0 locked; additional locks remain exact hard positions
- explicit bounded analyzed candidate pool (3–24)
- existing Set Intelligence optimizer remains sole path-search authority
- request-local transition assessments only; no canonical evidence mutation
- renderer-safe preview alternatives
- apply requires exact `regeneration_id` + `path_id` deterministic replay
- successful apply appends one immutable child revision with `operation=regenerate`
- regenerated revisions remain visible to inspection/export/evidence surfaces

Closes #143

## Bundle Context

Bundle 57 established immutable playlist revision history and governed lock semantics. Bundle 61 added read-only selected transition inspection over an exact immutable revision. The R4 roadmap still requires `regeneration around locks`; Bundle 62 implements only that remaining editor regeneration slice and does not broaden scope into Human DJ Review execution, Personal DJ Model training, production activation, release or deployment.

## Canonical dependency

Base branch: `feature/bundle-0-bootstrap`
Exact canonical base SHA: `f5747ee01a413cecac208d7051dce21fee6958ad`
Exact implementation head SHA: `4c94e89c653883211c3ed9cd720cf2407e64613f`
Exact compare: `22 commits ahead / 0 behind / 17 files`
Merge-base: exactly `f5747ee01a413cecac208d7051dce21fee6958ad`

## Governed product flow

```text
current immutable PlaylistRevision
  + explicit candidate pool
  + persisted locked positions
  -> deterministic bounded Set Intelligence regeneration
  -> renderer-safe preview alternatives
  -> exact regeneration_id + path_id replay
  -> evidence/lock/pool identity revalidation
  -> one immutable child PlaylistRevision (operation=regenerate)
```

## Determinism and stale-replay safety

- candidate-pool ordering is canonicalized; reversing the same pool does not change regeneration identity
- regeneration identity is bound to the current evidence state of every candidate track
- latest attempt/status, latest success and active correction identity participate in the governed replay identity
- evidence change, correction change, lock change, revision change or candidate-pool change invalidates stale replay fail-closed
- successful apply never mutates the parent revision in place

## Authority boundaries

- no renderer-supplied transition scoring or output sequence
- no filesystem paths/private MIR payloads to renderer
- no audio read/hash or MIR/provider execution during regeneration
- no persisted request-local TransitionAssessment state
- locked positions remain exact hard constraints
- no Human DJ Review execution
- no Personal DJ Model training
- no production activation
- no release/deploy/signing/notarization

## Verification — exact head `4c94e89c653883211c3ed9cd720cf2407e64613f`

### PR Guard #297
PASS.

### CI #840
PASS.

Python 3.11:
- compile PASS
- critical lint PASS
- `432 passed, 6 warnings in 48.31s`
- artifact ID `9384205327`
- artifact ZIP SHA-256 `80fb7ea511e9d0a2ceb8a39176b769d120d9bf08684667d44b1d6ff3c81a761c`
- artifact size `13473` bytes

Python 3.12:
- compile PASS
- critical lint PASS
- `432 passed, 5 warnings in 49.99s`
- artifact ID `9384207022`
- artifact ZIP SHA-256 `dfafc3df3c346dc657f08d9a278e767e5ca1121ba21ca235cdd4bb5919e73ad1`
- artifact size `13368` bytes

### Desktop Rust #141
PASS on macOS / pinned Rust 1.88.0:
- rustfmt PASS
- bundled resource fixture PASS
- Cargo check PASS
- Cargo test PASS

### Desktop Sidecar Proof #74
PASS on Ubuntu and macOS:
- sidecar unit/process tests PASS
- target-native build PASS
- packaged smoke PASS
- package manifest verification PASS
- proof upload PASS

Linux proof artifact:
- ID `9384224929`
- SHA-256 `1b5509bad956dcdce77f88ee4a151217b22235f3d0878f32c21e6b19ac94c6e8`
- size `241816199` bytes

macOS proof artifact:
- ID `9384289912`
- SHA-256 `17ef4f13c1989d34004025d55de122ead0f63c64f15c26395a6f813fe44f75b2`
- size `175630873` bytes

## Review hygiene

- unresolved review threads: `0`
- submitted reviews: `0`
- all final execution evidence above is exact-head evidence

## Diagnostic history

Initial CI exposed bounded implementation defects only: stale-replay evidence identity, renderer/capability regression assertions, required PR Bundle Context, and rustfmt. Fixes were forward-only. A subsequent deterministic-replay test caught candidate evidence hashing in caller order; the final fix canonicalizes evidence identity by track ID. Final exact head passes all gates.

`MERGE_AUTHORIZATION=NO`
`RELEASE_AUTHORIZATION=NO`
`DEPLOY_AUTHORIZATION=NO`
`PRODUCTION_EFFECTS=NO`