### PR TITLE
Bundle 64: R4 Bounded DJ Pilot Evidence R1

### DIFF
--- a/docs/bundles/BUNDLE_64_R4_BOUNDED_DJ_PILOT_EVIDENCE_R1.md
+++ b/docs/bundles/BUNDLE_64_R4_BOUNDED_DJ_PILOT_EVIDENCE_R1.md
@@ -1,0 +1,287 @@
+# Bundle 64 — R4 Bounded DJ Pilot Evidence R1
+
+Status: governed implementation slice  
+Issue: #148  
+Canonical dependency: `8474d6c0c526e714c6b0a4fece5b47f0be5ade32`
+
+## Purpose
+
+Bundle 64 implements the evidence boundary required by the R4 go-to-market checkpoint.
+
+It does not add another editor feature and it does not turn APPLAYLIST into an analytics product.
+
+```text
+real local DJ pilot use
+  -> explicit bounded workflow events
+  -> explicit exit survey evidence
+  -> strict validation + correlation
+  -> append-only local SQLite ledger
+  -> deterministic product metrics
+  + optional canonical Bundle 63 Human DJ Review aggregate
+  -> INCOMPLETE / READY_FOR_HUMAN_DECISION
+```
+
+No synthetic usage or survey evidence is generated.
+
+## Why this slice exists
+
+The R4 roadmap requires a bounded DJ pilot before feature scope broadens. The named questions are no longer primarily engineering questions:
+
+- does APPLAYLIST reduce preparation time,
+- do DJs inspect and act on its recommendations,
+- how much manual correction remains necessary,
+- do DJs successfully export a usable result,
+- do they return in a later week,
+- do they trust and understand the system,
+- would they pay for it,
+- and does the blinded Human DJ Review evidence from Bundle 63 support continuing the current intelligence direction.
+
+A CI pass cannot answer those questions. Bundle 64 therefore creates a governed evidence mechanism for real pilot use.
+
+## Local-first boundary
+
+All R1 evidence is written to an explicitly supplied local SQLite file.
+
+There is:
+
+- no analytics SDK,
+- no HTTP client,
+- no SaaS collector,
+- no cloud upload path,
+- no background telemetry,
+- no tracking outside an explicitly bounded pilot.
+
+Every event, survey, receipt and report carries authority-false fields. The code has no path that converts pilot evidence into optimizer activation, production activation or Personal DJ Model training.
+
+## Workflow event contract
+
+Schema:
+
+`applaylist-r4-pilot-event-r1`
+
+Protocol:
+
+`r4-bounded-dj-pilot-r1`
+
+Required event vocabulary:
+
+- `import_started`
+- `usable_set_reached`
+- `recommendation_presented`
+- `recommendation_inspected`
+- `recommendation_accepted`
+- `recommendation_rejected`
+- `manual_reorder`
+- `manual_replace`
+- `manual_lock`
+- `export_completed`
+
+Each event is bound to:
+
+- `participant_ref`
+- `session_id`
+- `event_ref`
+- `event_type`
+- timezone-aware `observed_at`
+- optional bounded `object_ref`
+- optional bounded scalar `metadata`
+
+Recommendation events require `object_ref` so the denominator and subsequent interaction refer to one explicit recommendation presentation.
+
+## Correlation rules
+
+The ledger fails closed when:
+
+- `usable_set_reached` has no prior `import_started` in that participant/session,
+- usable-set time precedes import time,
+- recommendation inspection has no matching prior presentation,
+- recommendation decision has no matching prior inspection,
+- the same recommendation presentation is inspected twice,
+- both accept and reject are attempted for one immutable recommendation presentation,
+- a singleton import/usable-set event is duplicated under another event reference.
+
+Exact retries with the same natural key and identical canonical bytes are idempotent. A changed retry under the same natural key is rejected.
+
+## Exit survey contract
+
+Schema:
+
+`applaylist-r4-pilot-survey-r1`
+
+The survey is explicit human evidence. It contains:
+
+- participant reference,
+- survey reference,
+- timezone-aware observation time,
+- willingness-to-pay: `yes | no | unsure`,
+- optional stated monthly price in integer minor units,
+- explicit three-letter uppercase currency token when a price exists,
+- trust score 1–5,
+- explainability score 1–5,
+- optional bounded note and reason codes.
+
+Currency values are never converted implicitly. Price evidence remains separated by currency in the report.
+
+## Append-only evidence
+
+`PilotEvidenceLedger` creates two SQLite tables:
+
+- `pilot_events`
+- `pilot_surveys`
+
+Both tables have `UPDATE` and `DELETE` denial triggers.
+
+Identity is deterministic from canonical validated evidence. Exact retries do not create a second evidence row. Conflicting retries fail closed.
+
+## Product metrics
+
+The deterministic R1 report exposes:
+
+### Preparation
+
+- import-session count,
+- count of import -> usable-set samples,
+- mean preparation seconds,
+- median preparation seconds.
+
+### Recommendation workflow
+
+- presented count,
+- inspected count,
+- inspection rate,
+- accepted count,
+- rejected count,
+- acceptance/rejection rates.
+
+`recommendation_presented` is explicit because an inspection percentage requires a real denominator.
+
+### Human editor activity
+
+Per import session:
+
+- reorder count/rate,
+- replace count/rate,
+- lock count/rate.
+
+Zero manual edits are a measurable result when an import session exists; the system does not require an edit merely to mark the metric assessable.
+
+### Export
+
+- import-session count,
+- sessions with a completed export,
+- export completion rate.
+
+### Repeat weekly use
+
+Repeat use is not marked assessable until actual workflow evidence spans at least two ISO weeks.
+
+The report then exposes:
+
+- number of ISO weeks represented,
+- participants with workflow evidence,
+- participants active in at least two distinct ISO weeks,
+- repeat-use rate.
+
+### Commercial/trust evidence
+
+- willingness-to-pay yes/no/unsure counts and yes-rate,
+- stated monthly-price medians kept separate per currency,
+- mean trust score,
+- mean explainability score.
+
+## Bundle 63 binding
+
+`build_r4_pilot_report` may receive the canonical:
+
+`applaylist-human-dj-review-aggregate-r1`
+
+The aggregate fingerprint is recomputed and validated. Activation/PDM/musical-superiority authority must remain false.
+
+Its `pass | fail | incomplete` verdict is preserved as an evidence input only.
+
+A Bundle 63 `PASS` still means protocol completeness/integrity, not automatic musical superiority.
+
+## Evidence state
+
+Bundle 64 has only two evidence states:
+
+- `INCOMPLETE`
+- `READY_FOR_HUMAN_DECISION`
+
+`READY_FOR_HUMAN_DECISION` requires:
+
+1. all named R4 product metric categories to be assessable, and
+2. the bound Bundle 63 Human DJ Review aggregate to be complete (`pass` or `fail`, not `incomplete`).
+
+Even then:
+
+```text
+product_decision=UNDECIDED
+optimizer_ranking_activation_authorized=false
+personal_dj_model_training_authorized=false
+production_activation_authorized=false
+musical_superiority_implied=false
+```
+
+A human governed decision remains a separate later action.
+
+## CLI
+
+Record one validated real workflow event:
+
+```bash
+python scripts/applaylist_r4_pilot.py event \
+  --ledger APPLAYLIST_R4_PILOT_EVIDENCE_R1.sqlite \
+  --input event.json \
+  --receipt event.receipt.json
+```
+
+Record one explicit survey:
+
+```bash
+python scripts/applaylist_r4_pilot.py survey \
+  --ledger APPLAYLIST_R4_PILOT_EVIDENCE_R1.sqlite \
+  --input survey.json \
+  --receipt survey.receipt.json
+```
+
+Build a report and bind Bundle 63 human-review evidence:
+
+```bash
+python scripts/applaylist_r4_pilot.py report \
+  --ledger APPLAYLIST_R4_PILOT_EVIDENCE_R1.sqlite \
+  --human-review-aggregate APPLAYLIST_HUMAN_DJ_REVIEW_AGGREGATE_R1.json \
+  --output APPLAYLIST_R4_PILOT_REPORT_R1.json
+```
+
+The CLI only reads/writes explicit local files and refuses to overwrite output evidence files.
+
+## Test-fixture rule
+
+Tests use synthetic event/survey values solely to prove validation, correlation, immutability and deterministic metric semantics.
+
+They are not pilot evidence and must never be presented as product validation.
+
+## Explicit non-scope
+
+- automatic product GO/NO-GO,
+- automatic optimizer/ranking activation,
+- Personal DJ Model training,
+- production activation,
+- cloud analytics,
+- broad telemetry,
+- new recommendation/editor functionality,
+- new MIR/provider capability,
+- release/deploy/signing/notarization.
+
+## Next dependency
+
+After this slice is merged, the next step is operational rather than speculative engineering:
+
+1. run the bounded pilot with real DJs,
+2. collect genuine Bundle 63 blinded review evidence,
+3. collect genuine Bundle 64 workflow/survey evidence,
+4. generate the immutable aggregate report,
+5. make a separate governed human `CONTINUE / ADJUST / STOP-PIVOT` decision.
+
+No such product decision is inferred from CI or test fixtures.

--- a/scripts/applaylist_r4_pilot.py
+++ b/scripts/applaylist_r4_pilot.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from services.intelligence.r4_pilot_evidence import (
+    PilotEvidenceLedger,
+    build_r4_pilot_report,
+)
+
+
+def _load(path: str) -> dict[str, object]:
+    source = Path(path)
+    raw = json.loads(source.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise SystemExit(f"JSON object required: {source}")
+    return raw
+
+
+def _write(path: str, payload: object) -> None:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        raise SystemExit(f"output already exists: {target}")
+    target.write_text(
+        json.dumps(payload, ensure_ascii=False, sort_keys=True, indent=2, default=str) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Local-first APPLAYLIST R4 bounded DJ pilot evidence tooling."
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    event = sub.add_parser("event", help="Validate and append one real pilot workflow event.")
+    event.add_argument("--ledger", required=True)
+    event.add_argument("--input", required=True)
+    event.add_argument("--receipt", required=True)
+
+    survey = sub.add_parser("survey", help="Validate and append one explicit pilot survey.")
+    survey.add_argument("--ledger", required=True)
+    survey.add_argument("--input", required=True)
+    survey.add_argument("--receipt", required=True)
+
+    report = sub.add_parser("report", help="Aggregate local pilot evidence deterministically.")
+    report.add_argument("--ledger", required=True)
+    report.add_argument("--output", required=True)
+    report.add_argument("--human-review-aggregate")
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    ledger = PilotEvidenceLedger(args.ledger)
+
+    if args.command == "event":
+        receipt = ledger.record_event(_load(args.input))
+        _write(args.receipt, receipt)
+        print(json.dumps({"kind": "event", "record_id": receipt["record_id"]}, sort_keys=True))
+        return 0
+
+    if args.command == "survey":
+        receipt = ledger.record_survey(_load(args.input))
+        _write(args.receipt, receipt)
+        print(json.dumps({"kind": "survey", "record_id": receipt["record_id"]}, sort_keys=True))
+        return 0
+
+    if args.command == "report":
+        human_review = (
+            _load(args.human_review_aggregate) if args.human_review_aggregate else None
+        )
+        report = build_r4_pilot_report(
+            ledger=ledger,
+            human_review_aggregate=human_review,
+        )
+        _write(args.output, report)
+        print(
+            json.dumps(
+                {
+                    "evidence_state": report["evidence_state"],
+                    "product_decision": report["product_decision"],
+                    "report": Path(args.output).name,
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    raise SystemExit("unsupported command")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/intelligence/r4_pilot_evidence.py
+++ b/services/intelligence/r4_pilot_evidence.py
@@ -1,0 +1,856 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import sqlite3
+import statistics
+from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+R4_PILOT_PROTOCOL_VERSION = "r4-bounded-dj-pilot-r1"
+R4_PILOT_EVENT_SCHEMA = "applaylist-r4-pilot-event-r1"
+R4_PILOT_SURVEY_SCHEMA = "applaylist-r4-pilot-survey-r1"
+R4_PILOT_REPORT_SCHEMA = "applaylist-r4-pilot-report-r1"
+R4_PILOT_RECEIPT_SCHEMA = "applaylist-r4-pilot-ingest-receipt-r1"
+HUMAN_DJ_REVIEW_AGGREGATE_SCHEMA = "applaylist-human-dj-review-aggregate-r1"
+
+R4_PILOT_EVENT_TYPES = (
+    "import_started",
+    "usable_set_reached",
+    "recommendation_presented",
+    "recommendation_inspected",
+    "recommendation_accepted",
+    "recommendation_rejected",
+    "manual_reorder",
+    "manual_replace",
+    "manual_lock",
+    "export_completed",
+)
+R4_PILOT_WILLINGNESS_TO_PAY = ("yes", "no", "unsure")
+
+_RECOMMENDATION_EVENTS = frozenset(
+    {
+        "recommendation_presented",
+        "recommendation_inspected",
+        "recommendation_accepted",
+        "recommendation_rejected",
+    }
+)
+_SINGLETON_SESSION_EVENTS = frozenset({"import_started", "usable_set_reached"})
+_AUTHORITY_KEYS = (
+    "cloud_upload_authorized",
+    "personal_dj_model_training_authorized",
+    "production_activation_authorized",
+)
+
+
+class R4PilotEvidenceError(ValueError):
+    """Fail-closed error for bounded R4 pilot evidence."""
+
+
+def _canonical_json_bytes(value: object) -> bytes:
+    return (
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def canonical_payload_fingerprint(value: object) -> str:
+    return hashlib.sha256(_canonical_json_bytes(value)).hexdigest()
+
+
+def _token(value: object, field: str, *, maximum: int = 256) -> str:
+    if not isinstance(value, str):
+        raise R4PilotEvidenceError(f"{field} must be text")
+    normalized = value.strip()
+    if (
+        not normalized
+        or normalized != value
+        or len(normalized) > maximum
+        or any(ord(character) < 32 for character in normalized)
+    ):
+        raise R4PilotEvidenceError(f"{field} is invalid")
+    return normalized
+
+
+def _optional_token(value: object, field: str, *, maximum: int = 256) -> str | None:
+    if value is None:
+        return None
+    return _token(value, field, maximum=maximum)
+
+
+def _bounded_note(value: object) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise R4PilotEvidenceError("note must be text or null")
+    normalized = value.strip()
+    if (
+        normalized != value
+        or len(normalized) > 1000
+        or any(ord(character) < 32 and character not in "\n\t" for character in normalized)
+    ):
+        raise R4PilotEvidenceError("note is invalid")
+    return normalized or None
+
+
+def _timestamp(value: object, field: str = "observed_at") -> tuple[str, datetime]:
+    text = _token(value, field, maximum=64)
+    candidate = text[:-1] + "+00:00" if text.endswith("Z") else text
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError as exc:
+        raise R4PilotEvidenceError(f"{field} must be ISO-8601") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise R4PilotEvidenceError(f"{field} must include a timezone offset")
+    return parsed.isoformat(), parsed
+
+
+def _authority_false(raw: Mapping[str, Any]) -> None:
+    for key in _AUTHORITY_KEYS:
+        if raw.get(key) is not False:
+            raise R4PilotEvidenceError(f"{key} must be false")
+
+
+def _metadata(value: object) -> dict[str, str | int | float | bool]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping) or len(value) > 12:
+        raise R4PilotEvidenceError("metadata must be an object with at most 12 entries")
+    normalized: dict[str, str | int | float | bool] = {}
+    for raw_key, raw_value in value.items():
+        key = _token(raw_key, "metadata key", maximum=64)
+        if isinstance(raw_value, bool):
+            normalized[key] = raw_value
+        elif isinstance(raw_value, int):
+            normalized[key] = raw_value
+        elif isinstance(raw_value, float):
+            if not math.isfinite(raw_value):
+                raise R4PilotEvidenceError("metadata numbers must be finite")
+            normalized[key] = raw_value
+        elif isinstance(raw_value, str):
+            normalized[key] = _token(raw_value, f"metadata[{key}]", maximum=256)
+        else:
+            raise R4PilotEvidenceError("metadata values must be bounded scalars")
+    return dict(sorted(normalized.items()))
+
+
+def validate_pilot_event(raw: Mapping[str, Any]) -> dict[str, Any]:
+    expected_keys = {
+        "schema",
+        "protocol_version",
+        "participant_ref",
+        "session_id",
+        "event_ref",
+        "event_type",
+        "observed_at",
+        "object_ref",
+        "metadata",
+        *_AUTHORITY_KEYS,
+    }
+    if set(raw) != expected_keys:
+        raise R4PilotEvidenceError("pilot event has unexpected or missing fields")
+    if raw.get("schema") != R4_PILOT_EVENT_SCHEMA:
+        raise R4PilotEvidenceError("unsupported pilot event schema")
+    if raw.get("protocol_version") != R4_PILOT_PROTOCOL_VERSION:
+        raise R4PilotEvidenceError("unsupported pilot protocol version")
+    _authority_false(raw)
+
+    event_type = _token(raw.get("event_type"), "event_type", maximum=64)
+    if event_type not in R4_PILOT_EVENT_TYPES:
+        raise R4PilotEvidenceError("unsupported pilot event type")
+    object_ref = _optional_token(raw.get("object_ref"), "object_ref", maximum=256)
+    if event_type in _RECOMMENDATION_EVENTS and object_ref is None:
+        raise R4PilotEvidenceError("recommendation events require object_ref")
+    observed_at, _ = _timestamp(raw.get("observed_at"))
+
+    return {
+        "schema": R4_PILOT_EVENT_SCHEMA,
+        "protocol_version": R4_PILOT_PROTOCOL_VERSION,
+        "participant_ref": _token(raw.get("participant_ref"), "participant_ref"),
+        "session_id": _token(raw.get("session_id"), "session_id"),
+        "event_ref": _token(raw.get("event_ref"), "event_ref"),
+        "event_type": event_type,
+        "observed_at": observed_at,
+        "object_ref": object_ref,
+        "metadata": _metadata(raw.get("metadata")),
+        "cloud_upload_authorized": False,
+        "personal_dj_model_training_authorized": False,
+        "production_activation_authorized": False,
+    }
+
+
+def _integer_score(value: object, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or not 1 <= value <= 5:
+        raise R4PilotEvidenceError(f"{field} must be an integer from 1 to 5")
+    return value
+
+
+def _reason_codes(value: object) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list) or len(value) > 8:
+        raise R4PilotEvidenceError("reason_codes must be an array with at most 8 entries")
+    codes = [_token(item, "reason_code", maximum=64) for item in value]
+    if len(set(codes)) != len(codes):
+        raise R4PilotEvidenceError("reason_codes must be unique")
+    return codes
+
+
+def validate_pilot_survey(raw: Mapping[str, Any]) -> dict[str, Any]:
+    expected_keys = {
+        "schema",
+        "protocol_version",
+        "participant_ref",
+        "survey_ref",
+        "observed_at",
+        "willingness_to_pay",
+        "stated_monthly_price_minor",
+        "currency",
+        "trust_score",
+        "explainability_score",
+        "note",
+        "reason_codes",
+        *_AUTHORITY_KEYS,
+    }
+    if set(raw) != expected_keys:
+        raise R4PilotEvidenceError("pilot survey has unexpected or missing fields")
+    if raw.get("schema") != R4_PILOT_SURVEY_SCHEMA:
+        raise R4PilotEvidenceError("unsupported pilot survey schema")
+    if raw.get("protocol_version") != R4_PILOT_PROTOCOL_VERSION:
+        raise R4PilotEvidenceError("unsupported pilot protocol version")
+    _authority_false(raw)
+
+    willingness = _token(raw.get("willingness_to_pay"), "willingness_to_pay", maximum=16)
+    if willingness not in R4_PILOT_WILLINGNESS_TO_PAY:
+        raise R4PilotEvidenceError("unsupported willingness_to_pay value")
+
+    raw_price = raw.get("stated_monthly_price_minor")
+    raw_currency = raw.get("currency")
+    if raw_price is None:
+        price_minor = None
+        if raw_currency is not None:
+            raise R4PilotEvidenceError("currency requires stated_monthly_price_minor")
+        currency = None
+    else:
+        if isinstance(raw_price, bool) or not isinstance(raw_price, int):
+            raise R4PilotEvidenceError("stated_monthly_price_minor must be an integer or null")
+        if raw_price < 0 or raw_price > 100_000_000:
+            raise R4PilotEvidenceError("stated_monthly_price_minor is out of bounds")
+        price_minor = raw_price
+        currency = _token(raw_currency, "currency", maximum=3)
+        if len(currency) != 3 or currency.upper() != currency or not currency.isalpha():
+            raise R4PilotEvidenceError("currency must be a three-letter uppercase token")
+
+    observed_at, _ = _timestamp(raw.get("observed_at"))
+    return {
+        "schema": R4_PILOT_SURVEY_SCHEMA,
+        "protocol_version": R4_PILOT_PROTOCOL_VERSION,
+        "participant_ref": _token(raw.get("participant_ref"), "participant_ref"),
+        "survey_ref": _token(raw.get("survey_ref"), "survey_ref"),
+        "observed_at": observed_at,
+        "willingness_to_pay": willingness,
+        "stated_monthly_price_minor": price_minor,
+        "currency": currency,
+        "trust_score": _integer_score(raw.get("trust_score"), "trust_score"),
+        "explainability_score": _integer_score(
+            raw.get("explainability_score"), "explainability_score"
+        ),
+        "note": _bounded_note(raw.get("note")),
+        "reason_codes": _reason_codes(raw.get("reason_codes")),
+        "cloud_upload_authorized": False,
+        "personal_dj_model_training_authorized": False,
+        "production_activation_authorized": False,
+    }
+
+
+def _record_identity(prefix: str, payload: Mapping[str, Any]) -> str:
+    return f"{prefix}:{canonical_payload_fingerprint(payload)}"
+
+
+class PilotEvidenceLedger:
+    """Local append-only SQLite ledger for bounded R4 pilot evidence."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.execute("PRAGMA busy_timeout=5000")
+        return conn
+
+    def _initialize(self) -> None:
+        conn = self._connect()
+        try:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS pilot_events (
+                    event_id TEXT PRIMARY KEY,
+                    participant_ref TEXT NOT NULL,
+                    session_id TEXT NOT NULL,
+                    event_ref TEXT NOT NULL,
+                    event_type TEXT NOT NULL,
+                    observed_at TEXT NOT NULL,
+                    object_ref TEXT,
+                    event_json TEXT NOT NULL,
+                    UNIQUE(participant_ref, session_id, event_ref)
+                );
+                CREATE TABLE IF NOT EXISTS pilot_surveys (
+                    survey_id TEXT PRIMARY KEY,
+                    participant_ref TEXT NOT NULL,
+                    survey_ref TEXT NOT NULL,
+                    observed_at TEXT NOT NULL,
+                    survey_json TEXT NOT NULL,
+                    UNIQUE(participant_ref, survey_ref)
+                );
+                CREATE TRIGGER IF NOT EXISTS pilot_events_no_update
+                BEFORE UPDATE ON pilot_events
+                BEGIN SELECT RAISE(ABORT, 'pilot evidence is immutable'); END;
+                CREATE TRIGGER IF NOT EXISTS pilot_events_no_delete
+                BEFORE DELETE ON pilot_events
+                BEGIN SELECT RAISE(ABORT, 'pilot evidence is immutable'); END;
+                CREATE TRIGGER IF NOT EXISTS pilot_surveys_no_update
+                BEFORE UPDATE ON pilot_surveys
+                BEGIN SELECT RAISE(ABORT, 'pilot evidence is immutable'); END;
+                CREATE TRIGGER IF NOT EXISTS pilot_surveys_no_delete
+                BEFORE DELETE ON pilot_surveys
+                BEGIN SELECT RAISE(ABORT, 'pilot evidence is immutable'); END;
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _event_time(payload: Mapping[str, Any]) -> datetime:
+        return _timestamp(payload["observed_at"])[1]
+
+    def _prior_event(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        participant_ref: str,
+        session_id: str,
+        event_type: str,
+        object_ref: str | None = None,
+    ) -> dict[str, Any] | None:
+        sql = (
+            "SELECT event_json FROM pilot_events "
+            "WHERE participant_ref=? AND session_id=? AND event_type=?"
+        )
+        params: list[object] = [participant_ref, session_id, event_type]
+        if object_ref is not None:
+            sql += " AND object_ref=?"
+            params.append(object_ref)
+        sql += " ORDER BY observed_at, event_id LIMIT 1"
+        row = conn.execute(sql, params).fetchone()
+        return json.loads(row["event_json"]) if row else None
+
+    def _validate_event_correlation(
+        self,
+        conn: sqlite3.Connection,
+        payload: Mapping[str, Any],
+    ) -> None:
+        participant_ref = str(payload["participant_ref"])
+        session_id = str(payload["session_id"])
+        event_type = str(payload["event_type"])
+        observed = self._event_time(payload)
+
+        if event_type in _SINGLETON_SESSION_EVENTS:
+            prior = self._prior_event(
+                conn,
+                participant_ref=participant_ref,
+                session_id=session_id,
+                event_type=event_type,
+            )
+            if prior is not None:
+                raise R4PilotEvidenceError(
+                    f"{event_type} may occur only once per participant/session"
+                )
+
+        if event_type == "usable_set_reached":
+            imported = self._prior_event(
+                conn,
+                participant_ref=participant_ref,
+                session_id=session_id,
+                event_type="import_started",
+            )
+            if imported is None:
+                raise R4PilotEvidenceError("usable_set_reached requires prior import_started")
+            if observed < self._event_time(imported):
+                raise R4PilotEvidenceError("usable_set_reached cannot precede import_started")
+
+        if event_type not in _RECOMMENDATION_EVENTS:
+            return
+
+        object_ref = str(payload["object_ref"])
+        presented = self._prior_event(
+            conn,
+            participant_ref=participant_ref,
+            session_id=session_id,
+            event_type="recommendation_presented",
+            object_ref=object_ref,
+        )
+        if event_type == "recommendation_presented":
+            if presented is not None:
+                raise R4PilotEvidenceError(
+                    "recommendation presentation object_ref must be unique per session"
+                )
+            return
+        if presented is None:
+            raise R4PilotEvidenceError(
+                f"{event_type} requires prior recommendation_presented for object_ref"
+            )
+        if observed < self._event_time(presented):
+            raise R4PilotEvidenceError(f"{event_type} cannot precede recommendation_presented")
+
+        inspected = self._prior_event(
+            conn,
+            participant_ref=participant_ref,
+            session_id=session_id,
+            event_type="recommendation_inspected",
+            object_ref=object_ref,
+        )
+        if event_type == "recommendation_inspected":
+            if inspected is not None:
+                raise R4PilotEvidenceError(
+                    "recommendation inspection may occur only once per presentation"
+                )
+            return
+        if inspected is None:
+            raise R4PilotEvidenceError(
+                f"{event_type} requires prior recommendation_inspected for object_ref"
+            )
+        if observed < self._event_time(inspected):
+            raise R4PilotEvidenceError(f"{event_type} cannot precede recommendation_inspected")
+
+        accepted = self._prior_event(
+            conn,
+            participant_ref=participant_ref,
+            session_id=session_id,
+            event_type="recommendation_accepted",
+            object_ref=object_ref,
+        )
+        rejected = self._prior_event(
+            conn,
+            participant_ref=participant_ref,
+            session_id=session_id,
+            event_type="recommendation_rejected",
+            object_ref=object_ref,
+        )
+        if accepted is not None or rejected is not None:
+            raise R4PilotEvidenceError("recommendation may have only one immutable decision")
+
+    def record_event(self, raw: Mapping[str, Any]) -> dict[str, Any]:
+        payload = validate_pilot_event(raw)
+        event_id = _record_identity("pilot-event", payload)
+        event_json = _canonical_json_bytes(payload).decode("utf-8")
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            existing = conn.execute(
+                """
+                SELECT event_id, event_json FROM pilot_events
+                WHERE participant_ref=? AND session_id=? AND event_ref=?
+                """,
+                (
+                    payload["participant_ref"],
+                    payload["session_id"],
+                    payload["event_ref"],
+                ),
+            ).fetchone()
+            if existing is not None:
+                if existing["event_json"] == event_json:
+                    conn.commit()
+                    return self._receipt("event", str(existing["event_id"]), payload)
+                raise R4PilotEvidenceError("conflicting retry for immutable pilot event_ref")
+
+            self._validate_event_correlation(conn, payload)
+            conn.execute(
+                """
+                INSERT INTO pilot_events(
+                    event_id, participant_ref, session_id, event_ref,
+                    event_type, observed_at, object_ref, event_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event_id,
+                    payload["participant_ref"],
+                    payload["session_id"],
+                    payload["event_ref"],
+                    payload["event_type"],
+                    payload["observed_at"],
+                    payload["object_ref"],
+                    event_json,
+                ),
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+        return self._receipt("event", event_id, payload)
+
+    def record_survey(self, raw: Mapping[str, Any]) -> dict[str, Any]:
+        payload = validate_pilot_survey(raw)
+        survey_id = _record_identity("pilot-survey", payload)
+        survey_json = _canonical_json_bytes(payload).decode("utf-8")
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            existing = conn.execute(
+                """
+                SELECT survey_id, survey_json FROM pilot_surveys
+                WHERE participant_ref=? AND survey_ref=?
+                """,
+                (payload["participant_ref"], payload["survey_ref"]),
+            ).fetchone()
+            if existing is not None:
+                if existing["survey_json"] == survey_json:
+                    conn.commit()
+                    return self._receipt("survey", str(existing["survey_id"]), payload)
+                raise R4PilotEvidenceError("conflicting retry for immutable pilot survey_ref")
+            conn.execute(
+                """
+                INSERT INTO pilot_surveys(
+                    survey_id, participant_ref, survey_ref, observed_at, survey_json
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    survey_id,
+                    payload["participant_ref"],
+                    payload["survey_ref"],
+                    payload["observed_at"],
+                    survey_json,
+                ),
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+        return self._receipt("survey", survey_id, payload)
+
+    @staticmethod
+    def _receipt(kind: str, record_id: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+        receipt = {
+            "schema": R4_PILOT_RECEIPT_SCHEMA,
+            "protocol_version": R4_PILOT_PROTOCOL_VERSION,
+            "kind": kind,
+            "record_id": record_id,
+            "participant_ref": payload["participant_ref"],
+            "observed_at": payload["observed_at"],
+            "cloud_upload_authorized": False,
+            "personal_dj_model_training_authorized": False,
+            "production_activation_authorized": False,
+        }
+        receipt["receipt_fingerprint"] = canonical_payload_fingerprint(receipt)
+        return receipt
+
+    def list_events(self) -> tuple[dict[str, Any], ...]:
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT event_json FROM pilot_events ORDER BY observed_at, event_id"
+            ).fetchall()
+        finally:
+            conn.close()
+        return tuple(json.loads(row["event_json"]) for row in rows)
+
+    def list_surveys(self) -> tuple[dict[str, Any], ...]:
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT survey_json FROM pilot_surveys ORDER BY observed_at, survey_id"
+            ).fetchall()
+        finally:
+            conn.close()
+        return tuple(json.loads(row["survey_json"]) for row in rows)
+
+
+def validate_human_review_aggregate(raw: Mapping[str, Any]) -> dict[str, Any]:
+    if raw.get("schema") != HUMAN_DJ_REVIEW_AGGREGATE_SCHEMA:
+        raise R4PilotEvidenceError("unsupported Human DJ Review aggregate schema")
+    if raw.get("activation_authorized") is not False:
+        raise R4PilotEvidenceError("Human DJ Review aggregate cannot authorize activation")
+    if raw.get("personal_dj_model_training_authorized") is not False:
+        raise R4PilotEvidenceError("Human DJ Review aggregate cannot authorize PDM training")
+    if raw.get("musical_superiority_implied") is not False:
+        raise R4PilotEvidenceError("Human DJ Review aggregate cannot imply musical superiority")
+
+    supplied_fingerprint = _token(
+        raw.get("aggregate_fingerprint"), "aggregate_fingerprint", maximum=128
+    )
+    material = dict(raw)
+    material.pop("aggregate_fingerprint", None)
+    if canonical_payload_fingerprint(material) != supplied_fingerprint:
+        raise R4PilotEvidenceError("Human DJ Review aggregate fingerprint mismatch")
+
+    report = raw.get("report")
+    if not isinstance(report, Mapping):
+        raise R4PilotEvidenceError("Human DJ Review aggregate report must be an object")
+    verdict = str(report.get("verdict", "")).strip().lower()
+    if verdict not in {"pass", "fail", "incomplete"}:
+        raise R4PilotEvidenceError("Human DJ Review aggregate verdict is invalid")
+    if report.get("activation_authorized") is not False:
+        raise R4PilotEvidenceError("Human DJ Review report cannot authorize activation")
+
+    def _optional_count(key: str) -> int | None:
+        value = report.get(key)
+        if value is None:
+            return None
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise R4PilotEvidenceError(f"Human DJ Review {key} is invalid")
+        return value
+
+    return {
+        "protocol_version": str(raw.get("protocol_version", "")),
+        "packet_fingerprint": str(raw.get("packet_fingerprint", "")),
+        "aggregate_fingerprint": supplied_fingerprint,
+        "verdict": verdict,
+        "case_count": _optional_count("case_count"),
+        "reviewed_case_count": _optional_count("reviewed_case_count"),
+        "review_count": _optional_count("review_count"),
+        "musical_superiority_implied": False,
+        "activation_authorized": False,
+    }
+
+
+def _ratio(numerator: int, denominator: int) -> float | None:
+    if denominator <= 0:
+        return None
+    return round(numerator / denominator, 6)
+
+
+def _mean(values: Sequence[int | float]) -> float | None:
+    if not values:
+        return None
+    return round(statistics.fmean(values), 6)
+
+
+def _median(values: Sequence[int | float]) -> float | None:
+    if not values:
+        return None
+    return round(float(statistics.median(values)), 6)
+
+
+def build_r4_pilot_report(
+    *,
+    ledger: PilotEvidenceLedger,
+    human_review_aggregate: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    events = ledger.list_events()
+    surveys = ledger.list_surveys()
+    event_counts = Counter(str(item["event_type"]) for item in events)
+    session_events: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    participant_weeks: dict[str, set[tuple[int, int]]] = defaultdict(set)
+    pilot_weeks: set[tuple[int, int]] = set()
+
+    for event in events:
+        key = (str(event["participant_ref"]), str(event["session_id"]))
+        session_events[key].append(event)
+        observed = _timestamp(event["observed_at"])[1]
+        iso = observed.isocalendar()
+        week = (iso.year, iso.week)
+        participant_weeks[str(event["participant_ref"])].add(week)
+        pilot_weeks.add(week)
+
+    import_sessions = 0
+    prep_durations: list[float] = []
+    export_sessions = 0
+    edit_counts = {
+        "manual_reorder": event_counts["manual_reorder"],
+        "manual_replace": event_counts["manual_replace"],
+        "manual_lock": event_counts["manual_lock"],
+    }
+    for items in session_events.values():
+        by_type = {str(item["event_type"]): item for item in items}
+        imported = by_type.get("import_started")
+        usable = by_type.get("usable_set_reached")
+        if imported is not None:
+            import_sessions += 1
+            if usable is not None:
+                start = _timestamp(imported["observed_at"])[1]
+                end = _timestamp(usable["observed_at"])[1]
+                seconds = (end - start).total_seconds()
+                if seconds < 0:
+                    raise R4PilotEvidenceError("negative preparation duration in immutable ledger")
+                prep_durations.append(seconds)
+            if any(item["event_type"] == "export_completed" for item in items):
+                export_sessions += 1
+
+    presented = event_counts["recommendation_presented"]
+    inspected = event_counts["recommendation_inspected"]
+    accepted = event_counts["recommendation_accepted"]
+    rejected = event_counts["recommendation_rejected"]
+    decisions = accepted + rejected
+
+    event_participants = set(participant_weeks)
+    survey_participants = {str(item["participant_ref"]) for item in surveys}
+    participants = sorted(event_participants | survey_participants)
+    repeat_assessable = len(pilot_weeks) >= 2 and bool(event_participants)
+    repeat_participants = sum(
+        1 for participant in event_participants if len(participant_weeks[participant]) >= 2
+    )
+
+    willingness_counts = Counter(str(item["willingness_to_pay"]) for item in surveys)
+    price_by_currency: dict[str, list[int]] = defaultdict(list)
+    for survey in surveys:
+        price = survey["stated_monthly_price_minor"]
+        currency = survey["currency"]
+        if price is not None and currency is not None:
+            price_by_currency[str(currency)].append(int(price))
+    price_summary = {
+        currency: {
+            "response_count": len(values),
+            "median_monthly_price_minor": _median(values),
+        }
+        for currency, values in sorted(price_by_currency.items())
+    }
+
+    coverage = {
+        "time_import_to_usable_set": bool(prep_durations),
+        "recommendation_inspection_rate": presented > 0,
+        "recommendation_accept_reject_rate": decisions > 0,
+        "manual_reorder_frequency": import_sessions > 0,
+        "manual_replace_frequency": import_sessions > 0,
+        "lock_frequency": import_sessions > 0,
+        "export_completion_rate": import_sessions > 0,
+        "repeat_weekly_use": repeat_assessable,
+        "willingness_to_pay": bool(surveys),
+        "trust_explainability": bool(surveys),
+    }
+    product_metric_coverage_complete = all(coverage.values())
+
+    human_summary = (
+        validate_human_review_aggregate(human_review_aggregate)
+        if human_review_aggregate is not None
+        else None
+    )
+    human_review_complete = (
+        human_summary is not None and human_summary["verdict"] in {"pass", "fail"}
+    )
+    evidence_state = (
+        "READY_FOR_HUMAN_DECISION"
+        if product_metric_coverage_complete and human_review_complete
+        else "INCOMPLETE"
+    )
+
+    report: dict[str, Any] = {
+        "schema": R4_PILOT_REPORT_SCHEMA,
+        "protocol_version": R4_PILOT_PROTOCOL_VERSION,
+        "evidence_state": evidence_state,
+        "product_decision": "UNDECIDED",
+        "participant_count": len(participants),
+        "session_count": len(session_events),
+        "event_count": len(events),
+        "survey_count": len(surveys),
+        "event_counts": {
+            event_type: event_counts[event_type] for event_type in R4_PILOT_EVENT_TYPES
+        },
+        "metrics": {
+            "time_import_to_usable_set": {
+                "sample_count": len(prep_durations),
+                "median_seconds": _median(prep_durations),
+                "mean_seconds": _mean(prep_durations),
+            },
+            "recommendation_inspection": {
+                "presented_count": presented,
+                "inspected_count": inspected,
+                "inspection_rate": _ratio(inspected, presented),
+            },
+            "recommendation_decision": {
+                "accepted_count": accepted,
+                "rejected_count": rejected,
+                "decision_count": decisions,
+                "acceptance_rate": _ratio(accepted, decisions),
+                "rejection_rate": _ratio(rejected, decisions),
+            },
+            "manual_edit_frequency_per_import_session": {
+                "import_session_count": import_sessions,
+                "reorder_count": edit_counts["manual_reorder"],
+                "replace_count": edit_counts["manual_replace"],
+                "lock_count": edit_counts["manual_lock"],
+                "reorder_per_session": _ratio(edit_counts["manual_reorder"], import_sessions),
+                "replace_per_session": _ratio(edit_counts["manual_replace"], import_sessions),
+                "lock_per_session": _ratio(edit_counts["manual_lock"], import_sessions),
+            },
+            "export_completion": {
+                "import_session_count": import_sessions,
+                "export_completed_session_count": export_sessions,
+                "completion_rate": _ratio(export_sessions, import_sessions),
+            },
+            "repeat_weekly_use": {
+                "assessable": repeat_assessable,
+                "pilot_iso_week_count": len(pilot_weeks),
+                "participant_with_usage_count": len(event_participants),
+                "repeat_participant_count": repeat_participants,
+                "repeat_rate": (
+                    _ratio(repeat_participants, len(event_participants))
+                    if repeat_assessable
+                    else None
+                ),
+            },
+            "willingness_to_pay": {
+                "response_count": len(surveys),
+                "yes_count": willingness_counts["yes"],
+                "no_count": willingness_counts["no"],
+                "unsure_count": willingness_counts["unsure"],
+                "yes_rate": _ratio(willingness_counts["yes"], len(surveys)),
+                "stated_price_by_currency": price_summary,
+            },
+            "trust_explainability": {
+                "response_count": len(surveys),
+                "mean_trust_score": _mean([int(item["trust_score"]) for item in surveys]),
+                "mean_explainability_score": _mean(
+                    [int(item["explainability_score"]) for item in surveys]
+                ),
+            },
+        },
+        "metric_coverage": coverage,
+        "product_metric_coverage_complete": product_metric_coverage_complete,
+        "human_dj_review": human_summary,
+        "human_dj_review_complete": human_review_complete,
+        "cloud_upload_authorized": False,
+        "optimizer_ranking_activation_authorized": False,
+        "personal_dj_model_training_authorized": False,
+        "production_activation_authorized": False,
+        "musical_superiority_implied": False,
+    }
+    report["report_fingerprint"] = canonical_payload_fingerprint(report)
+    return report
+
+
+__all__ = [
+    "HUMAN_DJ_REVIEW_AGGREGATE_SCHEMA",
+    "R4_PILOT_EVENT_SCHEMA",
+    "R4_PILOT_EVENT_TYPES",
+    "R4_PILOT_PROTOCOL_VERSION",
+    "R4_PILOT_RECEIPT_SCHEMA",
+    "R4_PILOT_REPORT_SCHEMA",
+    "R4_PILOT_SURVEY_SCHEMA",
+    "R4_PILOT_WILLINGNESS_TO_PAY",
+    "PilotEvidenceLedger",
+    "R4PilotEvidenceError",
+    "build_r4_pilot_report",
+    "canonical_payload_fingerprint",
+    "validate_human_review_aggregate",
+    "validate_pilot_event",
+    "validate_pilot_survey",
+]

--- a/tests/test_r4_pilot_evidence_r1.py
+++ b/tests/test_r4_pilot_evidence_r1.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from services.intelligence.r4_pilot_evidence import (
+    HUMAN_DJ_REVIEW_AGGREGATE_SCHEMA,
+    R4_PILOT_EVENT_SCHEMA,
+    R4_PILOT_PROTOCOL_VERSION,
+    R4_PILOT_SURVEY_SCHEMA,
+    PilotEvidenceLedger,
+    R4PilotEvidenceError,
+    build_r4_pilot_report,
+    canonical_payload_fingerprint,
+    validate_pilot_event,
+    validate_pilot_survey,
+)
+
+
+def _event(
+    event_type: str,
+    *,
+    observed_at: str,
+    event_ref: str,
+    session_id: str = "session-01",
+    participant_ref: str = "dj-01",
+    object_ref: str | None = None,
+) -> dict[str, object]:
+    return {
+        "schema": R4_PILOT_EVENT_SCHEMA,
+        "protocol_version": R4_PILOT_PROTOCOL_VERSION,
+        "participant_ref": participant_ref,
+        "session_id": session_id,
+        "event_ref": event_ref,
+        "event_type": event_type,
+        "observed_at": observed_at,
+        "object_ref": object_ref,
+        "metadata": {},
+        "cloud_upload_authorized": False,
+        "personal_dj_model_training_authorized": False,
+        "production_activation_authorized": False,
+    }
+
+
+def _survey(*, observed_at: str = "2026-08-24T19:00:00+02:00") -> dict[str, object]:
+    return {
+        "schema": R4_PILOT_SURVEY_SCHEMA,
+        "protocol_version": R4_PILOT_PROTOCOL_VERSION,
+        "participant_ref": "dj-01",
+        "survey_ref": "pilot-exit-r1",
+        "observed_at": observed_at,
+        "willingness_to_pay": "yes",
+        "stated_monthly_price_minor": 14900,
+        "currency": "CZK",
+        "trust_score": 4,
+        "explainability_score": 5,
+        "note": "Would use this for club-set preparation.",
+        "reason_codes": ["saved_time", "clear_explanations"],
+        "cloud_upload_authorized": False,
+        "personal_dj_model_training_authorized": False,
+        "production_activation_authorized": False,
+    }
+
+
+def _human_review_aggregate(verdict: str = "pass") -> dict[str, object]:
+    aggregate: dict[str, object] = {
+        "schema": HUMAN_DJ_REVIEW_AGGREGATE_SCHEMA,
+        "protocol_version": "human-dj-review-r1",
+        "packet_fingerprint": "a" * 64,
+        "report": {
+            "verdict": verdict,
+            "case_count": 12,
+            "reviewed_case_count": 12 if verdict != "incomplete" else 4,
+            "review_count": 12 if verdict != "incomplete" else 4,
+            "activation_authorized": False,
+        },
+        "activation_authorized": False,
+        "personal_dj_model_training_authorized": False,
+        "musical_superiority_implied": False,
+    }
+    aggregate["aggregate_fingerprint"] = canonical_payload_fingerprint(aggregate)
+    return aggregate
+
+
+def _complete_session(
+    ledger: PilotEvidenceLedger,
+    *,
+    session_id: str,
+    date: str,
+    usable_minute: int,
+) -> None:
+    participant = "dj-01"
+    ledger.record_event(
+        _event(
+            "import_started",
+            observed_at=f"{date}T18:00:00+02:00",
+            event_ref=f"{session_id}:import",
+            session_id=session_id,
+            participant_ref=participant,
+        )
+    )
+    ledger.record_event(
+        _event(
+            "usable_set_reached",
+            observed_at=f"{date}T18:{usable_minute:02d}:00+02:00",
+            event_ref=f"{session_id}:usable",
+            session_id=session_id,
+            participant_ref=participant,
+            object_ref=f"revision:{session_id}",
+        )
+    )
+    recommendation_ref = f"recommendation:{session_id}:01"
+    ledger.record_event(
+        _event(
+            "recommendation_presented",
+            observed_at=f"{date}T18:{usable_minute + 1:02d}:00+02:00",
+            event_ref=f"{session_id}:presented",
+            session_id=session_id,
+            participant_ref=participant,
+            object_ref=recommendation_ref,
+        )
+    )
+    ledger.record_event(
+        _event(
+            "recommendation_inspected",
+            observed_at=f"{date}T18:{usable_minute + 2:02d}:00+02:00",
+            event_ref=f"{session_id}:inspected",
+            session_id=session_id,
+            participant_ref=participant,
+            object_ref=recommendation_ref,
+        )
+    )
+    ledger.record_event(
+        _event(
+            "recommendation_accepted",
+            observed_at=f"{date}T18:{usable_minute + 3:02d}:00+02:00",
+            event_ref=f"{session_id}:accepted",
+            session_id=session_id,
+            participant_ref=participant,
+            object_ref=recommendation_ref,
+        )
+    )
+    ledger.record_event(
+        _event(
+            "export_completed",
+            observed_at=f"{date}T18:{usable_minute + 9:02d}:00+02:00",
+            event_ref=f"{session_id}:export",
+            session_id=session_id,
+            participant_ref=participant,
+            object_ref=f"revision:{session_id}",
+        )
+    )
+
+
+def test_event_and_survey_validation_are_fail_closed() -> None:
+    event = _event(
+        "import_started",
+        observed_at="2026-08-17T18:00:00+02:00",
+        event_ref="event-01",
+    )
+    assert validate_pilot_event(event)["observed_at"].endswith("+02:00")
+
+    naive = dict(event)
+    naive["observed_at"] = "2026-08-17T18:00:00"
+    with pytest.raises(R4PilotEvidenceError, match="timezone offset"):
+        validate_pilot_event(naive)
+
+    unsafe = dict(event)
+    unsafe["cloud_upload_authorized"] = True
+    with pytest.raises(R4PilotEvidenceError, match="must be false"):
+        validate_pilot_event(unsafe)
+
+    survey = _survey()
+    assert validate_pilot_survey(survey)["currency"] == "CZK"
+    bad_price = dict(survey)
+    bad_price["currency"] = None
+    with pytest.raises(R4PilotEvidenceError, match="currency"):
+        validate_pilot_survey(bad_price)
+
+
+def test_append_only_exact_retry_and_conflicting_retry(tmp_path: Path) -> None:
+    ledger = PilotEvidenceLedger(tmp_path / "pilot.sqlite")
+    event = _event(
+        "import_started",
+        observed_at="2026-08-17T18:00:00+02:00",
+        event_ref="event-01",
+    )
+
+    first = ledger.record_event(event)
+    second = ledger.record_event(event)
+    assert first["record_id"] == second["record_id"]
+    assert len(ledger.list_events()) == 1
+
+    conflict = dict(event)
+    conflict["observed_at"] = "2026-08-17T18:00:01+02:00"
+    with pytest.raises(R4PilotEvidenceError, match="conflicting retry"):
+        ledger.record_event(conflict)
+
+    with sqlite3.connect(tmp_path / "pilot.sqlite") as conn:
+        with pytest.raises(sqlite3.DatabaseError, match="immutable"):
+            conn.execute("UPDATE pilot_events SET participant_ref='other'")
+        with pytest.raises(sqlite3.DatabaseError, match="immutable"):
+            conn.execute("DELETE FROM pilot_events")
+
+
+def test_recommendation_and_preparation_correlation_fail_closed(tmp_path: Path) -> None:
+    ledger = PilotEvidenceLedger(tmp_path / "pilot.sqlite")
+    recommendation = "recommendation:01"
+
+    with pytest.raises(R4PilotEvidenceError, match="prior recommendation_presented"):
+        ledger.record_event(
+            _event(
+                "recommendation_inspected",
+                observed_at="2026-08-17T18:02:00+02:00",
+                event_ref="inspect-01",
+                object_ref=recommendation,
+            )
+        )
+
+    with pytest.raises(R4PilotEvidenceError, match="prior import_started"):
+        ledger.record_event(
+            _event(
+                "usable_set_reached",
+                observed_at="2026-08-17T18:03:00+02:00",
+                event_ref="usable-01",
+            )
+        )
+
+    ledger.record_event(
+        _event(
+            "recommendation_presented",
+            observed_at="2026-08-17T18:01:00+02:00",
+            event_ref="present-01",
+            object_ref=recommendation,
+        )
+    )
+    with pytest.raises(R4PilotEvidenceError, match="prior recommendation_inspected"):
+        ledger.record_event(
+            _event(
+                "recommendation_accepted",
+                observed_at="2026-08-17T18:02:00+02:00",
+                event_ref="accept-too-early",
+                object_ref=recommendation,
+            )
+        )
+    ledger.record_event(
+        _event(
+            "recommendation_inspected",
+            observed_at="2026-08-17T18:02:00+02:00",
+            event_ref="inspect-02",
+            object_ref=recommendation,
+        )
+    )
+    ledger.record_event(
+        _event(
+            "recommendation_accepted",
+            observed_at="2026-08-17T18:03:00+02:00",
+            event_ref="accept-01",
+            object_ref=recommendation,
+        )
+    )
+    with pytest.raises(R4PilotEvidenceError, match="only one immutable decision"):
+        ledger.record_event(
+            _event(
+                "recommendation_rejected",
+                observed_at="2026-08-17T18:04:00+02:00",
+                event_ref="reject-01",
+                object_ref=recommendation,
+            )
+        )
+
+
+def test_empty_or_single_week_evidence_is_incomplete(tmp_path: Path) -> None:
+    ledger = PilotEvidenceLedger(tmp_path / "pilot.sqlite")
+    empty = build_r4_pilot_report(ledger=ledger)
+    assert empty["evidence_state"] == "INCOMPLETE"
+    assert empty["product_decision"] == "UNDECIDED"
+    assert empty["metric_coverage"]["repeat_weekly_use"] is False
+    assert empty["production_activation_authorized"] is False
+
+    _complete_session(ledger, session_id="session-01", date="2026-08-17", usable_minute=10)
+    single_week = build_r4_pilot_report(
+        ledger=ledger,
+        human_review_aggregate=_human_review_aggregate(),
+    )
+    assert single_week["metrics"]["repeat_weekly_use"]["assessable"] is False
+    assert single_week["evidence_state"] == "INCOMPLETE"
+
+
+def test_complete_two_week_fixture_is_ready_for_human_decision_not_auto_go(
+    tmp_path: Path,
+) -> None:
+    ledger = PilotEvidenceLedger(tmp_path / "pilot.sqlite")
+    _complete_session(ledger, session_id="session-01", date="2026-08-17", usable_minute=10)
+    _complete_session(ledger, session_id="session-02", date="2026-08-24", usable_minute=5)
+
+    for index, event_type in enumerate(("manual_reorder", "manual_replace", "manual_lock"), 1):
+        ledger.record_event(
+            _event(
+                event_type,
+                observed_at=f"2026-08-24T18:{10 + index:02d}:00+02:00",
+                event_ref=f"session-02:{event_type}",
+                session_id="session-02",
+                object_ref="revision:session-02",
+            )
+        )
+    ledger.record_survey(_survey())
+
+    report = build_r4_pilot_report(
+        ledger=ledger,
+        human_review_aggregate=_human_review_aggregate("pass"),
+    )
+    metrics = report["metrics"]
+
+    assert report["evidence_state"] == "READY_FOR_HUMAN_DECISION"
+    assert report["product_decision"] == "UNDECIDED"
+    assert report["product_metric_coverage_complete"] is True
+    assert report["human_dj_review_complete"] is True
+    assert metrics["time_import_to_usable_set"]["sample_count"] == 2
+    assert metrics["time_import_to_usable_set"]["median_seconds"] == 450.0
+    assert metrics["recommendation_inspection"]["inspection_rate"] == 1.0
+    assert metrics["recommendation_decision"]["acceptance_rate"] == 1.0
+    assert metrics["manual_edit_frequency_per_import_session"]["reorder_per_session"] == 0.5
+    assert metrics["manual_edit_frequency_per_import_session"]["replace_per_session"] == 0.5
+    assert metrics["manual_edit_frequency_per_import_session"]["lock_per_session"] == 0.5
+    assert metrics["export_completion"]["completion_rate"] == 1.0
+    assert metrics["repeat_weekly_use"]["repeat_rate"] == 1.0
+    assert metrics["willingness_to_pay"]["yes_rate"] == 1.0
+    assert metrics["willingness_to_pay"]["stated_price_by_currency"]["CZK"][
+        "median_monthly_price_minor"
+    ] == 14900.0
+    assert metrics["trust_explainability"]["mean_trust_score"] == 4.0
+    assert metrics["trust_explainability"]["mean_explainability_score"] == 5.0
+    assert report["optimizer_ranking_activation_authorized"] is False
+    assert report["personal_dj_model_training_authorized"] is False
+    assert report["production_activation_authorized"] is False
+    assert report["musical_superiority_implied"] is False
+
+
+def test_human_review_binding_is_integrity_checked_and_incomplete_blocks_readiness(
+    tmp_path: Path,
+) -> None:
+    ledger = PilotEvidenceLedger(tmp_path / "pilot.sqlite")
+    _complete_session(ledger, session_id="session-01", date="2026-08-17", usable_minute=10)
+    _complete_session(ledger, session_id="session-02", date="2026-08-24", usable_minute=5)
+    ledger.record_survey(_survey())
+
+    incomplete = build_r4_pilot_report(
+        ledger=ledger,
+        human_review_aggregate=_human_review_aggregate("incomplete"),
+    )
+    assert incomplete["human_dj_review_complete"] is False
+    assert incomplete["evidence_state"] == "INCOMPLETE"
+
+    tampered = _human_review_aggregate("pass")
+    report = tampered["report"]
+    assert isinstance(report, dict)
+    report["review_count"] = 99
+    with pytest.raises(R4PilotEvidenceError, match="fingerprint mismatch"):
+        build_r4_pilot_report(ledger=ledger, human_review_aggregate=tampered)


### PR DESCRIPTION
## Summary

Implements the R4 bounded DJ pilot evidence boundary after merged Bundle 63.

- explicit local workflow-event contract for import -> usable set, recommendation presentation/inspection/decision, manual edits and export
- explicit local exit-survey contract for willingness-to-pay, trust and explainability
- timezone-aware fail-closed timestamp validation
- recommendation and preparation correlation validation
- deterministic event/survey identities and receipts
- append-only immutable SQLite ledger with UPDATE/DELETE denial
- deterministic R4 product-metric report
- repeat-weekly-use stays unassessable until evidence spans at least two ISO weeks
- optional integrity-checked Bundle 63 Human DJ Review aggregate binding
- `READY_FOR_HUMAN_DECISION` is evidence readiness only; `product_decision=UNDECIDED`
- no cloud analytics, production activation, optimizer/ranking activation, PDM training, release or deploy

Closes #148

## Verification

Exact branch preflight:
- base SHA: `8474d6c0c526e714c6b0a4fece5b47f0be5ade32`
- implementation HEAD at PR open: `67771e2ef8d864ae5d97709610a7bc38770a2ed3`
- compare: `4 commits ahead / 0 behind / 4 files`
- merge-base: exact canonical base SHA
- changed scope: new Python evidence service, local CLI, tests and bundle documentation only

Required GitHub Actions verification is executed on the exact PR head. No PASS is claimed until CI and PR Guard complete successfully.

## Bundle Context

Bundle 63 made genuine blinded Human DJ Review execution auditable. The R4 roadmap then requires a bounded pilot before broadening feature scope. Bundle 64 adds only the local product-evidence boundary needed to measure that pilot.

Product metrics:
- time import -> usable set
- recommendation inspection rate with explicit presented denominator
- accept/reject rates
- reorder/replace/lock frequency per import session
- export completion rate
- repeat weekly use
- willingness-to-pay
- trust and explainability

Test fixtures prove the machinery only and are never product evidence. Real pilot evidence can only enter through explicit validated event/survey records.

A complete product metric set plus a complete Bundle 63 human-review aggregate yields only:

`evidence_state=READY_FOR_HUMAN_DECISION`

It never yields automatic product GO or activation.

Authority boundary:

`cloud_upload_authorized=false`
`optimizer_ranking_activation_authorized=false`
`personal_dj_model_training_authorized=false`
`production_activation_authorized=false`
`musical_superiority_implied=false`

`MERGE_AUTHORIZATION=NO`
`RELEASE_AUTHORIZATION=NO`
`DEPLOY_AUTHORIZATION=NO`
`PRODUCTION_EFFECTS=NO`
